### PR TITLE
SampleSet.aggregate() preserves order

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -987,15 +987,19 @@ class SampleSet(abc.Iterable, abc.Sized):
             other fields are.
 
         """
-
         _, indices, inverse = np.unique(self.record.sample, axis=0,
                                         return_index=True, return_inverse=True)
+
+        # unique also sorts the array which we don't want, so we undo the sort
+        order = np.argsort(indices)
+        indices = indices[order]
 
         record = self.record[indices]
 
         # fix the number of occurrences
         record.num_occurrences = 0
         for old_idx, new_idx in enumerate(inverse):
+            new_idx = order[new_idx]
             record[new_idx].num_occurrences += self.record[old_idx].num_occurrences
 
         # dev note: we don't check the energies as they should be the same

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -261,6 +261,52 @@ class TestAggregate(unittest.TestCase):
         self.assertEqual(samples,
                          dimod.SampleSet.from_samples(([[-1, 1], [-1, 1]], 'ab'), dimod.SPIN, energy=[0.0, 0.0]))
 
+    def test_order_preservation_2x2_unique(self):
+        bqm = dimod.BinaryQuadraticModel({}, {'ab': 1}, 0, dimod.SPIN)
+
+        # these are unique so order should be preserved
+        ss1 = dimod.SampleSet.from_samples_bqm([{'a': 1, 'b': -1},
+                                                {'a': -1, 'b': 1}],
+                                               bqm)
+        ss2 = ss1.aggregate()
+
+        self.assertEqual(ss1, ss2)
+
+    def test_order_preservation(self):
+        bqm = dimod.BinaryQuadraticModel({}, {'ab': 1}, 0, dimod.SPIN)
+
+        ss1 = dimod.SampleSet.from_samples_bqm([{'a': 1, 'b': -1},
+                                                {'a': -1, 'b': 1},
+                                                {'a': 1, 'b': -1}],
+                                               bqm)
+        ss2 = ss1.aggregate()
+
+        target = dimod.SampleSet.from_samples_bqm([{'a': 1, 'b': -1},
+                                                   {'a': -1, 'b': 1}],
+                                                  bqm,
+                                                  num_occurrences=[2, 1])
+
+        self.assertEqual(target, ss2)
+
+    def test_order_preservation_doubled(self):
+        bqm = dimod.BinaryQuadraticModel({}, {'ab': 1, 'bc': -1}, 0, dimod.SPIN)
+        ss1 = dimod.SampleSet.from_samples_bqm(([[1, 1, 0],
+                                                 [1, 0, 0],
+                                                 [0, 0, 0],
+                                                 [0, 0, 0],
+                                                 [1, 1, 0],
+                                                 [1, 0, 0],
+                                                 [0, 0, 0]], 'abc'),
+                                               bqm)
+
+        target = dimod.SampleSet.from_samples_bqm(([[1, 1, 0],
+                                                    [1, 0, 0],
+                                                    [0, 0, 0]], 'abc'),
+                                                  bqm,
+                                                  num_occurrences=[2, 2, 3])
+
+        self.assertEqual(target, ss1.aggregate())
+
 
 class TestAppend(unittest.TestCase):
     def test_sampleset1_append1(self):


### PR DESCRIPTION
Closes #461 

I took a look at the source for `numpy.unique` to see if there is a more direct way to do it, but I think it still make sense to leverage numpy's implementation rather than write our own.