### PR TITLE
Cythonize BQM.energies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,9 @@ cache:
   - '%PYTHON%\Lib\site-packages -> requirements.txt'
   - '%AppData%\pip-cache'
 
-  # cache the .pyd file
+  # cache the .pyd files
   - dimod\roof_duality\ -> dimod\roof_duality\_fix_variables.pyx, dimod\roof_duality\src\compressed_matrix.hpp, dimod\roof_duality\src\fix_variables.cpp, dimod\roof_duality\src\fix_variables.hpp, dimod\roof_duality\fix_variables.py, dimod\roof_duality\__init__.py
+  - dimod\cyutils\ -> dimod\cyutils\_energy.pyx
 
 install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt --cache-dir %AppData%\\pip-cache"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,15 +96,20 @@ jobs:
     steps: 
       - checkout
 
-      - run: 
-          name: install pyenv
-          command: |
-            brew install pyenv
-
       - run: &install-boost-osx-template
           name: install boost
           command: |
             brew install boost
+
+      - run: &install-openmp-osx-template
+          name: install openmp
+          command: |
+            brew install libomp
+
+      - run: &install-pyenv-osx-template
+          name: install pyenv
+          command: |
+            brew install pyenv
 
       - restore_cache:
           keys:
@@ -275,12 +280,11 @@ jobs:
     steps: 
       - checkout
 
-      - run: 
-          name: install pyenv
-          command: |
-            brew install pyenv
-
       - run: *install-boost-osx-template
+
+      - run: *install-openmp-osx-template
+
+      - run: *install-pyenv-osx-template
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ jobs:
     docker:
       - image: circleci/python:3.7-stretch
 
+    environment:
+      # openmp detects the cores of the cpu, not the number the thread has
+      # access to
+      OMP_NUM_THREADS: 2
+
     working_directory: ~/repo
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ ENV/
 
 # cython intermediate files
 dimod/roof_duality/_fix_variables.cpp
+dimod/cyutils/_energy.cpp
 
 # benchmarking stuff
 benchmarks/html/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include dimod/serialization *.json
 recursive-include dimod/roof_duality *.cpp *.pyx *.hpp
+recursive-include dimod/cyutils *.cpp *.pyx *.hpp

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,15 @@ To install from source:
     pip install -r requirements.txt
     python setup.py install
 
-Note that for an installation from source some functionality requires that your
-system have Boost C++ libraries installed. 
+C++ Extensions
+~~~~~~~~~~~~~~
+
+`dimod` includes some optional C++ extensions that improve performance and add
+functionality. To install from source with these extensions your system must:
+
+    * Have the [Boost C++ libraries](https://www.boost.org/) installed
+    * If OSX, have [OpenMP](https://openmp.llvm.org/) installed by running
+    `brew install libomp`
 
 .. installation-end-marker
 

--- a/dimod/cyutils/__init__.py
+++ b/dimod/cyutils/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+try:
+    from dimod.cyutils._energy import fast_energy
+except ImportError:
+    _CYUTILS = False
+else:
+    _CYUTILS = True

--- a/dimod/cyutils/_energy.pyx
+++ b/dimod/cyutils/_energy.pyx
@@ -1,8 +1,5 @@
 # distutils: language = c++
-# distutils: extra_compile_args=-fopenmp
-# distutils: extra_link_args=-fopenmp
 # cython: language_level = 3
-#
 # =============================================================================
 #
 # Copyright 2019 D-Wave Systems Inc.

--- a/dimod/cyutils/_energy.pyx
+++ b/dimod/cyutils/_energy.pyx
@@ -1,0 +1,101 @@
+# distutils: language = c++
+# distutils: extra_compile_args=-fopenmp
+# distutils: extra_link_args=-fopenmp
+# cython: language_level = 3
+#
+# =============================================================================
+#
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+
+cimport cython
+from cython.parallel import prange
+
+import numpy as np
+cimport numpy as np
+
+ctypedef fused samples_type:
+    np.npy_int8
+    np.npy_int16
+    np.npy_int32
+    np.npy_int64
+    np.npy_float32
+    np.npy_float64
+
+ctypedef fused bias_type:
+    np.npy_float32
+    np.npy_float64
+
+ctypedef fused index_type:
+    np.npy_int8
+    np.npy_int16
+    np.npy_int32
+    np.npy_int64
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef bias_type _energy(bias_type[:] ldata,  # linear
+                       index_type[:] irow, index_type[:] icol, bias_type[:] qdata,  # quadratic
+                       samples_type[:] sample,
+                       Py_ssize_t num_variables,
+                       Py_ssize_t num_interactions) nogil:
+    cdef bias_type energy = 0
+
+    cdef Py_ssize_t li, qi
+
+    for li in range(num_variables):
+        energy = energy + sample[li] * ldata[li]
+
+    for qi in range(num_interactions):
+        energy = energy + sample[irow[qi]] * sample[icol[qi]] * qdata[qi]
+
+    return energy
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def fast_energy(bias_type[:] ldata,  # linear
+                index_type[:] irow, index_type[:] icol, bias_type[:] qdata,  # quadratic
+                bias_type offset,
+                samples_type[:, :] samples):
+
+    cdef Py_ssize_t num_samples = samples.shape[0]
+    cdef Py_ssize_t num_variables = samples.shape[1]
+    cdef Py_ssize_t num_interactions = irow.shape[0]
+
+    if bias_type is np.npy_float32:
+        dtype = np.float32
+    elif bias_type is np.npy_float64:
+        dtype = np.float64
+    else:
+        raise RuntimeError
+
+    energies = np.empty(num_samples, dtype=dtype)
+    cdef bias_type[::1] energies_view = energies
+
+    cdef Py_ssize_t row
+
+    # we can use static schedule because each energy calculation takes
+    # approximately the same amount of time
+    for row in prange(num_samples, nogil=True, schedule='static'):
+        energies_view[row] = offset + _energy(ldata,
+                                              irow, icol, qdata,
+                                              samples[row, :],
+                                              num_variables,
+                                              num_interactions)
+
+    return energies

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,13 @@ class ve_build_ext(build_ext):
             extra_compile_args = ['/openmp']
             extra_link_args = []
         else:
-            extra_compile_args = ['-fopenmp']
-            extra_link_args = ['-fopenmp']
+            compiler_name = os.path.basename(sysconfig.get_config_var("CC"))
+            if 'clang' in compiler_name:
+                extra_compile_args = ['-Xpreprocessor -fopenmp']
+                extra_link_args = ['-lomp']
+            else:
+                extra_compile_args = ['-fopenmp']
+                extra_link_args = ['-fopenmp']
 
         for ext in self.extensions:
             ext.extra_compile_args.extend(extra_compile_args)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ import sys
 import os
 
 from setuptools import setup
+from distutils import sysconfig
 from distutils.extension import Extension
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
@@ -70,6 +71,7 @@ classifiers = [
     ]
 
 python_requires = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+
 
 try:
     from Cython.Build import cythonize
@@ -138,6 +140,20 @@ class ve_build_ext(build_ext):
             raise BuildFailed()
 
     def build_extension(self, ext):
+
+        compiler = self.compiler.compiler_type
+
+        if compiler == 'msvc':
+            extra_compile_args = ['/openmp']
+            extra_link_args = []
+        else:
+            extra_compile_args = ['-fopenmp']
+            extra_link_args = ['-fopenmp']
+
+        for ext in self.extensions:
+            ext.extra_compile_args.extend(extra_compile_args)
+            ext.extra_link_args.extend(extra_link_args)
+
         try:
             build_ext.build_extension(self, ext)
         except (CCompilerError, DistutilsExecError, DistutilsPlatformError):

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,11 @@ extras_require = {'all': ['networkx>=2.0,<3.0',
                   ':python_version == "2.7"': ['futures'],
                   ':python_version <= "3.3"': ['enum34>=1.1.6,<2.0.0']}
 
+setup_requires = ['numpy>=1.14.0,<2.0.0']
+
 packages = ['dimod',
             'dimod.core',
+            'dimod.cyutils',
             'dimod.generators',
             'dimod.reference',
             'dimod.reference.composites',
@@ -80,7 +83,10 @@ ext = '.pyx' if USE_CYTHON else '.cpp'
 extensions = [Extension("dimod.roof_duality._fix_variables",
                         ['dimod/roof_duality/_fix_variables'+ext,
                          'dimod/roof_duality/src/fix_variables.cpp'],
-                        include_dirs=['dimod/roof_duality/src/'])]
+                        include_dirs=['dimod/roof_duality/src/']),
+              Extension('dimod.cyutils._energy',
+                        ['dimod/cyutils/_energy'+ext])
+              ]
 
 if USE_CYTHON:
     from Cython.Build import cythonize
@@ -123,6 +129,9 @@ class ve_build_ext(build_ext):
     # This class allows C extension building to fail.
 
     def run(self):
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+
         try:
             build_ext.run(self)
         except DistutilsPlatformError:
@@ -154,6 +163,7 @@ def run_setup(cpp):
         packages=packages,
         install_requires=install_requires,
         extras_require=extras_require,
+        setup_requires=setup_requires,
         include_package_data=True,
         classifiers=classifiers,
         zip_safe=False,

--- a/tests/test_cyutils.py
+++ b/tests/test_cyutils.py
@@ -1,0 +1,36 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+import unittest
+
+import numpy as np
+
+import dimod
+
+
+@unittest.skipUnless(dimod.cyutils._CYUTILS, "no cpp extensions built")
+class Test_fast_energy(unittest.TestCase):
+    def test_interaction(self):
+        ldata = np.asarray([-1, 1.5], dtype=float)
+        irow = np.asarray([0], dtype=np.int)
+        icol = np.asarray([1], dtype=np.int)
+        qdata = np.asarray([-1], dtype=float)
+        offset = np.float(1.5)
+
+        samples = np.asarray([[-1, -1], [-1, 1], [1, -1], [1, 1]], dtype=np.int8)
+
+        energies = dimod.cyutils.fast_energy(ldata, irow, icol, qdata, offset, samples)
+
+        np.testing.assert_array_equal(energies, [0, 5, 0, 1])


### PR DESCRIPTION
Use cython to speed up energy calculations, falling back on numpy if the extension if not built.

Test script:
```
import timeit

import networkx as nx
import numpy as np

import dimod

num_variables = 100
num_samples = 1000

samples = np.ones((num_samples, num_variables), dtype=np.int8)

G = nx.complete_graph(num_variables)

bqm = dimod.BQM.from_ising({}, {edge: -1 for edge in G.edges})

N = 1000

contime = timeit.timeit('bqm.to_numpy_vectors()', 'from __main__ import bqm', number=N)
print('numpy conversion time', contime)

cytime = timeit.timeit('bqm.energies(samples, _use_cpp=True)', 'from __main__ import bqm, samples', number=N)
print('cython', cytime)

nptime = timeit.timeit('bqm.energies(samples, _use_cpp=False)', 'from __main__ import bqm, samples', number=N)
print('numpy', nptime)

print('cython/numpy', cytime/nptime)
```
Output:
```
numpy conversion time 2.7262168080196716
cython 7.390854711004067
numpy 50.06847931200173
cython/numpy 0.14761492285291822
```