### PR TITLE
Recursive info field serialization

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -61,7 +61,7 @@ from six import itervalues, iteritems
 
 from dimod.decorators import vartype_argument, lockable_method
 from dimod.sampleset import as_samples
-from dimod.serialization.utils import dfs_serialize_ndarray, dfs_deserialize_ndarray
+from dimod.serialization.utils import serialize_ndarrays, deserialize_ndarrays
 from dimod.utilities import resolve_label_conflict, LockableDict
 from dimod.views.bqm import LinearView, QuadraticView, AdjacencyView
 from dimod.views.samples import SampleView
@@ -1776,7 +1776,7 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
             "variable_labels": variables,
             "variable_type": self.vartype.name,
             "offset": float(offset),
-            "info": dfs_serialize_ndarray(self.info, use_bytes=use_bytes,
+            "info": serialize_ndarrays(self.info, use_bytes=use_bytes,
                                           bytes_type=bytes_type),
             }
 
@@ -1927,7 +1927,7 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
                                      str(vartype),  # handle unicode for py2
                                      variable_order=variables)
 
-        bqm.info.update(dfs_deserialize_ndarray(obj['info']))
+        bqm.info.update(deserialize_ndarrays(obj['info']))
         return bqm
 
     def to_networkx_graph(self, node_attribute_name='bias', edge_attribute_name='bias'):

--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -61,6 +61,7 @@ from six import itervalues, iteritems
 
 from dimod.decorators import vartype_argument, lockable_method
 from dimod.sampleset import as_samples
+from dimod.serialization.utils import dfs_serialize_ndarray, dfs_deserialize_ndarray
 from dimod.utilities import resolve_label_conflict, LockableDict
 from dimod.views.bqm import LinearView, QuadraticView, AdjacencyView
 from dimod.views.samples import SampleView
@@ -1775,7 +1776,8 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
             "variable_labels": variables,
             "variable_type": self.vartype.name,
             "offset": float(offset),
-            "info": self.info,
+            "info": dfs_serialize_ndarray(self.info, use_bytes=use_bytes,
+                                          bytes_type=bytes_type),
             }
 
         if use_bytes:
@@ -1925,7 +1927,7 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
                                      str(vartype),  # handle unicode for py2
                                      variable_order=variables)
 
-        bqm.info.update(obj["info"])
+        bqm.info.update(dfs_deserialize_ndarray(obj['info']))
         return bqm
 
     def to_networkx_graph(self, node_attribute_name='bias', edge_attribute_name='bias'):

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -33,8 +33,12 @@ from numpy.lib import recfunctions
 from dimod.decorators import vartype_argument
 from dimod.exceptions import WriteableError
 from dimod.serialization.format import Formatter
-from dimod.serialization.utils import pack_samples, unpack_samples
-from dimod.serialization.utils import serialize_ndarray, deserialize_ndarray
+from dimod.serialization.utils import (pack_samples,
+                                       unpack_samples,
+                                       serialize_ndarray,
+                                       deserialize_ndarray,
+                                       dfs_serialize_ndarray,
+                                       dfs_deserialize_ndarray)
 from dimod.utilities import LockableDict
 from dimod.variables import Variables
 from dimod.vartypes import Vartype
@@ -1422,7 +1426,8 @@ class SampleSet(abc.Iterable, abc.Sized):
             # other
             "variable_labels": self.variables.to_serializable(),
             "variable_type": self.vartype.name,
-            "info": self.info,
+            "info": dfs_serialize_ndarray(self.info, use_bytes=use_bytes,
+                                          bytes_type=bytes_type),
             }
 
     def _asdict(self):
@@ -1513,7 +1518,7 @@ class SampleSet(abc.Iterable, abc.Sized):
         num_variables = obj['num_variables']
         variables = [tuple(v) if isinstance(v, list) else v
                      for v in obj["variable_labels"]]
-        info = obj['info']
+        info = dfs_deserialize_ndarray(obj['info'])
 
         # vectors
         vectors = {name: deserialize_ndarray(data)

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -37,8 +37,8 @@ from dimod.serialization.utils import (pack_samples,
                                        unpack_samples,
                                        serialize_ndarray,
                                        deserialize_ndarray,
-                                       dfs_serialize_ndarray,
-                                       dfs_deserialize_ndarray)
+                                       serialize_ndarrays,
+                                       deserialize_ndarrays)
 from dimod.utilities import LockableDict
 from dimod.variables import Variables
 from dimod.vartypes import Vartype
@@ -1426,7 +1426,7 @@ class SampleSet(abc.Iterable, abc.Sized):
             # other
             "variable_labels": self.variables.to_serializable(),
             "variable_type": self.vartype.name,
-            "info": dfs_serialize_ndarray(self.info, use_bytes=use_bytes,
+            "info": serialize_ndarrays(self.info, use_bytes=use_bytes,
                                           bytes_type=bytes_type),
             }
 
@@ -1518,7 +1518,7 @@ class SampleSet(abc.Iterable, abc.Sized):
         num_variables = obj['num_variables']
         variables = [tuple(v) if isinstance(v, list) else v
                      for v in obj["variable_labels"]]
-        info = dfs_deserialize_ndarray(obj['info'])
+        info = deserialize_ndarrays(obj['info'])
 
         # vectors
         vectors = {name: deserialize_ndarray(data)

--- a/dimod/serialization/utils.py
+++ b/dimod/serialization/utils.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 #
 # =============================================================================
+from numbers import Integral, Number
 
 try:
     import collections.abc as abc
@@ -92,9 +93,14 @@ def serialize_ndarrays(obj, use_bytes=False, bytes_type=bytes):
     if isinstance(obj, np.ndarray):
         return serialize_ndarray(obj, use_bytes=use_bytes, bytes_type=bytes_type)
     elif isinstance(obj, abc.Mapping):
-        return {key: serialize_ndarrays(val) for key, val in obj.items()}
+        return {serialize_ndarrays(key): serialize_ndarrays(val)
+                for key, val in obj.items()}
     elif isinstance(obj, abc.Sequence) and not isinstance(obj, string_types):
         return list(map(serialize_ndarrays, obj))
+    if isinstance(obj, Integral):
+        return int(obj)
+    elif isinstance(obj, Number):
+        return float(obj)
     return obj
 
 

--- a/dimod/serialization/utils.py
+++ b/dimod/serialization/utils.py
@@ -78,7 +78,16 @@ def deserialize_ndarray(obj):
 def serialize_ndarrays(obj, use_bytes=False, bytes_type=bytes):
     """Looks through the object, serializing numpy arrays.
 
-    Note: Does not check for recursive references.
+    Developer note: this function was written for serializing info fields
+    in the sample set and binary quadratic model objects. This is not a general
+    serialization function.
+
+    Notes:
+        Lists and dicts are copies in the returned object. Does not attempt to
+        only copy-on-write, even though that would be more performant.
+
+        Does not check for recursive references.
+
     """
     if isinstance(obj, np.ndarray):
         return serialize_ndarray(obj, use_bytes=use_bytes, bytes_type=bytes_type)
@@ -90,10 +99,7 @@ def serialize_ndarrays(obj, use_bytes=False, bytes_type=bytes):
 
 
 def deserialize_ndarrays(obj):
-    """Inverse of dfs_serialize_ndarray.
-
-    Note: Does not check for recursive references.
-    """
+    """Inverse of dfs_serialize_ndarray."""
     if isinstance(obj, abc.Mapping):
         if obj.get('type', '') == 'array':
             return deserialize_ndarray(obj)

--- a/dimod/serialization/utils.py
+++ b/dimod/serialization/utils.py
@@ -42,8 +42,9 @@ def serialize_ndarray(arr, use_bytes=False, bytes_type=bytes):
         data = bytes_type(arr.tobytes(order='C'))
     else:
         data = arr.tolist()
-    return dict(data=data,
-                type=arr.dtype.name,
+    return dict(type='array',
+                data=data,
+                data_type=arr.dtype.name,
                 shape=arr.shape,
                 use_bytes=bool(use_bytes))
 
@@ -60,9 +61,9 @@ def deserialize_ndarray(obj):
 
     """
     if obj['use_bytes']:
-        arr = np.frombuffer(obj['data'], dtype=obj['type'])
+        arr = np.frombuffer(obj['data'], dtype=obj['data_type'])
     else:
-        arr = np.asarray(obj['data'], dtype=obj['type'])
+        arr = np.asarray(obj['data'], dtype=obj['data_type'])
     arr = arr.reshape(obj['shape'])  # makes a view generally, but that's fine
     return arr
 

--- a/tests/test_serialization_json.py
+++ b/tests/test_serialization_json.py
@@ -101,6 +101,7 @@ class TestFunctional(unittest.TestCase):
     def test_info_field(self):
         bqm = dimod.BQM.empty('SPIN')
         bqm.info['a'] = np.ones((3, 3))
+        bqm.info[np.int64(5)] = np.float32(.9)
         obj = [bqm]
 
         new = json.loads(json.dumps(obj, cls=DimodEncoder), cls=DimodDecoder)

--- a/tests/test_serialization_json.py
+++ b/tests/test_serialization_json.py
@@ -98,6 +98,15 @@ class TestFunctional(unittest.TestCase):
         new = json.loads(json.dumps(obj, cls=DimodEncoder), cls=DimodDecoder)
         self.assertEqual(obj, new)
 
+    def test_info_field(self):
+        bqm = dimod.BQM.empty('SPIN')
+        bqm.info['a'] = np.ones((3, 3))
+        obj = [bqm]
+
+        new = json.loads(json.dumps(obj, cls=DimodEncoder), cls=DimodDecoder)
+
+        np.testing.assert_array_equal(new[0].info['a'], np.ones((3, 3)))
+
 
 @unittest.skipUnless(_simplejson, "simplejson is not installed")
 class TestSimpleJson(unittest.TestCase):

--- a/tests/test_serialization_utils.py
+++ b/tests/test_serialization_utils.py
@@ -1,0 +1,51 @@
+# Copyright 2019 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# =============================================================================
+
+import unittest
+
+import numpy as np
+
+from dimod.serialization.utils import serialize_ndarray, deserialize_ndarray
+
+
+class TestNdArraySerialization(unittest.TestCase):
+    def test_functional_empty(self):
+        arr = np.empty((0, 0))
+
+        obj = serialize_ndarray(arr)
+        new = deserialize_ndarray(obj)
+        np.testing.assert_array_equal(arr, new)
+        self.assertEqual(arr.dtype, new.dtype)
+
+        obj = serialize_ndarray(arr, use_bytes=True)
+        self.assertIsInstance(obj['data'], bytes)
+        new = deserialize_ndarray(obj)
+        np.testing.assert_array_equal(arr, new)
+        self.assertEqual(arr.dtype, new.dtype)
+
+    def test_functional_3x3triu(self):
+        arr = np.triu(np.ones((3, 3)))
+
+        obj = serialize_ndarray(arr)
+        new = deserialize_ndarray(obj)
+        np.testing.assert_array_equal(arr, new)
+        self.assertEqual(arr.dtype, new.dtype)
+
+        obj = serialize_ndarray(arr, use_bytes=True)
+        self.assertIsInstance(obj['data'], bytes)
+        new = deserialize_ndarray(obj)
+        np.testing.assert_array_equal(arr, new)
+        self.assertEqual(arr.dtype, new.dtype)


### PR DESCRIPTION
Created a more generic serialization for numpy arrays. This allows us to serialize the info field.

Slightly alters the serialization introduced in #511 