### PR TITLE
to_json/from_json

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1487,19 +1487,13 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
 
         return coo.load(obj, cls.empty(vartype))
 
-    def to_json(self, fp=None):
+    def to_json(self):
         """Serialize the binary quadratic model using JSON.
 
-        Args:
-            fp (file, optional):
-                A `.write()`-supporting `file object`_ to save the binary quadratic model to,
-                formatted according to the current `BQM schema`_\ . If not provided,
-                returns a string.
+        Returns:
+            str: Bnary quadratic model serialized in accordance with `BQM schema`_.
 
-        .. _file object: https://docs.python.org/3/glossary.html#term-file-object
         .. _BQM schema: https://github.com/dwavesystems/dimod/blob/master/dimod/io/bqm_json_schema.json
-
-
 
         Examples:
             This example shows a serialized binary quadratic model in JSON encoding for
@@ -1525,14 +1519,6 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
                     }
                 }
 
-
-            This is an example of writing a binary quadratic model to a JSON-format file.
-
-            >>> import dimod
-            >>> bqm = dimod.BinaryQuadraticModel({'a': -1.0, 'b': 1.0}, {('a', 'b'): -1.0}, 0.0, dimod.SPIN)
-            >>> with open('tmp.txt', 'w') as file:  # doctest: +SKIP
-            ...     bqm.to_json(file)
-
             This is an example of writing a binary quadratic model to a JSON-format string.
 
             >>> import dimod
@@ -1546,14 +1532,18 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
              "variable_labels": ["a", "b"], "variable_type": "SPIN",
              "version": {"bqm_schema": "1.0.0", "dimod": "0.6.3"}}
 
+            This is an example of writing a binary quadratic model to a JSON-format file.
+
+            >>> import dimod
+            >>> bqm = dimod.BinaryQuadraticModel({'a': -1.0, 'b': 1.0}, {('a', 'b'): -1.0}, 0.0, dimod.SPIN)
+            >>> with open('tmp.txt', 'w') as file:  # doctest: +SKIP
+            ...     file.write(bqm.to_json())
+
         """
         import json
-        from dimod.io.json import DimodStreamEncoder
+        from dimod.io.json import DimodEncoder
 
-        if fp is None:
-            return json.dumps(self, cls=DimodStreamEncoder, sort_keys=True)
-        else:
-            return json.dump(self, fp, cls=DimodStreamEncoder, sort_keys=True)
+        return json.dumps(self, cls=DimodEncoder, sort_keys=True)
 
     @classmethod
     def from_json(cls, obj):
@@ -1561,9 +1551,9 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
 
         Args:
             obj: (str/file):
-                Either a string or a  `.read()`-supporting `file object`_
+                Either a string or a `.read()`-supporting `file object`_
                 that represents linear and quadratic biases for a binary quadratic model
-                formatted in accordance to the current `BQM schema`_\ .
+                formatted in accordance to the current `BQM schema`_ .
 
         .. _file object: https://docs.python.org/3/glossary.html#term-file-object
         .. _BQM schema: https://github.com/dwavesystems/dimod/blob/master/dimod/io/bqm_json_schema.json

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1506,6 +1506,9 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
              'variable_labels': [0, 2, 1],
              'info': {}}
 
+        See also:
+            :meth:`~.BinaryQuadraticModel.from_dict`
+
         """
         from dimod.io.json import DimodEncoder
 
@@ -1519,9 +1522,6 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
             dct (dict):
                 A dictionary as created by :meth:`~.BinaryQuadraticModel.to_dict`.
 
-        Returns:
-            :obj:`.BinaryQuadraticModel`
-
         Examples:
             >>> dct = {'linear_terms': [{'bias': 1, 'label': 0},
                        {'bias': 0.1, 'label': 2},
@@ -1533,6 +1533,9 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
                       'variable_labels': [0, 2, 1],
                       'info': {}}
             >>> bqm = dimod.BinaryQuadraticModel.from_dict(dct)
+
+        See also:
+            :meth:`~.BinaryQuadraticModel.to_dict`
 
         """
         from dimod.io.json import bqm_decode_hook

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1487,66 +1487,6 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
 
         return coo.load(obj, cls.empty(vartype))
 
-    def to_dict(self):
-        """Create a serializable JSON-style dict.
-
-        Returns:
-            dict: A python dictionary of JSON-serializable objects.
-
-        Examples:
-            >>> bqm = dimod.BinaryQuadraticModel.from_ising({0: 1, 2: .1}, {(0, 1): -1})
-            >>> bqm.to_dict()  # doctest: +SKIP
-            {'linear_terms': [{'bias': 1, 'label': 0},
-              {'bias': 0.1, 'label': 2},
-              {'bias': 0.0, 'label': 1}],
-             'quadratic_terms': [{'bias': -1, 'label_head': 1, 'label_tail': 0}],
-             'offset': 0.0,
-             'variable_type': 'SPIN',
-             'version': {'dimod': '0.6.12', 'bqm_schema': '1.0.0'},
-             'variable_labels': [0, 2, 1],
-             'info': {}}
-
-        See also:
-            :meth:`~.BinaryQuadraticModel.from_dict`
-
-        """
-        from dimod.io.json import DimodEncoder
-
-        return DimodEncoder().default(self)
-
-    @classmethod
-    def from_dict(cls, dct):
-        """Inverse of to_dict.
-
-        Args:
-            dct (dict):
-                A dictionary as created by :meth:`~.BinaryQuadraticModel.to_dict`.
-
-        Examples:
-            >>> dct = {'linear_terms': [{'bias': 1, 'label': 0},
-                       {'bias': 0.1, 'label': 2},
-                       {'bias': 0.0, 'label': 1}],
-                      'quadratic_terms': [{'bias': -1, 'label_head': 1, 'label_tail': 0}],
-                      'offset': 0.0,
-                      'variable_type': 'SPIN',
-                      'version': {'dimod': dimod.__version__, 'bqm_schema': '1.0.0'},
-                      'variable_labels': [0, 2, 1],
-                      'info': {}}
-            >>> bqm = dimod.BinaryQuadraticModel.from_dict(dct)
-
-        See also:
-            :meth:`~.BinaryQuadraticModel.to_dict`
-
-        """
-        from dimod.io.json import bqm_decode_hook
-
-        bqm = bqm_decode_hook(dct, cls=cls)
-
-        if not isinstance(bqm, cls):
-            raise ValueError("Given dct is not a serialized {}".format(cls))
-
-        return bqm
-
     def to_json(self, fp=None):
         """Serialize the binary quadratic model using JSON.
 

--- a/dimod/io/bqm_json_schema.json
+++ b/dimod/io/bqm_json_schema.json
@@ -2,7 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "binary quadratic model schema",
   "type": "object",
-  "required":["linear_terms", "info", "offset", "quadratic_terms", "variable_labels", "variable_type", "version"],
+  "required": ["linear_terms",
+               "info",
+               "offset",
+               "quadratic_terms",
+               "variable_labels",
+               "variable_type",
+               "version"],
   "properties": {
     "info": {
       "type": "object"

--- a/dimod/io/json.py
+++ b/dimod/io/json.py
@@ -35,18 +35,21 @@ with open(resource_filename(__name__, 'bqm_json_schema.json'), 'r') as schema_fi
 
 
 def _decode_label(label):
+    """Convert a list label into a tuple. Works recursively on nested lists."""
     if isinstance(label, list):
         return tuple(_decode_label(v) for v in label)
     return label
 
 
 def _encode_label(label):
+    """Convert a tuple label into a list. Works recursively on nested tuples."""
     if isinstance(label, tuple):
         return [_encode_label(v) for v in label]
     return label
 
 
 def bqm_decode_hook(dct, cls=None):
+    """Decode hook as can be used with json.loads."""
 
     if cls is None:
         cls = BinaryQuadraticModel

--- a/dimod/io/json.py
+++ b/dimod/io/json.py
@@ -46,7 +46,10 @@ def _encode_label(label):
     return label
 
 
-def bqm_decode_hook(dct):
+def bqm_decode_hook(dct, cls=None):
+
+    if cls is None:
+        cls = BinaryQuadraticModel
 
     if jsonschema.Draft4Validator(bqm_json_schema).is_valid(dct):
         # BinaryQuadraticModel
@@ -57,7 +60,7 @@ def bqm_decode_hook(dct):
         offset = dct['offset']
         vartype = Vartype[dct['variable_type']]
 
-        return BinaryQuadraticModel(linear, quadratic, offset, vartype, **dct['info'])
+        return cls(linear, quadratic, offset, vartype, **dct['info'])
 
     return dct
 

--- a/dimod/io/json.py
+++ b/dimod/io/json.py
@@ -40,6 +40,12 @@ def _decode_label(label):
     return label
 
 
+def _encode_label(label):
+    if isinstance(label, tuple):
+        return [_encode_label(v) for v in label]
+    return label
+
+
 def bqm_decode_hook(dct):
 
     if jsonschema.Draft4Validator(bqm_json_schema).is_valid(dct):
@@ -155,9 +161,9 @@ class _JSONQuadraticBiasStream(list):
     def __iter__(self):
         for (u, v), bias in iteritems(self.quadratic):
             if isinstance(u, tuple):
-                u = json.loads(json.dumps(u))  # handles nested tuples
+                u = _encode_label(u)  # handles nested tuples
             if isinstance(v, tuple):
-                v = json.loads(json.dumps(v))  # handles nested tuples
+                v = _encode_label(v)  # handles nested tuples
             yield {"bias": bias, "label_head": u, "label_tail": v}
 
     def __len__(self):
@@ -179,7 +185,7 @@ class _JSONLabelsStream(list):
     def __iter__(self):
         for u in self.linear:
             if isinstance(u, tuple):
-                u = json.loads(json.dumps(u))  # handles nested tuples
+                u = _encode_label(u)  # handles nested tuples
             yield u
 
     def __len__(self):

--- a/dimod/io/json.py
+++ b/dimod/io/json.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 import json
 from pkg_resources import resource_filename
 
+import jsonschema
+
 from six import iteritems
 
 from dimod.binary_quadratic_model import BinaryQuadraticModel
@@ -32,36 +34,35 @@ with open(resource_filename(__name__, 'bqm_json_schema.json'), 'r') as schema_fi
     bqm_json_schema = json.load(schema_file)
 
 
-def bqm_decode_hook(dct):
-    if 'bias' in dct:
-        bias = dct['bias']
-        if 'label' in dct:
-            u = dct['label']
-            if isinstance(u, list):
-                u = tuple(u)
-            return (u, bias)
-        else:
-            u = dct['label_head']
-            v = dct['label_tail']
-            if isinstance(u, list):
-                u = tuple(u)
-            if isinstance(v, list):
-                v = tuple(v)
-            return ((u, v), bias)
+def _decode_label(label):
+    if isinstance(label, list):
+        return tuple(_decode_label(v) for v in label)
+    return label
 
-    elif 'linear_terms' in dct and 'quadratic_terms' in dct:
-        return BinaryQuadraticModel(dict(dct['linear_terms']),
-                                    dict(dct['quadratic_terms']),
-                                    dct['offset'],
-                                    Vartype[dct['variable_type']],
-                                    **dct['info'])
+
+def bqm_decode_hook(dct):
+
+    if jsonschema.Draft4Validator(bqm_json_schema).is_valid(dct):
+        # BinaryQuadraticModel
+
+        linear = {_decode_label(obj['label']): obj['bias'] for obj in dct['linear_terms']}
+        quadratic = {(_decode_label(obj['label_head']), _decode_label(obj['label_tail'])): obj['bias']
+                     for obj in dct['quadratic_terms']}
+        offset = dct['offset']
+        vartype = Vartype[dct['variable_type']]
+
+        return BinaryQuadraticModel(linear, quadratic, offset, vartype, **dct['info'])
 
     return dct
 
 
-class DimodEncoder(json.JSONEncoder):
-    """Subclass the JSONEncoder for dimod objects."""
+class DimodStreamEncoder(json.JSONEncoder):
+    """Subclass the JSONEncoder for dimod objects.
+
+    By using the stream objects, we don't need to create the entire serializable object in memory
+    """
     def default(self, obj):
+
         if isinstance(obj, BinaryQuadraticModel):
 
             if obj.vartype is Vartype.SPIN:
@@ -71,21 +72,51 @@ class DimodEncoder(json.JSONEncoder):
             else:
                 raise RuntimeError("unknown vartype")
 
-            # by using the stream objects, we don't need to create the entire json_dict in memory
-            json_dict = {"linear_terms": _JSONLinearBiasStream.from_dict(obj.linear),
-                         "quadratic_terms": _JSONQuadraticBiasStream.from_dict(obj.quadratic),
+            json_dict = {"linear_terms": self._linear_biases(obj.linear),
+                         "quadratic_terms": self._quadratic_biases(obj.quadratic),
                          "offset": obj.offset,
                          "variable_type": vartype_string,
                          "version": {"dimod": __version__, "bqm_schema": bqm_json_schema_version},
-                         "variable_labels": _JSONLabelsStream.from_dict(obj.linear),
+                         "variable_labels": self._variable_labels(obj.linear),
                          "info": obj.info}
             return json_dict
 
-        if isinstance(obj, Response):
+        elif isinstance(obj, Response):
             # we will eventually want to implement this
             raise NotImplementedError
 
         return json.JSONEncoder.default(self, obj)
+
+    @staticmethod
+    def _linear_biases(linear):
+        return _JSONLinearBiasStream.from_dict(linear)
+
+    @staticmethod
+    def _quadratic_biases(quadratic):
+        return _JSONQuadraticBiasStream.from_dict(quadratic)
+
+    @staticmethod
+    def _variable_labels(linear):
+        return _JSONLabelsStream.from_dict(linear)
+
+
+class DimodEncoder(DimodStreamEncoder):
+    """Subclass the JSONEncoder for dimod objects.
+
+    In this case we dump the steam contents into arrays so that intermediate representations function
+    correctly.
+    """
+    @staticmethod
+    def _linear_biases(linear):
+        return list(_JSONLinearBiasStream.from_dict(linear))
+
+    @staticmethod
+    def _quadratic_biases(quadratic):
+        return list(_JSONQuadraticBiasStream.from_dict(quadratic))
+
+    @staticmethod
+    def _variable_labels(linear):
+        return list(_JSONLabelsStream.from_dict(linear))
 
 
 class _JSONLinearBiasStream(list):
@@ -100,10 +131,15 @@ class _JSONLinearBiasStream(list):
 
     def __iter__(self):
         for v, bias in iteritems(self.linear):
+            if isinstance(v, tuple):
+                v = json.loads(json.dumps(v))  # handles nested tuples
             yield {"bias": bias, "label": v}
 
     def __len__(self):
         return len(self.linear)
+
+    def __bool__(self):
+        return bool(self.linear)
 
 
 class _JSONQuadraticBiasStream(list):
@@ -118,10 +154,17 @@ class _JSONQuadraticBiasStream(list):
 
     def __iter__(self):
         for (u, v), bias in iteritems(self.quadratic):
+            if isinstance(u, tuple):
+                u = json.loads(json.dumps(u))  # handles nested tuples
+            if isinstance(v, tuple):
+                v = json.loads(json.dumps(v))  # handles nested tuples
             yield {"bias": bias, "label_head": u, "label_tail": v}
 
     def __len__(self):
         return len(self.quadratic)
+
+    def __bool__(self):
+        return bool(self.quadratic)
 
 
 class _JSONLabelsStream(list):
@@ -135,7 +178,12 @@ class _JSONLabelsStream(list):
 
     def __iter__(self):
         for u in self.linear:
+            if isinstance(u, tuple):
+                u = json.loads(json.dumps(u))  # handles nested tuples
             yield u
 
     def __len__(self):
         return len(self.linear)
+
+    def __bool__(self):
+        return bool(self.linear)

--- a/docs/reference/binary_quadratic_model.rst
+++ b/docs/reference/binary_quadratic_model.rst
@@ -94,6 +94,7 @@ Converting to other types
    :toctree: generated/
 
    BinaryQuadraticModel.from_coo
+   BinaryQuadraticModel.from_dict
    BinaryQuadraticModel.from_ising
    BinaryQuadraticModel.from_json
    BinaryQuadraticModel.from_numpy_matrix
@@ -101,6 +102,7 @@ Converting to other types
    BinaryQuadraticModel.from_qubo
    BinaryQuadraticModel.from_pandas_dataframe
    BinaryQuadraticModel.to_coo
+   BinaryQuadraticModel.to_dict
    BinaryQuadraticModel.to_ising
    BinaryQuadraticModel.to_json
    BinaryQuadraticModel.to_networkx_graph

--- a/docs/reference/binary_quadratic_model.rst
+++ b/docs/reference/binary_quadratic_model.rst
@@ -94,7 +94,6 @@ Converting to other types
    :toctree: generated/
 
    BinaryQuadraticModel.from_coo
-   BinaryQuadraticModel.from_dict
    BinaryQuadraticModel.from_ising
    BinaryQuadraticModel.from_json
    BinaryQuadraticModel.from_numpy_matrix
@@ -102,7 +101,6 @@ Converting to other types
    BinaryQuadraticModel.from_qubo
    BinaryQuadraticModel.from_pandas_dataframe
    BinaryQuadraticModel.to_coo
-   BinaryQuadraticModel.to_dict
    BinaryQuadraticModel.to_ising
    BinaryQuadraticModel.to_json
    BinaryQuadraticModel.to_networkx_graph

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1875,3 +1875,36 @@ class TestConvert(unittest.TestCase):
         self.assertIn('tag', new_bqm.info)
         self.assertEqual(new_bqm.info['tag'], 5)
         self.assertIn(('a', "complex key"), new_bqm.linear)
+
+    def test_from_dict_docstring(self):
+        bqm0 = dimod.BinaryQuadraticModel.from_ising({0: 1, 2: .1}, {(0, 1): -1})
+        dct = {'linear_terms': [{'bias': 1, 'label': 0},
+               {'bias': 0.1, 'label': 2},
+               {'bias': 0.0, 'label': 1}],
+               'quadratic_terms': [{'bias': -1, 'label_head': 1, 'label_tail': 0}],
+               'offset': 0.0,
+               'variable_type': 'SPIN',
+               'version': {'dimod': dimod.__version__, 'bqm_schema': '1.0.0'},
+               'variable_labels': [0, 2, 1],
+               'info': {}}
+        bqm = dimod.BinaryQuadraticModel.from_dict(dct)
+
+        self.assertEqual(bqm, bqm0)
+
+    def test_functional_to_and_from_dict_empty(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        new_bqm = dimod.BinaryQuadraticModel.from_dict(bqm.to_dict())
+        self.assertEqual(bqm, new_bqm)
+
+    def test_functional_to_and_from_dict_with_info(self):
+        linear = {'a': -1, 4: 1, ('a', "complex key"): 3}
+        quadratic = {('a', 'c'): 1.2, ('b', 'c'): .3, ('a', 3): -1}
+        bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN, tag=5)
+
+        new_bqm = dimod.BinaryQuadraticModel.from_dict(bqm.to_dict())
+
+        self.assertEqual(bqm, new_bqm)
+        self.assertIn('tag', new_bqm.info)
+        self.assertEqual(new_bqm.info['tag'], 5)
+        self.assertIn(('a', "complex key"), new_bqm.linear)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1875,36 +1875,3 @@ class TestConvert(unittest.TestCase):
         self.assertIn('tag', new_bqm.info)
         self.assertEqual(new_bqm.info['tag'], 5)
         self.assertIn(('a', "complex key"), new_bqm.linear)
-
-    def test_from_dict_docstring(self):
-        bqm0 = dimod.BinaryQuadraticModel.from_ising({0: 1, 2: .1}, {(0, 1): -1})
-        dct = {'linear_terms': [{'bias': 1, 'label': 0},
-               {'bias': 0.1, 'label': 2},
-               {'bias': 0.0, 'label': 1}],
-               'quadratic_terms': [{'bias': -1, 'label_head': 1, 'label_tail': 0}],
-               'offset': 0.0,
-               'variable_type': 'SPIN',
-               'version': {'dimod': dimod.__version__, 'bqm_schema': '1.0.0'},
-               'variable_labels': [0, 2, 1],
-               'info': {}}
-        bqm = dimod.BinaryQuadraticModel.from_dict(dct)
-
-        self.assertEqual(bqm, bqm0)
-
-    def test_functional_to_and_from_dict_empty(self):
-        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
-
-        new_bqm = dimod.BinaryQuadraticModel.from_dict(bqm.to_dict())
-        self.assertEqual(bqm, new_bqm)
-
-    def test_functional_to_and_from_dict_with_info(self):
-        linear = {'a': -1, 4: 1, ('a', "complex key"): 3}
-        quadratic = {('a', 'c'): 1.2, ('b', 'c'): .3, ('a', 3): -1}
-        bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN, tag=5)
-
-        new_bqm = dimod.BinaryQuadraticModel.from_dict(bqm.to_dict())
-
-        self.assertEqual(bqm, new_bqm)
-        self.assertIn('tag', new_bqm.info)
-        self.assertEqual(new_bqm.info['tag'], 5)
-        self.assertIn(('a', "complex key"), new_bqm.linear)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1825,7 +1825,7 @@ class TestConvert(unittest.TestCase):
         filename = path.join(tmpdir, 'test.txt')
 
         with open(filename, 'w') as file:
-            bqm.to_json(fp=file)
+            file.write(bqm.to_json())
 
         with open(filename, 'r') as file:
             jsonschema.validate(json.load(file), bqm_json_schema)
@@ -1841,7 +1841,7 @@ class TestConvert(unittest.TestCase):
         filename = path.join(tmpdir, 'test.txt')
 
         with open(filename, 'w') as file:
-            bqm.to_json(fp=file)
+            file.write(bqm.to_json())
 
         with open(filename, 'r') as file:
             jsonschema.validate(json.load(file), bqm_json_schema)

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -1,0 +1,41 @@
+import unittest
+import json
+
+import jsonschema
+
+import dimod
+import dimod.io.json as dson
+
+
+class TestDimodEncoder(unittest.TestCase):
+    def test_empty_bqm(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        dct = dson.DimodEncoder().default(bqm)
+
+        self.assertEqual(dct,
+                         {'linear_terms': [],
+                          'quadratic_terms': [],
+                          'offset': 0.0,
+                          'variable_type': 'SPIN',
+                          'version': {'dimod': dimod.__version__, 'bqm_schema': '1.0.0'},
+                          'variable_labels': [], 'info': {}})
+
+        jsonschema.validate(dct, dson.bqm_json_schema)
+
+    def test_bqm_labels(self):
+        bqm = dimod.BinaryQuadraticModel.from_ising({'a': -1, 0: 1, (0,): -1, ((0,),): 1.5},
+                                                    {('a', 0): -1, ('a', (0,)): 1, (0, (0,)): .5})
+
+        dct = dson.DimodEncoder().default(bqm)
+
+        jsonschema.validate(dct, dson.bqm_json_schema)
+
+    def test_bqm_complex(self):
+        linear = {'a': -1, 4: 1, ('a', "complex key"): 3}
+        quadratic = {('a', 'c'): 1.2, ('b', 'c'): .3, ('a', 3): -1}
+        bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
+
+        dct = dson.DimodEncoder().default(bqm)
+
+        jsonschema.validate(dct, dson.bqm_json_schema)

--- a/tests/test_io_json.py
+++ b/tests/test_io_json.py
@@ -1,3 +1,19 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+
 import unittest
 import json
 


### PR DESCRIPTION
**This is a backwards compatibility break**

Simplifies the `BinaryQuadraticModel.to_json` method to always return a string. We also remove a lot of boilerplate used to encode bqms with low memory footprint. That case will be covered by #235 .

We will also close #218 as redundant. In order to prevent having too many serialization methods, we don't include `to_dict`/`from_dict`.