### PR TITLE
Fix illegal argument of change_vartype in Sampler.sample

### DIFF
--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -186,12 +186,12 @@ class Sampler:
         if bqm.vartype is Vartype.SPIN:
             Q, offset = bqm.to_qubo()
             response = self.sample_qubo(Q, **parameters)
-            response.change_vartype(Vartype.SPIN, data_vector_offsets={'energy': offset})
+            response.change_vartype(Vartype.SPIN, energy_offset=offset)
             return response
         elif bqm.vartype is Vartype.BINARY:
             h, J, offset = bqm.to_ising()
             response = self.sample_ising(h, J, **parameters)
-            response.change_vartype(Vartype.BINARY, data_vector_offsets={'energy': offset})
+            response.change_vartype(Vartype.BINARY, energy_offset=offset)
             return response
         else:
             raise RuntimeError("binary quadratic model has an unknown vartype")

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -16,6 +16,8 @@
 
 import unittest
 
+import numpy as np
+
 import dimod
 
 
@@ -202,3 +204,41 @@ class TestSamplerClass(unittest.TestCase):
                         "sampler must have a 'properties' property")
         self.assertFalse(callable(sampler.properties),
                          "sampler must have a 'properties' property")
+
+    def test_instantiation_overwrite_sample_ising_and_call_sample(self):
+        class Dummy(dimod.Sampler):
+            def sample_ising(self, h, J):
+                return dimod.Response.from_samples([[-1, 1]], {"energy": [0.05]}, {}, dimod.SPIN)
+
+            @property
+            def parameters(self):
+                return {}
+
+            @property
+            def properties(self):
+                return {}
+
+        sampler = Dummy()
+        bqm = dimod.BinaryQuadraticModel({0: 0.1, 1: -0.3}, {(0, 1): -1}, 0.0, dimod.BINARY)
+        resp = sampler.sample(bqm)
+        expected_resp = dimod.Response.from_samples([[0, 1]], {"energy": [-0.3]}, {}, dimod.BINARY)
+        np.testing.assert_almost_equal(resp.record, expected_resp.record)
+
+    def test_instantiation_overwrite_sample_qubo_and_call_sample(self):
+        class Dummy(dimod.Sampler):
+            def sample_qubo(self, Q):
+                return dimod.Response.from_samples([[0, 1]], {"energy": [1.4]}, {}, dimod.BINARY)
+
+            @property
+            def parameters(self):
+                return {}
+
+            @property
+            def properties(self):
+                return {}
+
+        sampler = Dummy()
+        bqm = dimod.BinaryQuadraticModel({0: 0.1, 1: -0.3}, {(0, 1): -1}, 0.1, dimod.SPIN)
+        resp = sampler.sample(bqm)
+        expected_resp = dimod.Response.from_samples([[-1, 1]], {"energy": [0.7]}, {}, dimod.SPIN)
+        np.testing.assert_almost_equal(resp.record, expected_resp.record)

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -222,7 +222,8 @@ class TestSamplerClass(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel({0: 0.1, 1: -0.3}, {(0, 1): -1}, 0.0, dimod.BINARY)
         resp = sampler.sample(bqm)
         expected_resp = dimod.Response.from_samples([[0, 1]], {"energy": [-0.3]}, {}, dimod.BINARY)
-        np.testing.assert_almost_equal(resp.record, expected_resp.record)
+        np.testing.assert_almost_equal(resp.record.sample, expected_resp.record.sample)
+        np.testing.assert_almost_equal(resp.record.energy, expected_resp.record.energy)
 
     def test_instantiation_overwrite_sample_qubo_and_call_sample(self):
         class Dummy(dimod.Sampler):
@@ -241,4 +242,5 @@ class TestSamplerClass(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel({0: 0.1, 1: -0.3}, {(0, 1): -1}, 0.1, dimod.SPIN)
         resp = sampler.sample(bqm)
         expected_resp = dimod.Response.from_samples([[-1, 1]], {"energy": [0.7]}, {}, dimod.SPIN)
-        np.testing.assert_almost_equal(resp.record, expected_resp.record)
+        np.testing.assert_almost_equal(resp.record.sample, expected_resp.record.sample)
+        np.testing.assert_almost_equal(resp.record.energy, expected_resp.record.energy)


### PR DESCRIPTION
**Issue**
* The illegal argument: `data_vector_offsets` of `change_vartype` is used in `Sampler.sample`
* There is no test to call `Sampler.sample` from `Sampler.sample_qubo` or `Sampler.sample_ising`

**Fix**
* Replaced  `data_vector_offsets` with `energy_offset` which is correct argument of `change_vartype`
* Added tests to call `Sampler.sample`