### PR TITLE
Added Travis CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dimod
 
+[![Build Status](https://travis-ci.org/dwavesystems/dimod.svg?branch=master)](https://travis-ci.org/dwavesystems/dimod)
+
 A shared API for QUBO/Ising samplers.
 
 ## Included Samplers


### PR DESCRIPTION
To check the build status easily, the Travis CI status badge is added to README.