### PR TITLE
Remove abstract sampler examples, rearrange items on RtD 1st page & 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,10 @@
 .. image:: https://readthedocs.org/projects/dimod/badge/?version=latest
     :target: http://dimod.readthedocs.io/en/latest/?badge=latest
 
-.. index-start-marker
-
 dimod
 =====
+
+.. index-start-marker1
 
 `dimod` is a shared API for binary quadratic samplers. It provides a binary quadratic
 model (BQM) class that contains Ising and quadratic unconstrained binary
@@ -22,17 +22,23 @@ provides utilities for constructing new samplers and composed samplers and for
 minor-embedding. Its reference examples include several samplers and composed
 samplers.
 
+.. index-end-marker1
+
 Learn more about `dimod on Read the Docs <http://dimod.readthedocs.io/en/latest/>`_\ .
 
 Example Usage
 -------------
+
+.. index-start-marker2
+
 This example constructs a simple QUBO and converts it to Ising format.
 
 >>> import dimod
 >>> bqm = dimod.BinaryQuadraticModel({0: -1, 1: -1}, {(0, 1): 2}, 0.0, dimod.BINARY)  # QUBO
 >>> bqm_ising = bqm.change_vartype(dimod.SPIN, inplace=False)  # Ising
 
-An example of using one of the built-in test Samplers.
+This example uses one of dimod's test samplers, ExactSampler, a solver that calculates
+the energies of all possible samples.
 
 >>> import dimod
 >>> h = {0: 0.0, 1: 0.0}
@@ -45,7 +51,7 @@ matrix([[-1, -1],
         [ 1,  1],
         [-1,  1]])
 
-.. index-end-marker
+.. index-end-marker2
 
 See the documentation for more examples.
 

--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -167,31 +167,6 @@ class Sampler:
     @samplemixinmethod
     def sample(self, bqm, **parameters):
         """Samples from a binary quadratic model using an implemented sample method.
-
-        Examples:
-            This example implements a placeholder Ising sampler and samples using
-            the mixin binary quadratic model sampler.
-
-            >>> import dimod
-            >>> class ImplementIsingSampler(dimod.Sampler):
-            ...     def sample_ising(self, h, J):
-            ...         return dimod.Response.from_dicts([{1: -1, 2: +1}], {'energy': [-1.0]}) # Placeholder
-            ...     @property
-            ...     def properties(self):
-            ...         return self._properties
-            ...     @property
-            ...     def parameters(self):
-            ...         return dict()
-            ...
-            >>> sampler = ImplementIsingSampler()
-            >>> model = dimod.BinaryQuadraticModel({0: 1, 1: -1, 2: .5},
-            ...                                    {(0, 1): .5, (1, 2): 1.5},
-            ...                                    1.4,
-            ...                                    dimod.SPIN)
-            >>> response = sampler.sample(model)
-            >>> print(response)
-            [[-1  1]]
-
         """
         if bqm.vartype is Vartype.SPIN:
             Q, offset = bqm.to_qubo()
@@ -209,29 +184,6 @@ class Sampler:
     @samplemixinmethod
     def sample_ising(self, h, J, **parameters):
         """Samples from an Ising model using an implemented sample method.
-
-        Examples:
-            This example implements a placeholder QUBO sampler and samples using
-            the mixin Ising sampler.
-
-            >>> import dimod
-            >>> class ImplementQuboSampler(dimod.Sampler):
-            ...     def sample_qubo(self, Q):
-            ...         return dimod.Response.from_dicts([{1: -1, 2: +1}], {'energy': [-1.0]}) # Placeholder
-            ...     @property
-            ...     def properties(self):
-            ...         return self._properties
-            ...     @property
-            ...     def parameters(self):
-            ...         return dict()
-            ...
-            >>> sampler = ImplementQuboSampler()
-            >>> h = {1: 0.5, 2: -1, 3: -0.75}
-            >>> J = {}
-            >>> response = sampler.sample_ising(h, J)
-            >>> print(response)
-            [[-1  1]]
-
         """
         bqm = BinaryQuadraticModel.from_ising(h, J)
         response = self.sample(bqm, **parameters)
@@ -240,29 +192,6 @@ class Sampler:
     @samplemixinmethod
     def sample_qubo(self, Q, **parameters):
         """Samples from a QUBO using an implemented sample method.
-
-        Examples:
-            This example implements a placeholder Ising sampler and samples using
-            the mixin QUBO sampler.
-
-            >>> import dimod
-            >>> class ImplementIsingSampler(dimod.Sampler):
-            ...     def sample_ising(self, h, J):
-            ...         return dimod.Response.from_dicts([{1: -1, 2: +1}], {'energy': [-1.0]}) # Placeholder
-            ...     @property
-            ...     def properties(self):
-            ...         return self._properties
-            ...     @property
-            ...     def parameters(self):
-            ...         return dict()
-            ...
-            >>> sampler = ImplementIsingSampler()
-            >>> Q = {(0, 0): -0.5, (0, 1): 1, (1, 1): -0.75}
-            >>> response = sampler.sample_qubo(Q)
-            >>> print(response)
-            [[0 1]]
-
-
         """
         bqm = BinaryQuadraticModel.from_qubo(Q)
         response = self.sample(bqm, **parameters)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,13 +2,26 @@
 
 .. _contents:
 
-.. include:: ../README.rst
-  :start-after: index-start-marker
-  :end-before: index-end-marker
+=====
+dimod
+=====
 
-The example's QUBO form, :math:`\text{E}(a_i, b_{i,j}; q_i) = -q_1 -q_2 + 2q_1 q_2`,
+.. include:: ../README.rst
+  :start-after: index-start-marker1
+  :end-before: index-end-marker1
+
+Example Usage
+-------------
+
+The QUBO form, :math:`\text{E}(a_i, b_{i,j}; q_i) = -q_1 -q_2 + 2q_1 q_2`,
 is related to the Ising form, :math:`\text{E}(h_i, j_{i,j}; s_i) = \frac{1}{2}(s_1s_2-1)`,
 via the simple manipulation :math:`s_i=2q_i-1`.
+
+.. include:: ../README.rst
+  :start-after: index-start-marker2
+  :end-before: index-end-marker2
+
+
 
 Documentation
 -------------


### PR DESCRIPTION
@arcondello RtD first page currently has a prominent "Learn more about dimod on Read the Docs" and the "The example’s QUBO form, E(ai,bi,j;qi)=−q1−q2+2q1q2..." isn't connected to its example.
As discussed, I am removing examples from abstract sampler class so they're not inherited