### PR TITLE
SampleSet.data_vectors

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -560,6 +560,32 @@ class SampleSet(abc.Iterable, abc.Sized):
     ###############################################################################################
 
     @property
+    def data_vectors(self):
+        """The per-sample data in a vector.
+
+        Returns:
+            dict: A dict where the keys are the fields in the record and the
+            values are the corresponding arrays.
+
+        Examples:
+            >>> sampleset = dimod.SampleSet.from_samples([[-1, 1], [1, 1]], dimod.SPIN,
+                                                         energy=[-1, 1])
+            >>> sampleset.data_vectors['energy']
+            array([-1,  1])
+
+            Note that this is equivalent to, and less performant than:
+
+            >>> sampleset = dimod.SampleSet.from_samples([[-1, 1], [1, 1]], dimod.SPIN,
+                                                         energy=[-1, 1])
+            >>> sampleset.record['energy']
+            array([-1,  1])
+
+
+        """
+        return {field: self.record[field] for field in self.record.dtype.names
+                if field != 'sample'}
+
+    @property
     def first(self):
         """Sample with the lowest-energy.
 

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -360,6 +360,24 @@ class TestFirst(unittest.TestCase):
             dimod.SampleSet.from_samples([], dimod.SPIN, energy=[]).first
 
 
+class TestDataVectors(unittest.TestCase):
+    # SampleSet.data_vectors property
+    def test_empty(self):
+        ss = dimod.SampleSet.from_samples([], dimod.SPIN, energy=[])
+
+        self.assertEqual(set(ss.data_vectors), {'energy', 'num_occurrences'})
+        for field, vector in ss.data_vectors.items():
+            np.testing.assert_array_equal(vector, [])
+
+    def test_view(self):
+        # make sure that the vectors are views
+        ss = dimod.SampleSet.from_samples([[-1, 1], [1, 1]], dimod.SPIN, energy=[5, 5])
+
+        self.assertEqual(set(ss.data_vectors), {'energy', 'num_occurrences'})
+        for field, vector in ss.data_vectors.items():
+            np.shares_memory(vector, ss.record)
+
+
 class Test_concatenate(unittest.TestCase):
     def test_simple(self):
         ss0 = dimod.SampleSet.from_samples([-1, +1], dimod.SPIN, energy=-1)


### PR DESCRIPTION
Restore the `SampleSet.data_vectors` property.

Closes #393 