### PR TITLE
Bug fix: RuntimeWarning thrown in BQM unittests

### DIFF
--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1499,10 +1499,14 @@ class TestConvert(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel(linear, quadratic, 0.0, dimod.BINARY)
 
         bqm_df = bqm.to_pandas_dataframe()
+        variables = list(bqm_df)
 
         for config in itertools.product((0, 1), repeat=4):
-            sample = dict(zip(['a', 'b', 'c', 16], config))
-            sample_series = pd.Series(sample)
+            sample = dict(zip(variables, config))
+            # Note: explicitly set the index of Series object to be equal (in same order)
+            # to the column list of the DataFrame multiplied later, to avoid sorting of
+            # indexes with mixed types. See https://github.com/dwavesystems/dimod/pull/167.
+            sample_series = pd.Series(data=sample, index=variables)
 
             self.assertAlmostEqual(bqm.energy(sample), sample_series.dot(bqm_df.dot(sample_series)))
 


### PR DESCRIPTION
Dance around deficiencies in `pandas.DataFrame.dot()` implementation to
avoid sorting the index array with mixed types (and throwing `TypeError`
wrapped with `RuntimeWarning`).

Post-mortem:

- [`pandas.DataFrame.dot`](https://github.com/pandas-dev/pandas/blob/a00154dcfe5057cb3fd86653172e74b6893e337d/pandas/core/frame.py#L821) calculates a union of indices (variables) of
  left- and right-hand-side DataFrame/Series to align them before multiplying

- [`pandas.Index.union`](https://github.com/pandas-dev/pandas/blob/a00154dcfe5057cb3fd86653172e74b6893e337d/pandas/core/indexes/base.py#L2189) returns early (does nothing) if two indices it has to
  combine are equal. If indices differ (even just in order), the method joins them,
  and just for a good measure, [sorts them](https://github.com/pandas-dev/pandas/blob/a00154dcfe5057cb3fd86653172e74b6893e337d/pandas/core/indexes/base.py#L2263)

- by making left-hand-side `DataFrame` have the same columns as the
  right-hand-side `Series` (in the same order), we short-circuit the `union()`,
  and avoid the sorting of column names. The sorting of lists (column names)
  of mixed types is not defined in Python3 (results in `TypeError`)

- note: the dot product was correctly calculated, just the order of
  columns was undefined, since they were initialized from a `dict`

Closes #116.