### PR TITLE
Prevent from_numpy_vectors from silently truncating 

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -2395,6 +2395,9 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         except ValueError:
             raise ValueError("quadratic should be a 3-tuple")
 
+        if not len(heads) == len(tails) == len(values):
+            raise ValueError("row, col, and bias should be of equal length")
+
         if variable_order is None:
             variable_order = list(range(len(linear)))
 


### PR DESCRIPTION
I think the risk a user inadvertently creates mismatched-length vectors and gets a BQM that is silently truncated by 
```
quadratic = {(variable_order[u], variable_order[v]): float(bias)
                     for u, v, bias in zip(heads, tails, values)}
``` 
, which will be hard to diagnose, especially for large numbers of variables, is high and the inconvenience of maybe having to set shorten vectors that would have been happily trimmed is not a big deal.