### PR TITLE
Remove jsonschema dependency

### DIFF
--- a/dimod/serialization/json.py
+++ b/dimod/serialization/json.py
@@ -55,7 +55,6 @@ import operator
 
 from functools import reduce
 
-import jsonschema
 import numpy as np
 
 from six import iteritems
@@ -308,13 +307,20 @@ def _unpack_record(obj, vartype):
     return record
 
 
+def _is_bqm_json_schema_v1(dct):
+    # replaces jsonschema.Draft4Validator(bqm_json_schema_v1).is_valid(dct)
+    # this function is obviously a lot less complete but since this is a
+    # deprecated format it's good enough for now
+    return all(field in dct for field in bqm_json_schema_v1["required"])
+
+
 def bqm_decode_hook(dct, cls=None):
     # deprecated
 
     if cls is None:
         cls = BinaryQuadraticModel
 
-    if jsonschema.Draft4Validator(bqm_json_schema_v1).is_valid(dct):
+    if _is_bqm_json_schema_v1(dct):
         # BinaryQuadraticModel
 
         linear = {_decode_label(obj['label']): obj['bias'] for obj in dct['linear_terms']}
@@ -328,13 +334,20 @@ def bqm_decode_hook(dct, cls=None):
     return dct
 
 
+def _is_sampleset_json_schema_v1(dct):
+    # replaces jsonschema.Draft4Validator(sampleset_json_schema_v1).is_valid(dct)
+    # this function is obviously a lot less complete but since this is a
+    # deprecated format it's good enough for now
+    return all(field in dct for field in sampleset_json_schema_v1["required"])
+
+
 def sampleset_decode_hook(dct, cls=None):
     # deprecated
 
     if cls is None:
         cls = SampleSet
 
-    if jsonschema.Draft4Validator(sampleset_json_schema_v1).is_valid(dct):
+    if _is_sampleset_json_schema_v1(dct):
         # SampleSet
 
         vartype = Vartype[dct['variable_type']]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ enum34==1.1.6; python_version<="3.3"
 numpy==1.15.0
 six==1.11.0
 futures; python_version=="2.7"
-jsonschema==2.6.0
 
 networkx==2.0
 pandas==0.23.4; python_version>="3.5"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ else:
 
 install_requires = ['numpy>=1.15.0,<2.0.0',
                     'six>=1.10.0,<2.0.0',
-                    'jsonschema>=2.6.0,<3.0.0']
+                    ]
 
 extras_require = {'all': ['networkx>=2.0,<3.0',
                           'pandas>=0.22.0,<0.23.0',


### PR DESCRIPTION
`jsonschema` was only used for a legacy serialisation method, since that functionality is deprecated it makes sense to remove the dependency.