### PR TITLE
Fix Travis Py3/OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
             - brew update
             - brew upgrade python
             - pip3 install virtualenv
-            - virtualenv env -p python
+            - virtualenv env -p python3
             - source env/bin/activate
           deploy:
         - os: osx


### PR DESCRIPTION
Explicitly use python3 when creating virtualenv; looks like the global
python is now py2.