### PR TITLE
Refactor @vartype_argument

### DIFF
--- a/dimod/compatibility23.py
+++ b/dimod/compatibility23.py
@@ -20,8 +20,6 @@ if _PY2:
 
     zip_longest = itertools.izip_longest
 
-    RecursionError_ = RuntimeError
-
 else:
 
     range_ = range
@@ -38,8 +36,3 @@ else:
         return iter(d.keys())
 
     zip_longest = itertools.zip_longest
-
-    if sys.version_info.minor > 4:
-        RecursionError_ = RecursionError
-    else:
-        RecursionError_ = RuntimeError

--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -2,7 +2,6 @@
 todo - describe how to use the dimod sampler template
 """
 from dimod.binary_quadratic_model_convert import to_qubo, to_ising, from_qubo, from_ising
-from dimod.compatibility23 import RecursionError_
 from dimod.exceptions import InvalidSampler
 from dimod.vartypes import Vartype
 

--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -16,29 +16,38 @@ class Sampler(object):
     def __init__(self):
         self.sample_kwargs = {}
         self.properties = {}
+        self._methods_cycled = set()
+
+    def _ensure_finite_cycle(self, methodname):
+        """Ensure user-derived sampler implements at least one sampling method."""
+
+        # (In current Sampler implementation, if 3 or more base sample* methods
+        # are called, we have an infinite loop. The loop can be broken by
+        # overridding at least one sample method in a subclass.)
+        self._methods_cycled.add(methodname)
+        if len(self._methods_cycled) > 2:
+            raise InvalidSampler('Sampler subclass must override at least one '
+                                 'of the sampling methods')
 
     def sample(self, bqm, **sample_kwargs):
         """todo"""
-        try:
-            if bqm.vartype is Vartype.SPIN:
-                Q, offset = to_qubo(bqm)
-                response = self.sample_qubo(Q, **sample_kwargs)
-                response.change_vartype(Vartype.SPIN, offset)
-                return response
-            elif bqm.vartype is Vartype.BINARY:
-                h, J, offset = to_ising(bqm)
-                response = self.sample_ising(h, J, **sample_kwargs)
-                response.change_vartype(Vartype.BINARY, offset)
-                return response
-            else:
-                raise RuntimeError("binary quadratic model has an unknown vartype")
-        except RecursionError_:
-            msg = ("A RecursionError has been occured. This most often happens when trying to use "
-                   "the Sampler base class as a sampler.")
-            raise InvalidSampler(msg)
+        self._ensure_finite_cycle('sample')
+        if bqm.vartype is Vartype.SPIN:
+            Q, offset = to_qubo(bqm)
+            response = self.sample_qubo(Q, **sample_kwargs)
+            response.change_vartype(Vartype.SPIN, offset)
+            return response
+        elif bqm.vartype is Vartype.BINARY:
+            h, J, offset = to_ising(bqm)
+            response = self.sample_ising(h, J, **sample_kwargs)
+            response.change_vartype(Vartype.BINARY, offset)
+            return response
+        else:
+            raise RuntimeError("binary quadratic model has an unknown vartype")
 
     def sample_ising(self, h, J, **sample_kwargs):
         """todo"""
+        self._ensure_finite_cycle('sample_ising')
         bqm = from_ising(h, J)
         response = self.sample(bqm, **sample_kwargs)
         response.change_vartype(Vartype.SPIN)
@@ -46,6 +55,7 @@ class Sampler(object):
 
     def sample_qubo(self, Q, **sample_kwargs):
         """todo"""
+        self._ensure_finite_cycle('sample_qubo')
         bqm = from_qubo(Q)
         response = self.sample(bqm, **sample_kwargs)
         response.change_vartype(Vartype.BINARY)

--- a/dimod/decorators.py
+++ b/dimod/decorators.py
@@ -125,7 +125,7 @@ def vartype_argument(*args_names):
                     arg_idx = argspec.args.index(arg_name)
                     vartype = args[arg_idx]
                 except (ValueError, IndexError):
-                    raise RuntimeError('vartype argument missing')
+                    raise TypeError('vartype argument missing')
 
             if isinstance(vartype, Vartype):
                 return

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -77,3 +77,12 @@ class TestVartypeArgument(unittest.TestCase):
         self.assertRaises(TypeError, g)
         self.assertRaises(TypeError, g, x=SPIN)
         self.assertRaises(TypeError, g, vartype=SPIN)
+
+    def test_arg_with_default_value(self):
+        @vartype_argument('vartype')
+        def f(vartype='SPIN'):
+            return vartype
+
+        self.assertEqual(f(), SPIN)
+        self.assertEqual(f('BINARY'), BINARY)
+        self.assertEqual(f(vartype='BINARY'), BINARY)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -17,7 +17,7 @@ class TestVartypeArgument(unittest.TestCase):
         self.assertEqual(f(x='SPIN'), SPIN)
         self.assertRaises(TypeError, f, 'x')
         self.assertRaises(TypeError, f, x='x')
-        self.assertRaises(RuntimeError, f)
+        self.assertRaises(TypeError, f)
 
     def test_multiple_explicit_args(self):
         @vartype_argument('x', 'y')
@@ -29,7 +29,7 @@ class TestVartypeArgument(unittest.TestCase):
         self.assertEqual(f(y='BINARY', x='SPIN'), (SPIN, BINARY))
         self.assertRaises(TypeError, f, 'x', 'y')
         self.assertRaises(TypeError, f, x='x', y='SPIN')
-        self.assertRaises(RuntimeError, f)
+        self.assertRaises(TypeError, f)
 
     def test_kwargs(self):
         @vartype_argument('x', 'y')
@@ -37,8 +37,8 @@ class TestVartypeArgument(unittest.TestCase):
             return itemgetter('x', 'y')(kwargs)
 
         self.assertEqual(f(x=SPIN, y=BINARY), (SPIN, BINARY))
-        self.assertRaises(RuntimeError, f)
-        self.assertRaises(RuntimeError, f, x=SPIN)
+        self.assertRaises(TypeError, f)
+        self.assertRaises(TypeError, f, x=SPIN)
         self.assertRaises(TypeError, f, x='x', y='SPIN')
 
     def test_explicit_with_kwargs(self):
@@ -48,8 +48,8 @@ class TestVartypeArgument(unittest.TestCase):
 
         self.assertEqual(f('SPIN', y='BINARY'), (SPIN, BINARY))
         self.assertEqual(f(y='BINARY', x='SPIN'), (SPIN, BINARY))
-        self.assertRaises(RuntimeError, f)
-        self.assertRaises(RuntimeError, f, x=SPIN)
+        self.assertRaises(TypeError, f)
+        self.assertRaises(TypeError, f, x=SPIN)
         self.assertRaises(TypeError, f, x='x', y='SPIN')
 
     def test_default_argname(self):
@@ -67,13 +67,13 @@ class TestVartypeArgument(unittest.TestCase):
         def f(x=None):
             return x
 
-        self.assertRaises(RuntimeError, f)
-        self.assertRaises(RuntimeError, f, x=SPIN)
+        self.assertRaises(TypeError, f)
+        self.assertRaises(TypeError, f, x=SPIN)
 
         @vartype_argument('vartype')
         def g(x=None):
             return x
 
-        self.assertRaises(RuntimeError, g)
-        self.assertRaises(RuntimeError, g, x=SPIN)
+        self.assertRaises(TypeError, g)
+        self.assertRaises(TypeError, g, x=SPIN)
         self.assertRaises(TypeError, g, vartype=SPIN)


### PR DESCRIPTION
Support default argument values. Use `TypeError` consistently with Python's standard usage.