### PR TITLE
Add json encoding/decoding to BinaryQuadraticModel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include dimod/io/bqm_json_schema.json

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -166,7 +166,7 @@ class BinaryQuadraticModel(object):
             {}
             >>> bqm.quadratic
             {}
-            >>> bqn.offset
+            >>> bqm.offset
             0.0
 
         """
@@ -1292,6 +1292,93 @@ class BinaryQuadraticModel(object):
 ##################################################################################################
 # conversions
 ##################################################################################################
+
+    def to_json(self, fp=None):
+        """Serialize the binary quadratic model using JSON.
+
+        Args:
+            fp (file, optional):
+                A `.write()`-supporting `file object`_. If not provided, the method will return
+                a string.
+
+        .. _file object: https://docs.python.org/3/glossary.html#term-file-object
+
+        An example of a serialized BinaryQuadraticModel
+
+        .. code-block:: json
+
+            {
+                "linear_terms": [
+                    {"bias": 1.0, "label": 0},
+                    {"bias": -1.0, "label": 1}
+                ],
+                "info": {},
+                "offset": 0.5,
+                "quadratic_terms": [
+                    {"bias": 0.5, "label_head": 1, "label_tail": 0}
+                ],
+                "variable_labels": [0, 1],
+                "variable_type": "SPIN",
+                "version": {
+                    "bqm_schema": "1.0.0",
+                    "dimod": "0.6.3"
+                }
+            }
+
+        Examples:
+            Example of writing the binary quadratic model to a file
+
+            >>> bqm = dimod.BinaryQuadraticModel({'a': -1.0, 'b': 1.0}, {('a', 'b'): -1.0, 0.0, dimod.SPIN)
+            >>> with open('tmp.txt', 'w') as file:  # doctest: +SKIP
+            ...     bqm.to_json(file)
+
+            Example of writing to a string
+
+            >>> bqm = dimod.BinaryQuadraticModel({'a': -1.0, 'b': 1.0}, {('a', 'b'): -1.0}, 0.0, dimod.SPIN)
+            >>> bqm.to_json()  # doctest: +SKIP
+            {"info": {},
+             "linear_terms": [{"bias": -1.0, "label": "a"},
+                              {"bias": 1.0, "label": "b"}],
+             "offset": 0.0,
+             "quadratic_terms": [{"bias": -1.0, "label_head": "b", "label_tail": "a"}],
+             "variable_labels": ["a", "b"], "variable_type": "SPIN",
+             "version": {"bqm_schema": "1.0.0", "dimod": "0.6.3"}}
+
+        """
+        import json
+        from dimod.io.json import DimodEncoder
+
+        if fp is None:
+            return json.dumps(self, cls=DimodEncoder, sort_keys=True)
+        else:
+            return json.dump(self, fp, cls=DimodEncoder, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, obj):
+        """Deserialize a binary quadratic model from a JSON encoding.
+
+        Args:
+            obj: (str/file):
+                Either a string or a  A `.read()`-supporting `file object`_.
+
+        .. _file object: https://docs.python.org/3/glossary.html#term-file-object
+
+        Examples:
+            >>> bqm = dimod.BinaryQuadraticModel({'a': -1.0, 'b': 1.0}, {('a', 'b'): -1.0, 0.0, dimod.SPIN)
+            >>> with open('tmp.txt', 'w') as file:  # doctest: +SKIP
+            ...     bqm.to_json(file)
+            >>> with open('tmp.txt', 'r') as file:  # doctest: +SKIP
+            ...     new_bqm = dimod.BinaryQuadraticModel.from_json(file)
+
+        """
+        import json
+
+        from dimod.io.json import bqm_decode_hook
+
+        if isinstance(obj, str):
+            return json.loads(obj, object_hook=bqm_decode_hook)
+
+        return json.load(obj,  object_hook=bqm_decode_hook)
 
     def to_networkx_graph(self, node_attribute_name='bias', edge_attribute_name='bias'):
         """Convert a binary quadratic model to NetworkX graph format.

--- a/dimod/io/bqm_json_schema.json
+++ b/dimod/io/bqm_json_schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "binary quadratic model schema",
+  "type": "object",
+  "required":["linear_terms", "info", "offset", "quadratic_terms", "variable_labels", "variable_type", "version"],
+  "properties": {
+    "info": {
+      "type": "object"
+    },
+    "variable_labels": {
+      "type": "array",
+      "items": {
+        "type": ["integer", "string", "array"],
+        "minimum": 0
+      }
+    },
+    "variable_type": {
+      "type":"string",
+      "enum":["SPIN", "BINARY"]
+    },
+    "offset" : {
+      "type": "number"
+    },
+    "linear_terms": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required":["label", "bias"],
+        "properties": {
+          "label" : {
+            "type": ["integer", "string", "array"],
+            "minimum": 0
+          },
+          "bias":{
+             "type": "number"
+          }
+        }
+      }
+    },
+    "quadratic_terms": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required":["label_head", "label_tail", "bias"],
+        "properties": {
+          "label_head" : {
+            "type": ["integer", "string", "array"],
+            "minimum": 0
+          },
+          "label_tail" : {
+            "type": ["integer", "string", "array"],
+            "minimum": 0
+          },
+          "bias":{
+             "type": "number"
+          }
+        }
+      }
+    },
+    "version": {
+      "type": "object",
+      "required": ["bqm_schema", "dimod"],
+      "properties": {
+        "bqm_schema": {
+          "enum":["1.0.0"]
+        }
+      }
+    }
+  }
+}

--- a/dimod/io/json.py
+++ b/dimod/io/json.py
@@ -1,0 +1,126 @@
+from __future__ import absolute_import
+
+import json
+from pkg_resources import resource_filename
+
+import jsonschema
+from six import iteritems
+
+from dimod.binary_quadratic_model import BinaryQuadraticModel
+from dimod.package_info import __version__
+from dimod.response import Response
+from dimod.vartypes import Vartype
+
+bqm_json_schema_version = "1.0.0"
+
+with open(resource_filename(__name__, 'bqm_json_schema.json'), 'r') as schema_file:
+    bqm_json_schema = json.load(schema_file)
+
+
+def bqm_decode_hook(dct):
+    if 'bias' in dct:
+        bias = dct['bias']
+        if 'label' in dct:
+            u = dct['label']
+            if isinstance(u, list):
+                u = tuple(u)
+            return (u, bias)
+        else:
+            u = dct['label_head']
+            v = dct['label_tail']
+            if isinstance(u, list):
+                u = tuple(u)
+            if isinstance(v, list):
+                v = tuple(v)
+            return ((u, v), bias)
+
+    elif 'linear_terms' in dct and 'quadratic_terms' in dct:
+        return BinaryQuadraticModel(dict(dct['linear_terms']),
+                                    dict(dct['quadratic_terms']),
+                                    dct['offset'],
+                                    Vartype[dct['variable_type']],
+                                    **dct['info'])
+
+    return dct
+
+
+class DimodEncoder(json.JSONEncoder):
+    """Subclass the JSONEncoder for dimod objects."""
+    def default(self, obj):
+        if isinstance(obj, BinaryQuadraticModel):
+
+            if obj.vartype is Vartype.SPIN:
+                vartype_string = 'SPIN'
+            elif obj.vartype is Vartype.BINARY:
+                vartype_string = 'BINARY'
+            else:
+                raise RuntimeError("unknown vartype")
+
+            # by using the stream objects, we don't need to create the entire json_dict in memory
+            json_dict = {"linear_terms": _JSONLinearBiasStream.from_dict(obj.linear),
+                         "quadratic_terms": _JSONQuadraticBiasStream.from_dict(obj.quadratic),
+                         "offset": obj.offset,
+                         "variable_type": vartype_string,
+                         "version": {"dimod": __version__, "bqm_schema": bqm_json_schema_version},
+                         "variable_labels": _JSONLabelsStream.from_dict(obj.linear),
+                         "info": obj.info}
+            return json_dict
+
+        if isinstance(obj, Response):
+            # we will eventually want to implement this
+            raise NotImplementedError
+
+        return json.JSONEncoder.default(self, obj)
+
+
+class _JSONLinearBiasStream(list):
+    """Allows json to encode linear biases without needing to create a large number of dicts in
+    memory.
+    """
+    @classmethod
+    def from_dict(cls, linear):
+        jlbs = cls()
+        jlbs.linear = linear
+        return jlbs
+
+    def __iter__(self):
+        for v, bias in iteritems(self.linear):
+            yield {"bias": bias, "label": v}
+
+    def __len__(self):
+        return len(self.linear)
+
+
+class _JSONQuadraticBiasStream(list):
+    """Allows json to encode quadratic biases without needing to create a large number of dicts in
+    memory.
+    """
+    @classmethod
+    def from_dict(cls, quadratic):
+        jqbs = cls()
+        jqbs.quadratic = quadratic
+        return jqbs
+
+    def __iter__(self):
+        for (u, v), bias in iteritems(self.quadratic):
+            yield {"bias": bias, "label_head": v, "label_tail": u}
+
+    def __len__(self):
+        return len(self.quadratic)
+
+
+class _JSONLabelsStream(list):
+    """Allows json to encode variable labels without needing to create a large list in memory.
+    """
+    @classmethod
+    def from_dict(cls, linear):
+        jlbs = cls()
+        jlbs.linear = linear
+        return jlbs
+
+    def __iter__(self):
+        for u in self.linear:
+            yield u
+
+    def __len__(self):
+        return len(self.linear)

--- a/docs/reference/binary_quadratic_model.rst
+++ b/docs/reference/binary_quadratic_model.rst
@@ -93,10 +93,12 @@ Converting to other types
    :toctree: generated/
 
    BinaryQuadraticModel.from_ising
+   BinaryQuadraticModel.from_json
    BinaryQuadraticModel.from_numpy_matrix
    BinaryQuadraticModel.from_qubo
    BinaryQuadraticModel.from_pandas_dataframe
    BinaryQuadraticModel.to_ising
+   BinaryQuadraticModel.to_json
    BinaryQuadraticModel.to_networkx_graph
    BinaryQuadraticModel.to_numpy_matrix
    BinaryQuadraticModel.to_qubo

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ enum34==1.1.6
 numpy==1.14.0
 six==1.11.0
 futures; python_version=="2.7"
+jsonschema==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ else:
 
 install_requires = ['enum34>=1.1.6,<2.0.0',
                     'numpy>=1.14.0,<2.0.0',
-                    'six>=1.10.0,<2.0.0']
+                    'six>=1.10.0,<2.0.0',
+                    'jsonschema>=2.6.0,<3.0.0']
 
 extras_require = {'all': ['networkx>=2.0,<3.0',
                           'pandas>=0.22.0,<0.23.0'],
@@ -24,6 +25,7 @@ extras_require = {'all': ['networkx>=2.0,<3.0',
 
 packages = ['dimod',
             'dimod.core',
+            'dimod.io',
             'dimod.reference',
             'dimod.reference.composites',
             'dimod.reference.samplers',
@@ -41,5 +43,6 @@ setup(
     license='Apache 2.0',
     packages=packages,
     install_requires=install_requires,
-    extras_require=extras_require
+    extras_require=extras_require,
+    include_package_data=True
 )


### PR DESCRIPTION
#152 

Example of the json schema:

```
    {
        "linear_terms": [
            {"bias": 1.0, "label": 0},
            {"bias": -1.0, "label": 1}
        ],
        "info": {},
        "offset": 0.5,
        "quadratic_terms": [
            {"bias": 0.5, "label_head": 1, "label_tail": 0}
        ],
        "variable_labels": [0, 1],
        "variable_type": "SPIN",
        "version": {
            "bqm_schema": "1.0.0",
            "dimod": "0.6.3"
        }
    }
```