### PR TITLE
BQM Serialization version 3.0.0

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1760,19 +1760,22 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
 
         num_interactions = len(irow)
 
-        doc = {"basetype": "BinaryQuadraticModel",
-               "type": type(self).__name__,
-               "version": {"dimod": __version__,
-                           "bqm_schema": schema_version},
-               "variable_labels": variables,
-               "variable_type": self.vartype.name,
-               "info": self.info,
-               "offset": float(offset),
-               "index_type": np.dtype(index_dtype).str,
-               "bias_type": np.dtype(bias_dtype).str,
-               "shape": [num_variables, num_interactions],
-               "use_bytes": bool(use_bytes)
-               }
+        doc = {
+            # metadata
+            "type": type(self).__name__,
+            "version": {"bqm_schema": schema_version},
+            "use_bytes": bool(use_bytes),
+            "index_type": np.dtype(index_dtype).str,
+            "bias_type": np.dtype(bias_dtype).str,
+
+            # bqm
+            "num_variables": num_variables,
+            "num_interactions": num_interactions,
+            "variable_labels": variables,
+            "variable_type": self.vartype.name,
+            "offset": float(offset),
+            "info": self.info,
+            }
 
         if use_bytes:
             # these are vectors so don't need to specify byte-order

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1679,11 +1679,12 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
 
         Args:
             use_bytes (bool, optional, default=False):
-                If True, a compact representation representing the biases as bytes is used.
+                If True, a compact representation representing the biases as
+                bytes is used. Uses :func:`~numpy.ndarray.tobytes`.
 
-            bias_dtype (numpy.dtype, optional, default=numpy.float32):
-                If `use_bytes` is True, this numpy dtype will be used to
-                represent the bias values in the serialized format.
+            bias_dtype (data-type, optional, default=numpy.float32):
+                If `use_bytes` is True, this :class:`~numpy.dtype` will be used
+                to represent the bias values in the serialized format.
 
             bytes_type (class, optional, default=bytes):
                 This class will be used to wrap the bytes objects in the
@@ -1765,8 +1766,8 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
             "type": type(self).__name__,
             "version": {"bqm_schema": schema_version},
             "use_bytes": bool(use_bytes),
-            "index_type": np.dtype(index_dtype).str,
-            "bias_type": np.dtype(bias_dtype).str,
+            "index_type": np.dtype(index_dtype).name,
+            "bias_type": np.dtype(bias_dtype).name,
 
             # bqm
             "num_variables": num_variables,

--- a/dimod/serialization/json.py
+++ b/dimod/serialization/json.py
@@ -85,11 +85,9 @@ def _is_sampleset_v2(obj):
     return True
 
 
-def _is_bqm_v2(obj):
-    if obj.get("basetype", "") != "BinaryQuadraticModel":
-        return False
+def _is_bqm(obj):
     # we could do more checking but probably this is sufficient
-    return True
+    return obj.get("type", "") == "BinaryQuadraticModel"
 
 
 def dimod_object_hook(obj):
@@ -103,7 +101,7 @@ def dimod_object_hook(obj):
         # in the future we could handle subtypes but right now we just have the
         # one
         return SampleSet.from_serializable(obj)
-    elif _is_bqm_v2(obj):
+    elif _is_bqm(obj):
         # in the future we could handle subtypes but right now we just have the
         # one
         return BinaryQuadraticModel.from_serializable(obj)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -2169,6 +2169,95 @@ class TestSerialization(unittest.TestCase):
 
         self.assertEqual(dimod.BinaryQuadraticModel.from_serializable(s), bqm)
 
+    def test_from_serializable_empty_v3(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        s = {'basetype': 'BinaryQuadraticModel',
+             'bias_type': '<f4',
+             'index_type': '<u2',
+             'info': {},
+             'linear_biases': [],
+             'offset': 0.0,
+             'quadratic_biases': [],
+             'quadratic_head': [],
+             'quadratic_tail': [],
+             'shape': [0, 0],
+             'type': 'BinaryQuadraticModel',
+             'use_bytes': False,
+             'variable_labels': [],
+             'variable_type': 'SPIN',
+             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+
+        self.assertEqual(bqm, dimod.BinaryQuadraticModel.from_serializable(s))
+
+    def test_from_serializable_v3(self):
+        linear = {'a': -1, 4: 1, ('a', "complex key"): 3}
+        quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
+        bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
+
+        s = {'basetype': 'BinaryQuadraticModel',
+             'bias_type': '<f4',
+             'index_type': '<u2',
+             'info': {},
+             'linear_biases': [-1.0, 1.0, 3.0, 0.0, 0.0, 0.0],
+             'offset': 3.0,
+             'quadratic_biases': [1.0, 3.0, -1.0],
+             'quadratic_head': [0, 3, 0],
+             'quadratic_tail': [3, 4, 5],
+             'shape': [6, 3],
+             'type': 'BinaryQuadraticModel',
+             'use_bytes': False,
+             'variable_labels': ['a', 4, ('a', 'complex key'), 'c', 'b', 3],
+             'variable_type': 'SPIN',
+             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+
+        self.assertEqual(dimod.BinaryQuadraticModel.from_serializable(s), bqm)
+
+    def test_from_serializable_bytes_empty_v3(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        s = {'basetype': 'BinaryQuadraticModel',
+             'bias_type': '<f4',
+             'index_type': '<u2',
+             'info': {},
+             'linear_biases': b'',
+             'offset': 0.0,
+             'quadratic_biases': b'',
+             'quadratic_head': b'',
+             'quadratic_tail': b'',
+             'shape': [0, 0],
+             'type': 'BinaryQuadraticModel',
+             'use_bytes': True,
+             'variable_labels': [],
+             'variable_type': 'SPIN',
+             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+
+        self.assertEqual(bqm, dimod.BinaryQuadraticModel.from_serializable(s))
+
+    def test_from_serializable_bytes_v3(self):
+        linear = {'a': -1, 4: 1, ('a', "complex key"): 3}
+        quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
+        bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
+
+        s = {'basetype': 'BinaryQuadraticModel',
+             'bias_type': '<f4',
+             'index_type': '<u2',
+             'info': {},
+             'linear_biases': b'\x00\x00\x80\xbf\x00\x00\x80?\x00\x00@@\x00\x00\x00\x00'
+                              b'\x00\x00\x00\x00\x00\x00\x00\x00',
+             'offset': 3.0,
+             'quadratic_biases': b'\x00\x00\x80?\x00\x00@@\x00\x00\x80\xbf',
+             'quadratic_head': b'\x00\x00\x03\x00\x00\x00',
+             'quadratic_tail': b'\x03\x00\x04\x00\x05\x00',
+             'shape': [6, 3],
+             'type': 'BinaryQuadraticModel',
+             'use_bytes': True,
+             'variable_labels': ['a', 4, ('a', 'complex key'), 'c', 'b', 3],
+             'variable_type': 'SPIN',
+             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+
+        self.assertEqual(dimod.BinaryQuadraticModel.from_serializable(s), bqm)
+
     def test_functional_empty(self):
         # round trip
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -2172,8 +2172,8 @@ class TestSerialization(unittest.TestCase):
     def test_from_serializable_empty_v3(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 
-        s = {'bias_type': '<f4',
-             'index_type': '<u2',
+        s = {'bias_type': 'float32',
+             'index_type': 'uint16',
              'info': {},
              'linear_biases': [],
              'num_interactions': 0,
@@ -2195,8 +2195,8 @@ class TestSerialization(unittest.TestCase):
         quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
         bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
 
-        s = {'bias_type': '<f4',
-             'index_type': '<u2',
+        s = {'bias_type': 'float32',
+             'index_type': 'uint16',
              'info': {},
              'linear_biases': [-1.0, 1.0, 3.0, 0.0, 0.0, 0.0],
              'num_interactions': 3,
@@ -2216,8 +2216,8 @@ class TestSerialization(unittest.TestCase):
     def test_from_serializable_bytes_empty_v3(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 
-        s = {'bias_type': '<f4',
-             'index_type': '<u2',
+        s = {'bias_type': 'float32',
+             'index_type': 'uint16',
              'info': {},
              'linear_biases': b'',
              'num_interactions': 0,
@@ -2239,8 +2239,8 @@ class TestSerialization(unittest.TestCase):
         quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
         bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
 
-        s = {'bias_type': '<f4',
-             'index_type': '<u2',
+        s = {'bias_type': 'float32',
+             'index_type': 'uint16',
              'info': {},
              'linear_biases': b'\x00\x00\x80\xbf\x00\x00\x80?\x00\x00@@\x00\x00\x00\x00'
                               b'\x00\x00\x00\x00\x00\x00\x00\x00',

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -2172,21 +2172,21 @@ class TestSerialization(unittest.TestCase):
     def test_from_serializable_empty_v3(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 
-        s = {'basetype': 'BinaryQuadraticModel',
-             'bias_type': '<f4',
+        s = {'bias_type': '<f4',
              'index_type': '<u2',
              'info': {},
              'linear_biases': [],
+             'num_interactions': 0,
+             'num_variables': 0,
              'offset': 0.0,
              'quadratic_biases': [],
              'quadratic_head': [],
              'quadratic_tail': [],
-             'shape': [0, 0],
              'type': 'BinaryQuadraticModel',
              'use_bytes': False,
              'variable_labels': [],
              'variable_type': 'SPIN',
-             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+             'version': {'bqm_schema': '3.0.0'}}
 
         self.assertEqual(bqm, dimod.BinaryQuadraticModel.from_serializable(s))
 
@@ -2195,42 +2195,42 @@ class TestSerialization(unittest.TestCase):
         quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
         bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
 
-        s = {'basetype': 'BinaryQuadraticModel',
-             'bias_type': '<f4',
+        s = {'bias_type': '<f4',
              'index_type': '<u2',
              'info': {},
              'linear_biases': [-1.0, 1.0, 3.0, 0.0, 0.0, 0.0],
+             'num_interactions': 3,
+             'num_variables': 6,
              'offset': 3.0,
              'quadratic_biases': [1.0, 3.0, -1.0],
              'quadratic_head': [0, 3, 0],
              'quadratic_tail': [3, 4, 5],
-             'shape': [6, 3],
              'type': 'BinaryQuadraticModel',
              'use_bytes': False,
              'variable_labels': ['a', 4, ('a', 'complex key'), 'c', 'b', 3],
              'variable_type': 'SPIN',
-             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+             'version': {'bqm_schema': '3.0.0'}}
 
         self.assertEqual(dimod.BinaryQuadraticModel.from_serializable(s), bqm)
 
     def test_from_serializable_bytes_empty_v3(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 
-        s = {'basetype': 'BinaryQuadraticModel',
-             'bias_type': '<f4',
+        s = {'bias_type': '<f4',
              'index_type': '<u2',
              'info': {},
              'linear_biases': b'',
+             'num_interactions': 0,
+             'num_variables': 0,
              'offset': 0.0,
              'quadratic_biases': b'',
              'quadratic_head': b'',
              'quadratic_tail': b'',
-             'shape': [0, 0],
              'type': 'BinaryQuadraticModel',
              'use_bytes': True,
              'variable_labels': [],
              'variable_type': 'SPIN',
-             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+             'version': {'bqm_schema': '3.0.0'}}
 
         self.assertEqual(bqm, dimod.BinaryQuadraticModel.from_serializable(s))
 
@@ -2239,22 +2239,22 @@ class TestSerialization(unittest.TestCase):
         quadratic = {('a', 'c'): 1, ('b', 'c'): 3.0, ('a', 3): -1}
         bqm = dimod.BinaryQuadraticModel(linear, quadratic, 3, dimod.SPIN)
 
-        s = {'basetype': 'BinaryQuadraticModel',
-             'bias_type': '<f4',
+        s = {'bias_type': '<f4',
              'index_type': '<u2',
              'info': {},
              'linear_biases': b'\x00\x00\x80\xbf\x00\x00\x80?\x00\x00@@\x00\x00\x00\x00'
                               b'\x00\x00\x00\x00\x00\x00\x00\x00',
+             'num_interactions': 3,
+             'num_variables': 6,
              'offset': 3.0,
              'quadratic_biases': b'\x00\x00\x80?\x00\x00@@\x00\x00\x80\xbf',
              'quadratic_head': b'\x00\x00\x03\x00\x00\x00',
              'quadratic_tail': b'\x03\x00\x04\x00\x05\x00',
-             'shape': [6, 3],
              'type': 'BinaryQuadraticModel',
              'use_bytes': True,
              'variable_labels': ['a', 4, ('a', 'complex key'), 'c', 'b', 3],
              'variable_type': 'SPIN',
-             'version': {'bqm_schema': '3.0.0', 'dimod': '0.8.14'}}
+             'version': {'bqm_schema': '3.0.0'}}
 
         self.assertEqual(dimod.BinaryQuadraticModel.from_serializable(s), bqm)
 


### PR DESCRIPTION
Remove the numpy dependency for the binary quadratic model serialization. The sample set will be similarly updated.

In order to make this more "python agnostic", perhaps we should change some of the metadata. We could do something like

```
{"schema_version": "3.0.0",
 "basetype": "BinaryQuadraticModel"
 "encoder": {"library": "dimod",  # "encoder" holds all the stuff specific to the encoding library
             "version": "0.8.14",
             "type": "BinaryQuadraticModel"  # the subclass, if any
             },
 ...
 }
```
We could alternatively consider just ditching that information. Though I do think it can be useful in the case of storing in a database for benchmarking etc.