### PR TITLE
Update BQM to allow for metadata in an `info` field and to be built from empty

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -142,6 +142,36 @@ class BinaryQuadraticModel(object):
         self.add_variables_from(linear)
         self.add_interactions_from(quadratic)
 
+    @classmethod
+    def empty(cls, vartype):
+        """Creates an empty BinaryQuadraticModel.
+
+        Equivalent to
+
+        .. code-block:: python
+
+            BinaryQuadraticModel({}, {}, 0.0, vartype)
+
+        Args:
+            vartype (:class:`.Vartype`/str/set):
+                The variable type desired for the binary quadratic model. Accepted input values:
+
+                * :attr:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
+                * :attr:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
+
+        Examples:
+
+            >>> bqm = dimod.BinaryQuadraticModel.empty(dimod.BINARY)
+            >>> bqm.linear
+            {}
+            >>> bqm.quadratic
+            {}
+            >>> bqn.offset
+            0.0
+
+        """
+        return cls({}, {}, 0.0, vartype)
+
     def __repr__(self):
         return 'BinaryQuadraticModel({}, {}, {}, {})'.format(self.linear, self.quadratic, self.offset, self.vartype)
 

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -44,13 +44,13 @@ class BinaryQuadraticModel(object):
             See :meth:`.BinaryQuadraticModel.energy`.
 
         vartype (:class:`.Vartype`/str/set):
-            The variable type desired for the binary quadratic model. Accepted input values:
+            Variable type for the binary quadratic model. Accepted input values:
 
             * :class:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
             * :class:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
 
         **kwargs:
-            Any additional keyword parameters and their values will be stored in
+            Any additional keyword parameters and their values are stored in
             :attr:`.BinaryQuadraticModel.info`.
 
     Notes:
@@ -136,7 +136,7 @@ class BinaryQuadraticModel(object):
         self.adj = {}
         self.offset = offset  # we are agnostic to type, though generally should behave like a number
         self.vartype = vartype
-        self.info = kwargs  # dump any additional kwargs into info
+        self.info = kwargs  # any additional kwargs are kept as info (metadata)
 
         # add linear, quadratic
         self.add_variables_from(linear)
@@ -144,7 +144,7 @@ class BinaryQuadraticModel(object):
 
     @classmethod
     def empty(cls, vartype):
-        """Creates an empty BinaryQuadraticModel.
+        """Create an empty BinaryQuadraticModel.
 
         Equivalent to
 
@@ -154,7 +154,7 @@ class BinaryQuadraticModel(object):
 
         Args:
             vartype (:class:`.Vartype`/str/set):
-                The variable type desired for the binary quadratic model. Accepted input values:
+                Variable type for the binary quadratic model. Accepted input values:
 
                 * :attr:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
                 * :attr:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
@@ -924,9 +924,9 @@ class BinaryQuadraticModel(object):
                 the updated model.
 
             ignore_info (bool, optional, default=True):
-                If True, the info in the given bqm is ignored, otherwise
-                :attr:`.BinaryQuadraticModel.info` is updated with the given bqm's info, potentially
-                overwriting values.
+                If True, info in the given binary quadratic model is ignored, otherwise
+                :attr:`.BinaryQuadraticModel.info` is updated with the given binary quadratic
+                model's info, potentially overwriting values.
 
         Examples:
            This example creates two binary quadratic models and updates the first

--- a/docs/reference/binary_quadratic_model.rst
+++ b/docs/reference/binary_quadratic_model.rst
@@ -24,6 +24,14 @@ Vartype Properties
 Methods
 =======
 
+Construction Shortcuts
+----------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   BinaryQuadraticModel.empty
+
 Adding and removing variables and interactions
 ----------------------------------------------
 

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1506,3 +1506,27 @@ class TestConvert(unittest.TestCase):
         for u in bqm.adj:
             for v in bqm.adj[u]:
                 self.assertAlmostEqual(bqm.adj[u][v], bqm_new.adj[u][v])
+
+    def test_info(self):
+        bqm = dimod.BinaryQuadraticModel({}, {}, 0.0, dimod.SPIN, tag=1)
+
+        self.assertIn('tag', bqm.info)
+        self.assertEqual(bqm.info['tag'], 1)
+
+        new_bqm = bqm.copy()
+
+        self.assertIn('tag', new_bqm.info)
+        self.assertEqual(new_bqm.info['tag'], 1)
+
+        another_bqm = dimod.BinaryQuadraticModel({}, {}, 0.0, dimod.SPIN, id=5)
+
+        bqm.update(another_bqm, ignore_info=False)
+        self.assertIn('tag', bqm.info)
+        self.assertEqual(bqm.info['tag'], 1)
+        self.assertIn('id', bqm.info)
+        self.assertEqual(bqm.info['id'], 5)
+
+        new_bqm.update(another_bqm, ignore_info=True)
+        self.assertIn('tag', new_bqm.info)
+        self.assertEqual(new_bqm.info['tag'], 1)
+        self.assertNotIn('id', new_bqm.info)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1530,3 +1530,8 @@ class TestConvert(unittest.TestCase):
         self.assertIn('tag', new_bqm.info)
         self.assertEqual(new_bqm.info['tag'], 1)
         self.assertNotIn('id', new_bqm.info)
+
+    def test_empty(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        self.assertEqual(bqm, dimod.BinaryQuadraticModel({}, {}, 0.0, dimod.SPIN))


### PR DESCRIPTION
#153 #139 