### PR TITLE
Make SampleSet.samples an iterator

### DIFF
--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -16,6 +16,11 @@
 import unittest
 import json
 
+try:
+    import collections.abc as abc
+except ImportError:
+    import collections as abc
+
 from collections import OrderedDict
 
 import numpy as np
@@ -353,6 +358,15 @@ class TestIteration(unittest.TestCase):
         samples = list(sampleset.data())
         reversed_samples = list(sampleset.data(reverse=True))
         self.assertEqual(samples, list(reversed(reversed_samples)))
+
+    def test_iterator(self):
+        # deprecated feature
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1})
+        sampleset = dimod.SampleSet.from_samples_bqm([{'a': -1, 'b': 1}, {'a': 1, 'b': 1}], bqm)
+        self.assertIsInstance(sampleset.samples(), abc.Iterator)
+        self.assertIsInstance(sampleset.samples(n=2), abc.Iterator)
+        spl = next(sampleset.samples())
+        self.assertEqual(spl, {'a': 1, 'b': 1})
 
 
 class TestSerialization(unittest.TestCase):


### PR DESCRIPTION
The change introduced in #439 was backwards compatibility breaking. This restores backwards compatibility. However, using `SampleSet.samples` as an iterator is deprecated and will be removed in the future.

See https://github.com/dwavesystems/dwave-hybrid/issues/124
Closes #449 as redundant

