### PR TITLE
Add all chain variable to target bqm with embed_bqm

### DIFF
--- a/dimod/embedding/transforms.py
+++ b/dimod/embedding/transforms.py
@@ -97,7 +97,7 @@ def embed_bqm(source_bqm, embedding, target_adjacency, chain_strength=1.0, embed
     # create a new empty binary quadratic model with the same class as source_bqm
     target_bqm = source_bqm.empty(source_bqm.vartype)
 
-    # go ahead and add the offset
+    # add the offset
     target_bqm.add_offset(source_bqm.offset)
 
     # start with the linear biases, spreading the source bias equally over the target variables in
@@ -133,6 +133,14 @@ def embed_bqm(source_bqm, embedding, target_adjacency, chain_strength=1.0, embed
         target_bqm.add_interactions_from((u, v, b) for u, v in available_interactions)
 
     for chain in itervalues(embedding):
+
+        # in the case where the chain has length 1, there are no chain quadratic biases, but we
+        # none-the-less want the chain variables to appear in the target_bqm
+        if len(chain) == 1:
+            v, = chain
+            target_bqm.add_variable(v, 0.0)
+            continue
+
         quadratic_chain_biases = chain_to_quadratic(chain, target_adjacency, chain_strength)
         target_bqm.add_interactions_from(quadratic_chain_biases, vartype=Vartype.SPIN)  # these are spin
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -162,7 +162,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(freq, {0: .5})
 
 
-class TestApply(unittest.TestCase):
+class TestEmbedBQM(unittest.TestCase):
     def test_embed_bqm_empty(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 
@@ -380,6 +380,18 @@ class TestApply(unittest.TestCase):
 
         self.assertEqual(target_Q, {(0, 0): 0.0, (1, 1): 0.0, (2, 2): 2.0, (3, 3): 2.0,
                                     (0, 1): -1.0, (1, 2): -1.0, (2, 3): -4.0})
+
+    @unittest.skipUnless(_networkx, "No networkx installed")
+    def test_embedding_with_extra_chains(self):
+        embedding = {0: [0, 1], 1: [2], 2: [3]}
+        G = nx.cycle_graph(4)
+
+        bqm = dimod.BinaryQuadraticModel.from_qubo({(0, 0): 1})
+
+        target_bqm = dimod.embed_bqm(bqm, embedding, G)
+
+        for v in itertools.chain(*embedding.values()):
+            self.assertIn(v, target_bqm)
 
 
 class TestIterUnembed(unittest.TestCase):


### PR DESCRIPTION
```
        embedding = {0: [0, 1], 1: [2], 2: [3]}
        G = nx.cycle_graph(4)

        bqm = dimod.BinaryQuadraticModel.from_qubo({(0, 0): 1})

        target_bqm = dimod.embed_bqm(bqm, embedding, G)

        for v in itertools.chain(*embedding.values()):
            assert v in target_bqm
```
Previously failed but now works