### PR TITLE
BinaryQuadraticModel.is_writeable

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -62,55 +62,12 @@ from six import itervalues, iteritems
 from dimod.decorators import vartype_argument, lockable_method
 from dimod.serialization.utils import array2bytes, bytes2array
 from dimod.sampleset import as_samples
-from dimod.utilities import resolve_label_conflict
+from dimod.utilities import resolve_label_conflict, LockableDict
 from dimod.views.bqm import LinearView, QuadraticView, AdjacencyView
 from dimod.views.samples import SampleView
 from dimod.vartypes import Vartype
 
 __all__ = ['BinaryQuadraticModel', 'BQM']
-
-
-class LockableDict(dict):
-    """A dict that can turn writeablity on and off"""
-
-    # methods like update, clear etc are not wrappers for __setitem__,
-    # __delitem__ so they need to be overwritten
-
-    @property
-    def is_writeable(self):
-        return getattr(self, '_writeable', True)
-
-    @is_writeable.setter
-    def is_writeable(self, b):
-        self._writeable = bool(b)
-
-    @lockable_method
-    def __setitem__(self, key, value):
-        super(LockableDict, self).__setitem__(key, value)
-
-    @lockable_method
-    def __delitem__(self, key):
-        super(LockableDict, self).__delitem__(key)
-
-    @lockable_method
-    def clear(self):
-        super(LockableDict, self).clear()
-
-    @lockable_method
-    def pop(self, *args, **kwargs):
-        super(LockableDict, self).pop(*args, **kwargs)
-
-    @lockable_method
-    def popitem(self):
-        super(LockableDict, self).popitem()
-
-    @lockable_method
-    def setdefault(self, *args, **kwargs):
-        super(LockableDict, self).setdefault(*args, **kwargs)
-
-    @lockable_method
-    def update(self, *args, **kwargs):
-        super(LockableDict, self).update(*args, **kwargs)
 
 
 class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
@@ -335,6 +292,8 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
 
         # also set the flags on the relevant data object objects
         self._adj.is_writeable = self.info.is_writeable = b
+        for neighbors in self._adj.values():
+            neighbors.is_writeable = b
 
     @property
     def offset(self):
@@ -514,7 +473,7 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
             else:
                 _adj[v][v] = bias
         else:
-            _adj[v] = {v: bias}
+            _adj[v] = LockableDict({v: bias})
 
         try:
             self._counterpart.add_variable(v, bias, vartype=self.vartype)
@@ -636,9 +595,9 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         else:
             # so that they exist.
             if u not in self:
-                _adj[u] = {}
+                _adj[u] = LockableDict()
             if v not in self:
-                _adj[v] = {}
+                _adj[v] = LockableDict()
 
         if u in _adj[v]:
             _adj[u][v] = _adj[v][u] = _adj[u][v] + bias

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -72,7 +72,6 @@ __all__ = ['BinaryQuadraticModel', 'BQM']
 
 class LockableDict(dict):
     """A dict that can turn writeablity on and off"""
-    __slots__ = ('_writeable',)
 
     # methods like update, clear etc are not wrappers for __setitem__,
     # __delitem__ so they need to be overwritten

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -59,7 +59,7 @@ import numpy as np
 
 from six import itervalues, iteritems
 
-from dimod.decorators import vartype_argument
+from dimod.decorators import vartype_argument, lockable_method
 from dimod.serialization.utils import array2bytes, bytes2array
 from dimod.sampleset import as_samples
 from dimod.utilities import resolve_label_conflict
@@ -67,7 +67,51 @@ from dimod.views.bqm import LinearView, QuadraticView, AdjacencyView
 from dimod.views.samples import SampleView
 from dimod.vartypes import Vartype
 
-__all__ = 'BinaryQuadraticModel', 'BQM'
+__all__ = ['BinaryQuadraticModel', 'BQM']
+
+
+class LockableDict(dict):
+    """A dict that can turn writeablity on and off"""
+    __slots__ = ('_writeable',)
+
+    # methods like update, clear etc are not wrappers for __setitem__,
+    # __delitem__ so they need to be overwritten
+
+    @property
+    def is_writeable(self):
+        return getattr(self, '_writeable', True)
+
+    @is_writeable.setter
+    def is_writeable(self, b):
+        self._writeable = bool(b)
+
+    @lockable_method
+    def __setitem__(self, key, value):
+        super(LockableDict, self).__setitem__(key, value)
+
+    @lockable_method
+    def __delitem__(self, key):
+        super(LockableDict, self).__delitem__(key)
+
+    @lockable_method
+    def clear(self):
+        super(LockableDict, self).clear()
+
+    @lockable_method
+    def pop(self, *args, **kwargs):
+        super(LockableDict, self).pop(*args, **kwargs)
+
+    @lockable_method
+    def popitem(self):
+        super(LockableDict, self).popitem()
+
+    @lockable_method
+    def setdefault(self, *args, **kwargs):
+        super(LockableDict, self).setdefault(*args, **kwargs)
+
+    @lockable_method
+    def update(self, *args, **kwargs):
+        super(LockableDict, self).update(*args, **kwargs)
 
 
 class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):

--- a/dimod/decorators.py
+++ b/dimod/decorators.py
@@ -35,7 +35,7 @@ from six import iteritems, integer_types
 
 from dimod.compatibility23 import getargspec
 from dimod.core.structured import Structured
-from dimod.exceptions import BinaryQuadraticModelStructureError
+from dimod.exceptions import BinaryQuadraticModelStructureError, WriteableError
 from dimod.vartypes import as_vartype
 
 
@@ -349,3 +349,18 @@ def graph_argument(*arg_names, **options):
         return new_f
 
     return _graph_arg
+
+
+def lockable_method(f):
+    """Method decorator for objects with an is_writeable flag.
+
+    If wrapped method is called, and the associated object's `is_writeable`
+    attribute is set to True, a :exc:`.exceptions.WriteableError` is raised.
+
+    """
+    @wraps(f)
+    def _check_writeable(obj, *args, **kwds):
+        if not obj.is_writeable:
+            raise WriteableError
+        return f(obj, *args, **kwds)
+    return _check_writeable

--- a/dimod/exceptions.py
+++ b/dimod/exceptions.py
@@ -37,3 +37,7 @@ class BinaryQuadraticModelSizeError(BinaryQuadraticModelValueError):
 
 class BinaryQuadraticModelStructureError(BinaryQuadraticModelValueError):
     """Raised when the binary quadratic model does not fit the sampler"""
+
+
+class WriteableError(ValueError):
+    """Raised when trying to modify an immutable object."""

--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -20,6 +20,8 @@ import itertools
 
 from six import iteritems, itervalues
 
+from dimod.decorators import lockable_method
+
 __all__ = ['ising_energy',
            'qubo_energy',
            'ising_to_qubo',
@@ -390,3 +392,46 @@ def child_structure_dfs(sampler, seen=None):
             pass
 
     raise ValueError("no structured sampler found")
+
+
+class LockableDict(dict):
+    """A dict that can turn writeablity on and off"""
+
+    # methods like update, clear etc are not wrappers for __setitem__,
+    # __delitem__ so they need to be overwritten
+
+    @property
+    def is_writeable(self):
+        return getattr(self, '_writeable', True)
+
+    @is_writeable.setter
+    def is_writeable(self, b):
+        self._writeable = bool(b)
+
+    @lockable_method
+    def __setitem__(self, key, value):
+        super(LockableDict, self).__setitem__(key, value)
+
+    @lockable_method
+    def __delitem__(self, key):
+        super(LockableDict, self).__delitem__(key)
+
+    @lockable_method
+    def clear(self):
+        super(LockableDict, self).clear()
+
+    @lockable_method
+    def pop(self, *args, **kwargs):
+        super(LockableDict, self).pop(*args, **kwargs)
+
+    @lockable_method
+    def popitem(self):
+        super(LockableDict, self).popitem()
+
+    @lockable_method
+    def setdefault(self, *args, **kwargs):
+        super(LockableDict, self).setdefault(*args, **kwargs)
+
+    @lockable_method
+    def update(self, *args, **kwargs):
+        super(LockableDict, self).update(*args, **kwargs)

--- a/dimod/views/bqm.py
+++ b/dimod/views/bqm.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     import collections as abc
 
+from dimod.utilities import LockableDict
+
 
 class BQMView(object):
     __slots__ = '_adj',
@@ -69,7 +71,7 @@ class LinearView(BQMView, abc.MutableMapping):
         if v in adj:
             adj[v][v] = bias
         else:
-            adj[v] = {v: bias}
+            adj[v] = LockableDict({v: bias})
 
     def __str__(self):
         return str(dict(self))

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -2289,3 +2289,20 @@ class TestIsWriteable(unittest.TestCase):
 
         with self.assertRaises(WriteableError):
             bqm.add_interaction('a', 'b', 5)
+
+    def test_already_existing_biases(self):
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1})
+
+        bqm.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            bqm.add_variable('a', 1)
+
+        with self.assertRaises(WriteableError):
+            bqm.add_interaction('a', 'b', 1)
+
+        with self.assertRaises(WriteableError):
+            bqm.linear['a'] += 6
+
+        with self.assertRaises(WriteableError):
+            bqm.adj['a']['b'] += 5

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -2259,3 +2259,33 @@ class TestFromNetworkxGraph(unittest.TestCase):
                                                     offset=6)
         new = dimod.BinaryQuadraticModel.from_networkx_graph(bqm.to_networkx_graph())
         self.assertEqual(bqm, new)
+
+
+class TestIsWriteable(unittest.TestCase):
+    def test_offset(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        bqm.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            bqm.offset = 5
+
+    def test_info(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        bqm.is_writeable = False
+        with self.assertRaises(WriteableError):
+            bqm.info['a'] = 1
+
+    def test_biases(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        bqm.is_writeable = False
+        with self.assertRaises(WriteableError):
+            bqm.linear['a'] = 5
+
+        with self.assertRaises(WriteableError):
+            bqm.add_variable('a', 5)
+
+        with self.assertRaises(WriteableError):
+            bqm.add_interaction('a', 'b', 5)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -29,6 +29,9 @@ import numpy as np
 
 import dimod
 
+from dimod.exceptions import WriteableError
+from dimod.binary_quadratic_model import LockableDict
+
 try:
     import networkx as nx
     _networkx = True
@@ -40,6 +43,76 @@ try:
     _pandas = True
 except ImportError:
     _pandas = False
+
+
+class TestLockableDict(unittest.TestCase):
+
+    def test__setitem__(self):
+        d = LockableDict({'a': -1})
+
+        d.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            d['a'] = 5
+
+    def test__delitem__(self):
+        d = LockableDict({'a': -1})
+
+        d.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            del d['a']
+
+    def test_clear(self):
+        d = LockableDict({'a': -1})
+        d.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            d.clear()
+
+        d.is_writeable = True
+        d.clear()
+        self.assertEqual(d, {})
+
+    def test_pop(self):
+        d = LockableDict({'a': -1})
+        d.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            d.pop('a')
+
+    def test_popitem(self):
+        d = LockableDict({'a': -1, 'b': 2})
+
+        d.popitem()
+        self.assertEqual(len(d), 1)
+
+        d.is_writeable = False
+
+        with self.assertRaises(WriteableError):
+            d.popitem()
+
+    def test_setdefault(self):
+        d = LockableDict()
+
+        d.setdefault('a')
+        d.setdefault('b', 5)
+        self.assertEqual(d, {'a': None, 'b': 5})
+
+        d.is_writeable = False
+        with self.assertRaises(WriteableError):
+            d.setdefault('c', None)
+
+    def test_update(self):
+        d = LockableDict()
+
+        # check that it works normally
+        d.update({'a': 1})
+        self.assertEqual(d, {'a': 1})
+
+        d.is_writeable = False
+        with self.assertRaises(WriteableError):
+            d.update({'b': -1})
 
 
 class TestBinaryQuadraticModel(unittest.TestCase):


### PR DESCRIPTION
Note that at the moment the `vartype` property is writeable (see #489 ).