### PR TITLE
Fix vartype test

### DIFF
--- a/dimod/io/coo.py
+++ b/dimod/io/coo.py
@@ -15,7 +15,7 @@
 # ================================================================================================
 
 import re
-
+from dimod import Vartype
 from dimod.binary_quadratic_model import BinaryQuadraticModel
 
 _LINE_REGEX = r'^\s*(\d+)\s+(\d+)\s+([+-]?(?:[0-9]*[.]):?[0-9]+)\s*$'
@@ -65,8 +65,13 @@ def load(fp, cls=BinaryQuadraticModel, vartype=None):
         if vt:
             if vartype is None:
                 vartype = vt[0]
-            elif vt[0] not in vartype:
-                raise ValueError("vartypes from headers and/or inputs do not match")
+            else:
+                if isinstance(vartype, str):
+                    vartype = Vartype[vartype]
+                else:
+                    vartype = Vartype(vartype)
+                if Vartype[vt[0]] != vartype:
+                    raise ValueError("vartypes from headers and/or inputs do not match")
 
     if vartype is None:
         raise ValueError("vartype must be provided either as a header or as an argument")

--- a/dimod/io/coo.py
+++ b/dimod/io/coo.py
@@ -65,7 +65,7 @@ def load(fp, cls=BinaryQuadraticModel, vartype=None):
         if vt:
             if vartype is None:
                 vartype = vt[0]
-            elif vartype is not vt[0]:
+            elif vt[0] not in vartype:
                 raise ValueError("vartypes from headers and/or inputs do not match")
 
     if vartype is None:


### PR DESCRIPTION
@arcondello I don't think "vartype is not vt[0]" works because the two are never the same object. I think you meant "vartype != vt[0]". That works for 

```with open('test.qubo', 'r') as file:
    ...:     bqm = dimod.BinaryQuadraticModel.from_coo(file, 'BINARY') ```
but not for 
```with open('test.qubo', 'r') as file:
    ...:     bqm = dimod.BinaryQuadraticModel.from_coo(file, dimod.BINARY)```

A long-term fix is to see if they are the same vartype in case someone uses "# vartype=dimod.BINARY" in the file itself. But this at least lets me read files like the HADES problem files that have headers:

```# vartype: BINARY

0 4 -1.000000
0 5 -1.000000
0 6 0.000000```

Now these give me " vartypes from headers and/or inputs do not match" erros
