### PR TITLE
Speed up calculating the energy from responses

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -10,6 +10,7 @@ from numbers import Number
 from six import itervalues, iteritems, iterkeys
 
 from dimod.decorators import vartype_argument
+from dimod.response import SampleView
 from dimod.utilities import resolve_label_conflict
 from dimod.vartypes import Vartype
 
@@ -1283,6 +1284,13 @@ class BinaryQuadraticModel(object):
         """
         linear = self.linear
         quadratic = self.quadratic
+
+        if isinstance(sample, SampleView):
+            # because the SampleView object simply reads from an underlying matrix, each read
+            # is relatively expensive.
+            # However, sample.items() is ~10x faster than {sample[v] for v in sample}, therefore
+            # it is much more efficient to dump sample into a dictionary for repeated reads
+            sample = dict(sample)
 
         en = self.offset
         en += sum(linear[v] * sample[v] for v in linear)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1568,8 +1568,6 @@ class TestConvert(unittest.TestCase):
         tmpdir = tempfile.mkdtemp()
         filename = path.join(tmpdir, 'test.txt')
 
-        print(filename)
-
         with open(filename, 'w') as file:
             bqm.to_json(fp=file)
 

--- a/tests/test_random_sampler.py
+++ b/tests/test_random_sampler.py
@@ -1,9 +1,25 @@
 import unittest
 
 import dimod
+import dimod.testing as dtest
 
 
 class TestRandomSampler(unittest.TestCase):
-    def setUp(self):
-        self.sampler = dimod.RandomSampler()
-        self.sampler_factory = dimod.RandomSampler
+    def test_initialization(self):
+        sampler = dimod.RandomSampler()
+
+        dtest.assert_sampler_api(sampler)
+        self.assertEqual(sampler.properties, {})
+        self.assertEqual(sampler.parameters, {'num_reads': []})
+
+    def test_energies(self):
+        bqm = dimod.BinaryQuadraticModel({0: 0.0, 1: 0.0, 2: 0.0},
+                                         {(0, 1): -1.0, (1, 2): 1.0, (0, 2): 1.0},
+                                         1.0,
+                                         dimod.SPIN)
+        sampler = dimod.RandomSampler()
+        response = sampler.sample(bqm, num_reads=10)
+
+        # check their energies
+        for sample, energy in response.data(['sample', 'energy']):
+            self.assertAlmostEqual(energy, bqm.energy(sample))


### PR DESCRIPTION
By overwriting `SampleView.items` and `SampleView.values` we get approximately 10x speed up for calculating energies of a response.

Addresses #135 as well