### PR TITLE
Add SampleSet.is_writeable

### DIFF
--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -20,6 +20,7 @@ except ImportError:
 
 from operator import eq
 
+from dimod.decorators import lockable_method
 from dimod.utilities import resolve_label_conflict
 
 from six import PY3
@@ -43,7 +44,7 @@ class Variables(abc.Sequence, abc.Set):
         iterable: An iterable of variable labels.
 
     """
-    __slots__ = '_label', 'index'
+    __slots__ = ('_label', 'index', '_writeable')
 
     def __init__(self, iterable):
         self.index = index = CallableDict()
@@ -101,12 +102,21 @@ class Variables(abc.Sequence, abc.Set):
         else:
             return False
 
+    @property
+    def is_writeable(self):
+        return getattr(self, '_writeable', True)
+
+    @is_writeable.setter
+    def is_writeable(self, b):
+        self._writeable = bool(b)
+
     # index method is overloaded by __init__
 
     def count(self, v):
         # everything is unique
         return int(v in self)
 
+    @lockable_method
     def relabel(self, mapping):
 
         # put the new labels into a set for fast lookup

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -734,3 +734,17 @@ class Test_concatenate(unittest.TestCase):
     def test_empty(self):
         with self.assertRaises(ValueError):
             dimod.concatenate([])
+
+
+class TestWriteable(unittest.TestCase):
+    def test_locked(self):
+        ss = dimod.SampleSet.from_samples(([[1, 1], [0, 0]], 'ab'),
+                                          dimod.BINARY, energy=[1, 1])
+
+        ss.is_writeable = False
+
+        with self.assertRaises(dimod.exceptions.WriteableError):
+            ss.relabel_variables({'a': 'c'})
+
+        with self.assertRaises(dimod.exceptions.WriteableError):
+            ss.change_vartype('SPIN', inplace=True)


### PR DESCRIPTION
Right now if the underlying Numpy array is edited while the sample set is not writeable, a `ValueError` will be raised, rather than a `WriteableError`.