### PR TITLE
Add `to_numpy_vectors`, `from_numpy_vectors` to BQM

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -2077,8 +2077,8 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
         if variable_order is None:
             variable_order = list(range(len(linear)))
 
-        linear = {v: bias for v, bias in zip(variable_order, linear)}
-        quadratic = {(variable_order[u], variable_order[v]): bias
+        linear = {v: float(bias) for v, bias in zip(variable_order, linear)}
+        quadratic = {(variable_order[u], variable_order[v]): float(bias)
                      for u, v, bias in zip(heads, tails, values)}
 
         return cls(linear, quadratic, offset, vartype)

--- a/docs/reference/binary_quadratic_model.rst
+++ b/docs/reference/binary_quadratic_model.rst
@@ -97,6 +97,7 @@ Converting to other types
    BinaryQuadraticModel.from_ising
    BinaryQuadraticModel.from_json
    BinaryQuadraticModel.from_numpy_matrix
+   BinaryQuadraticModel.from_numpy_vectors
    BinaryQuadraticModel.from_qubo
    BinaryQuadraticModel.from_pandas_dataframe
    BinaryQuadraticModel.to_coo
@@ -104,5 +105,6 @@ Converting to other types
    BinaryQuadraticModel.to_json
    BinaryQuadraticModel.to_networkx_graph
    BinaryQuadraticModel.to_numpy_matrix
+   BinaryQuadraticModel.to_numpy_vectors
    BinaryQuadraticModel.to_qubo
    BinaryQuadraticModel.to_pandas_dataframe


### PR DESCRIPTION
Add two new method `BinaryQuadraticModel.to_numpy_vectors` and `BinaryQuadraticModel.from_numpy_vectors`. This serves as a sparse alternative to `to_numpy_matrix` and `from_numpy_matrix`.