### PR TITLE
SampleSet/BQM.to_serializable now handles numpy variable labels

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -53,7 +53,7 @@ try:
 except ImportError:
     import collections as abc
 
-from numbers import Number
+from numbers import Integral, Number
 
 import numpy as np
 
@@ -1739,11 +1739,28 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         from dimod.package_info import __version__
         schema_version = "2.0.0"
 
+        def iter_variables(variables):
+            # want to handle things like numpy numbers and fractions that do not
+            # serialize so easy
+            for v in variables:
+                if isinstance(v, Integral):
+                    yield int(v)
+                elif isinstance(v, Number):
+                    yield float(v)
+                elif isinstance(v, str):
+                    yield v
+                elif isinstance(v, (abc.Sequence, abc.Set)):
+                    yield tuple(iter_variables(v))
+                else:
+                    yield v
+
+        variables = list(iter_variables(self.variables))
+
         try:
-            variables = sorted(self.variables)
+            variables.sort()
         except TypeError:
-            # sorting unlike types in py3
-            variables = list(self.variables)
+            # cannot unlike types in py3
+            pass
 
         num_variables = len(variables)
 

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -65,6 +65,7 @@ from dimod.sampleset import as_samples
 from dimod.utilities import resolve_label_conflict, LockableDict
 from dimod.views.bqm import LinearView, QuadraticView, AdjacencyView
 from dimod.views.samples import SampleView
+from dimod.variables import iter_serialize_variables
 from dimod.vartypes import Vartype
 
 __all__ = ['BinaryQuadraticModel', 'BQM']
@@ -1739,22 +1740,7 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         from dimod.package_info import __version__
         schema_version = "2.0.0"
 
-        def iter_variables(variables):
-            # want to handle things like numpy numbers and fractions that do not
-            # serialize so easy
-            for v in variables:
-                if isinstance(v, Integral):
-                    yield int(v)
-                elif isinstance(v, Number):
-                    yield float(v)
-                elif isinstance(v, str):
-                    yield v
-                elif isinstance(v, (abc.Sequence, abc.Set)):
-                    yield tuple(iter_variables(v))
-                else:
-                    yield v
-
-        variables = list(iter_variables(self.variables))
+        variables = list(iter_serialize_variables(self.variables))
 
         try:
             variables.sort()

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -1359,7 +1359,7 @@ class SampleSet(abc.Iterable, abc.Sized):
                 "info": self.info,
                 "version": {"dimod": __version__,
                             "sampleset_schema": schema_version},
-                "variable_labels": list(self.variables),
+                "variable_labels": self.variables.to_serializable(),
                 "use_bytes": bool(use_bytes)}
 
     def _asdict(self):

--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -13,6 +13,8 @@
 #    limitations under the License.
 #
 # =============================================================================
+from numbers import Integral, Number
+
 try:
     import collections.abc as abc
 except ImportError:
@@ -25,6 +27,8 @@ from dimod.utilities import resolve_label_conflict
 
 from six import PY3
 from six.moves import map
+
+__all__ = ['Variables']
 
 
 class CallableDict(abc.Callable, dict):
@@ -115,6 +119,25 @@ class Variables(abc.Sequence, abc.Set):
     def count(self, v):
         # everything is unique
         return int(v in self)
+
+    def to_serializable(self):
+        def iter_variables(variables):
+            # want to handle things like numpy numbers and fractions that do not
+            # serialize so easy
+            for v in variables:
+                if isinstance(v, Integral):
+                    yield int(v)
+                elif isinstance(v, Number):
+                    yield float(v)
+                elif isinstance(v, str):
+                    yield v
+                # we want Collection, but that's not available in py2.7
+                elif isinstance(v, (abc.Sequence, abc.Set)):
+                    yield tuple(iter_variables(v))
+                else:
+                    yield v
+
+        return list(iter_variables(self))
 
     @lockable_method
     def relabel(self, mapping):

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -14,14 +14,15 @@
 #
 # ================================================================================================
 
-import unittest
-import random
-import itertools
-import tempfile
-import shutil
-import json
 import collections
+import fractions
+import itertools
+import json
 import pickle
+import random
+import shutil
+import tempfile
+import unittest
 
 from os import path
 
@@ -2220,6 +2221,16 @@ class TestSerialization(unittest.TestCase):
 
         self.assertEqual(bqm, new)
         self.assertEqual(new.info, {"tag": 5})
+
+    def test_variable_labels(self):
+        h = {0: 0, 1: 1, np.int64(2): 2, np.float(3): 3,
+             fractions.Fraction(4, 1): 4, fractions.Fraction(5, 2): 5,
+             '6': 6}
+        J = {}
+
+        bqm = dimod.BinaryQuadraticModel.from_ising(h, J)
+
+        json.dumps(bqm.to_serializable())
 
 
 class TestZeroField(unittest.TestCase):

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -14,6 +14,7 @@
 #
 # ================================================================================================
 import unittest
+import fractions
 import json
 import pickle
 
@@ -647,6 +648,15 @@ class TestSerialization(unittest.TestCase):
         new = dimod.SampleSet.from_serializable(json.loads(json_str))
 
         self.assertEqual(sampleset, new)
+
+    def test_numpy_variable_labels(self):
+        h = {0: 0, 1: 1, np.int64(2): 2, np.float(3): 3,
+             fractions.Fraction(4, 1): 4, fractions.Fraction(5, 2): 5,
+             '6': 6}
+
+        sampleset = dimod.NullSampler().sample_ising(h, {})
+
+        json.dumps(sampleset.to_serializable())
 
 
 @unittest.skipUnless(_pandas, "no pandas present")


### PR DESCRIPTION
Closes #496 

I am genuinely a bit unsure about this one, I am worried that there are too many edge cases and it might be more explicit to simply require that the user provide serializable variable labels.

The argument for this approach is that hashing treats them as equivalent anyway so for instance
```
>>> {np.int64(1): 1, 1: 2, Fraction(1): 3}
{1: 3}
```
but it might be astonishing that serializing and deserializing does not return the same type for the variable labels.