### PR TITLE
WIP: Don't force reinstall twine in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ artifacts:
   - path: dist\*.whl
 
 before_deploy:
-  - "%PYTHON%\\python.exe -m pip install twine --upgrade --force-reinstall"
+  - "%PYTHON%\\python.exe -m pip install twine"
 
   # set up the pypi credentials
   - "echo [pypi] > %USERPROFILE%\\.pypirc"


### PR DESCRIPTION
This should attempt to deploy and fail for lack of credentials. But it still should discover twine without it being present in scripts.