### PR TITLE
Force energy dtype to float in the Response

### DIFF
--- a/dimod/response.py
+++ b/dimod/response.py
@@ -765,7 +765,8 @@ def data_struct_array(sample, **vectors):  # data_struct_array(sample, *, energy
     datatypes = [('sample', np.dtype(np.int8), (num_variables,))]
 
     for kwarg, vector in vectors.items():
-        datavectors[kwarg] = vector = np.asarray(vector)
+        dtype = float if kwarg == 'energy' else None
+        datavectors[kwarg] = vector = np.asarray(vector, dtype)
 
         if len(vector.shape) < 1 or vector.shape[0] != num_samples:
             msg = ('{} and sample have a mismatched shape {}, {}. They must have the same size '

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -244,3 +244,23 @@ class TestSamplerClass(unittest.TestCase):
         expected_resp = dimod.Response.from_samples([[-1, 1]], {"energy": [0.7]}, {}, dimod.SPIN)
         np.testing.assert_almost_equal(resp.record.sample, expected_resp.record.sample)
         np.testing.assert_almost_equal(resp.record.energy, expected_resp.record.energy)
+
+    def test_sampler_can_return_integer_energy_values(self):
+        class Dummy(dimod.Sampler):
+            def sample_qubo(self, Q):
+                return dimod.Response.from_samples([[1]], {"energy": [-3]}, {}, dimod.BINARY)
+
+            @property
+            def parameters(self):
+                return {}
+
+            @property
+            def properties(self):
+                return {}
+
+        sampler = Dummy()
+        bqm = dimod.BinaryQuadraticModel({0: -3}, {}, 0, dimod.BINARY)
+        resp = sampler.sample(bqm)
+        expected_resp = dimod.Response.from_samples([[1]], {"energy": [-3]}, {}, dimod.BINARY)
+        np.testing.assert_almost_equal(resp.record.sample, expected_resp.record.sample)
+        np.testing.assert_almost_equal(resp.record.energy, expected_resp.record.energy)


### PR DESCRIPTION
This is to keep results correct if Sampler returns integer values and qubo-ising conversion occurs.