### PR TITLE
Replace Response.from_dicts by Response.from_samples in docstring

### DIFF
--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -34,7 +34,7 @@ to create a dimod sampler with the :class:`.Sampler` class.
         def sample_ising(self, h, J):
             sample = linear_ising(h, J)
             energy = dimod.ising_energy(sample, h, J)
-            return dimod.Response.from_dicts([sample], {'energy': [energy]})
+            return dimod.Response.from_samples([sample], {'energy': [energy]})
 
         @property
         def properties(self):
@@ -84,7 +84,7 @@ Below is a more complex version of the same sampler, where the :attr:`properties
             energy = dimod.ising_energy(sample, h, J)
             if verbose:
                 print(sample)
-            return dimod.Response.from_dicts([sample], {'energy': [energy]})
+            return dimod.Response.from_samples([sample], {'energy': [energy]})
 
         @property
         def properties(self):
@@ -137,7 +137,7 @@ class Sampler:
                         energy = dimod.ising_energy(sample, h, J)
                         if verbose:
                             print(sample)
-                        return dimod.Response.from_dicts([sample], {'energy': [energy]})
+                        return dimod.Response.from_samples([sample], {'energy': [energy]})
 
                     @property
                     def properties(self):
@@ -166,7 +166,7 @@ class Sampler:
                     def sample_ising(self, h, J):
                         sample = linear_ising(h, J) # Implemented elsewhere
                         energy = dimod.ising_energy(sample, h, J)
-                        return dimod.Response.from_dicts([sample], {'energy': [energy]})
+                        return dimod.Response.from_samples([sample], {'energy': [energy]})
 
                     @property
                     def properties(self):

--- a/dimod/core/structured.py
+++ b/dimod/core/structured.py
@@ -58,7 +58,7 @@ Examples:
                     samples.append(sample)
                     energies.append(bqm.energy(sample))
 
-                response = dimod.Response.from_dicts(samples, {'energy': energies}, vartype=bqm.vartype)
+                response = dimod.Response.from_samples(samples, {'energy': energies}, vartype=bqm.vartype)
 
                 return response
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -103,7 +103,7 @@ the :meth:`sample_ising` method).
         def sample_ising(self, h, J):
             sample = linear_ising(h, J)  # Defined elsewhere
             energy = dimod.ising_energy(sample, h, J)
-            return dimod.Response.from_dicts([sample], {'energy': [energy]})
+            return dimod.Response.from_samples([sample], {'energy': [energy]})
 
         @property
         def properties(self):


### PR DESCRIPTION
In some examples of docstring, deprecated method `Response.from_dicts` is used.
This pull request replaces `Response.from_dicts` by `Response.from_samples`.