### PR TITLE
Allow c++ extension build to fail gracefully.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,8 +167,6 @@ jobs:
     steps:
       - checkout
 
-      - run: *install-boost-linux-template
-
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}

--- a/dimod/__init__.py
+++ b/dimod/__init__.py
@@ -23,9 +23,13 @@ from dimod.reference import *
 import dimod.reference
 
 try:
-    from dimod.roof_duality import *
+    import dimod.roof_duality._fix_variables as _
 except ImportError:
     pass
+else:
+    # we only import fix_variables function into the top level namespace if the c++ extension
+    # is built
+    from dimod.roof_duality import *
 
 import dimod.testing
 

--- a/dimod/__init__.py
+++ b/dimod/__init__.py
@@ -22,7 +22,10 @@ import dimod.core
 from dimod.reference import *
 import dimod.reference
 
-from dimod.roof_duality import *
+try:
+    from dimod.roof_duality import *
+except ImportError:
+    pass
 
 import dimod.testing
 

--- a/dimod/roof_duality/fix_variables.py
+++ b/dimod/roof_duality/fix_variables.py
@@ -15,11 +15,6 @@
 # ================================================================================================
 from dimod.vartypes import Vartype
 
-try:
-    from dimod.roof_duality._fix_variables import fix_variables_wrapper
-except ImportError:
-    raise ImportError("c++ extension roof_duality is not built")
-
 
 def fix_variables(bqm, sampling_mode=True):
     """Determine assignments for some binary quadratic model variables.
@@ -45,13 +40,13 @@ def fix_variables(bqm, sampling_mode=True):
         >>> bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
         >>> bqm.add_variable('a', 1.0)
         >>> dimod.fix_variables(bqm)
-        {'a': -1}
+        {'a': -1} # doctest: +SKIP
 
         In this example, there are two ground states, so no variables fixed.
 
         >>> bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
         >>> bqm.add_interaction('a', 'b', -1.0)
-        >>> dimod.fix_variables(bqm)
+        >>> dimod.fix_variables(bqm) # doctest: +SKIP
         {}
 
         In this example with sampling_model off, additional variables are fixed.
@@ -68,6 +63,10 @@ def fix_variables(bqm, sampling_mode=True):
         (2002), pp. 155-225
 
     """
+    try:
+        from dimod.roof_duality._fix_variables import fix_variables_wrapper
+    except ImportError:
+        raise ImportError("c++ extension roof_duality is not built")
 
     if sampling_mode:
         method = 2  # roof-duality only

--- a/dimod/roof_duality/fix_variables.py
+++ b/dimod/roof_duality/fix_variables.py
@@ -13,8 +13,12 @@
 #    limitations under the License.
 #
 # ================================================================================================
-from dimod.roof_duality._fix_variables import fix_variables_wrapper
 from dimod.vartypes import Vartype
+
+try:
+    from dimod.roof_duality._fix_variables import fix_variables_wrapper
+except ImportError:
+    raise ImportError("c++ extension roof_duality is not built")
 
 
 def fix_variables(bqm, sampling_mode=True):
@@ -64,6 +68,7 @@ def fix_variables(bqm, sampling_mode=True):
         (2002), pp. 155-225
 
     """
+
     if sampling_mode:
         method = 2  # roof-duality only
     else:

--- a/docs/reference/bqm_functions.rst
+++ b/docs/reference/bqm_functions.rst
@@ -29,6 +29,8 @@ Higher-order Polynomials
 Roof-duality
 ============
 
+.. currentmodule:: dimod.roof_duality
+
 .. autosummary::
    :toctree: generated/
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ import os
 
 from setuptools import setup
 from distutils.extension import Extension
+from distutils.command.build_ext import build_ext
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
 # add __version__, __author__, __authoremail__, __description__ to this namespace
 _PY2 = sys.version_info.major == 2
@@ -84,22 +86,93 @@ if USE_CYTHON:
     from Cython.Build import cythonize
     extensions = cythonize(extensions)
 
-setup(
-    name='dimod',
-    version=__version__,
-    author=__author__,
-    author_email=__authoremail__,
-    description=__description__,
-    long_description=open('README.rst').read(),
-    url='https://github.com/dwavesystems/dimod',
-    download_url='https://github.com/dwavesystems/dimod/releases',
-    license='Apache 2.0',
-    ext_modules=extensions,
-    packages=packages,
-    install_requires=install_requires,
-    extras_require=extras_require,
-    include_package_data=True,
-    classifiers=classifiers,
-    zip_safe=False,
-    python_requires=python_requires
-)
+###############################################################################
+# The following code to fail gracefully when when c++ extensions cannot be
+# built is adapted from the simplejson library under the MIT License
+#
+# MIT License
+# ===========
+#
+# Copyright (c) 2006 Bob Ippolito
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+if sys.platform == 'win32' and sys.version_info < (2, 7):
+    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
+    # find the compiler
+    # It can also raise ValueError https://bugs.python.org/issue7511
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
+                  IOError, ValueError)
+else:
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+
+
+class BuildFailed(Exception):
+    pass
+
+
+class ve_build_ext(build_ext):
+    # This class allows C extension building to fail.
+
+    def run(self):
+        try:
+            build_ext.run(self)
+        except DistutilsPlatformError:
+            raise BuildFailed()
+
+    def build_extension(self, ext):
+        try:
+            build_ext.build_extension(self, ext)
+        except ext_errors:
+            raise BuildFailed()
+
+
+def run_setup(cpp):
+    if cpp:
+        kw = dict(cmdclass=dict(build_ext=ve_build_ext), ext_modules=extensions)
+    else:
+        kw = {}
+
+    setup(
+        name='dimod',
+        version=__version__,
+        author=__author__,
+        author_email=__authoremail__,
+        description=__description__,
+        long_description=open('README.rst').read(),
+        url='https://github.com/dwavesystems/dimod',
+        download_url='https://github.com/dwavesystems/dimod/releases',
+        license='Apache 2.0',
+        packages=packages,
+        install_requires=install_requires,
+        extras_require=extras_require,
+        include_package_data=True,
+        classifiers=classifiers,
+        zip_safe=False,
+        python_requires=python_requires,
+        **kw
+    )
+
+
+try:
+    run_setup(cpp=True)
+except BuildFailed:
+    print("building c++ extensions failed, trying to build without")
+    run_setup(cpp=False)

--- a/setup.py
+++ b/setup.py
@@ -114,15 +114,6 @@ if USE_CYTHON:
 # SOFTWARE.
 #
 
-if sys.platform == 'win32' and sys.version_info < (2, 7):
-    # 2.6's distutils.msvc9compiler can raise an IOError when failing to
-    # find the compiler
-    # It can also raise ValueError https://bugs.python.org/issue7511
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError,
-                  IOError, ValueError)
-else:
-    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
-
 
 class BuildFailed(Exception):
     pass
@@ -140,7 +131,7 @@ class ve_build_ext(build_ext):
     def build_extension(self, ext):
         try:
             build_ext.build_extension(self, ext)
-        except ext_errors:
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError):
             raise BuildFailed()
 
 


### PR DESCRIPTION
If for some reason the `python setup.py build_ext` command fails (either no available compiler or boost is not installed), the roof_duality extension is ignored.

Related to #281 