### PR TITLE
Add BQM.variables property

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -51,7 +51,7 @@ from numbers import Number
 
 import numpy as np
 
-from six import itervalues, iteritems, iterkeys
+from six import itervalues, iteritems, iterkeys, viewkeys
 
 from dimod.decorators import vartype_argument
 from dimod.response import SampleView
@@ -262,6 +262,11 @@ class BinaryQuadraticModel(Sized, Container, Iterable):
 
     def __iter__(self):
         return self.adj.__iter__()
+
+    @property
+    def variables(self):
+        """Returns BQM's variables as a dictionary view object."""
+        return viewkeys(self.linear)
 
 ##################################################################################################
 # vartype properties

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -226,6 +226,18 @@ class TestBinaryQuadraticModel(unittest.TestCase):
 
         self.assertEqual(set(bqm), {'a', 'b'})
 
+    def test_variables(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.BINARY)
+
+        self.assertEqual(set(bqm.variables), set())
+
+        bqm.add_interaction('a', 'b', -1)
+
+        self.assertEqual(set(bqm.variables), {'a', 'b'})
+        self.assertIn('a', bqm.variables)
+        self.assertEqual(bqm.variables & {'b'}, {'b'})
+        self.assertEqual(bqm.variables | {'c'}, {'a', 'b', 'c'})
+
     def test_add_variable(self):
         bqm = dimod.BinaryQuadraticModel({}, {('a', 'b'): -1}, 0.0, dimod.SPIN)
         bqm.add_variable('a', .5)


### PR DESCRIPTION
BQM already acts as an iterable container, but `variables` property is more explicit and it supports efficient set operations.