### PR TITLE
SampleSet.relabel_variables now correctly resolves the future

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -948,7 +948,7 @@ class SampleSet(abc.Iterable, abc.Sized):
         if not inplace:
             return self.copy().relabel_variables(mapping, inplace=True)
 
-        self._variables.relabel(mapping)
+        self.variables.relabel(mapping)
         return self
 
     def aggregate(self):


### PR DESCRIPTION
`SampleSet.relabel_variables` acted on `SampleSet._variables` which meant that if the `SampleSet` was constructed from a future and the future has not been resolved yet that it would fail.