### PR TITLE
Add offset and vartype properties to cybqm

### DIFF
--- a/dimod/bqm/adjarraybqm.pxd
+++ b/dimod/bqm/adjarraybqm.pxd
@@ -44,6 +44,8 @@ cdef class cyAdjArrayBQM:
     cdef vector[pair[size_t, Bias]] invars_
     cdef vector[pair[VarIndex, Bias]] outvars_
 
+    cdef public Bias offset
+
     cdef readonly object vartype
 
     cdef readonly object dtype

--- a/dimod/bqm/adjarraybqm.pxd
+++ b/dimod/bqm/adjarraybqm.pxd
@@ -44,8 +44,10 @@ cdef class cyAdjArrayBQM:
     cdef vector[pair[size_t, Bias]] invars_
     cdef vector[pair[VarIndex, Bias]] outvars_
 
-    cdef public object dtype
-    cdef public object index_dtype
+    cdef readonly object vartype
+
+    cdef readonly object dtype
+    cdef readonly object index_dtype
 
     # these are not public because the user has no way to access the underlying
     # variable indices

--- a/dimod/bqm/adjarraybqm.pyx
+++ b/dimod/bqm/adjarraybqm.pyx
@@ -88,25 +88,24 @@ cdef class cyAdjArrayBQM:
 
     This can be instantiated in several ways:
 
-        AdjVectorBQM()
+        AdjArrayBQM(vartype)
             Creates an empty binary quadratic model
 
-        AdjVectorBQM(n)
-            Where n is the number of nodes.
-
-        AdjVectorBQM((linear, [quadratic, [offset]]))
+        AdjArrayBQM((linear, [quadratic, [offset]]))
             Where linear, quadratic are:
                 dict[int, bias]
-                sequence[bias]
-            *NOT IMPLEMENTED YET*
+                sequence[bias]  *NOT IMPLEMENTED YET*
 
-        AdjVectorBQM(bqm)
+        AdjArrayBQM(bqm, vartype)
             Where bqm is another binary quadratic model (equivalent to
-            bqm.to_adjvector())
+            bqm.to_adjarray())
             *NOT IMPLEMENTED YET*
 
-        AdjVectorBQM(D)
+        AdjArrayBQM(D, vartype)
             Where D is a dense matrix D
+
+        AdjArrayBQM(n, vartype)
+            Where n is the number of nodes.
 
     """
 

--- a/dimod/bqm/adjarraybqm.pyx
+++ b/dimod/bqm/adjarraybqm.pyx
@@ -148,6 +148,7 @@ cdef class cyAdjArrayBQM:
             other = obj.to_adjarray()
             self.invars_ = other.invars_
             self.outvars_ = other.outvars_
+            self.offset = other.offset
             self._label_to_idx = other._label_to_idx
             self._idx_to_label = other._idx_to_label
         else:

--- a/dimod/bqm/adjarraybqm.pyx
+++ b/dimod/bqm/adjarraybqm.pyx
@@ -96,7 +96,7 @@ cdef class cyAdjArrayBQM:
                 dict[int, bias]
                 sequence[bias]  *NOT IMPLEMENTED YET*
 
-        AdjArrayBQM(bqm, vartype)
+        AdjArrayBQM(bqm)
             Where bqm is another binary quadratic model (equivalent to
             bqm.to_adjarray())
             *NOT IMPLEMENTED YET*

--- a/dimod/bqm/adjdictbqm.py
+++ b/dimod/bqm/adjdictbqm.py
@@ -47,9 +47,12 @@ class AdjDictBQM(ShapeableBQM):
 
         # handle the case where only vartype is given
         if vartype is None:
-            vartype = obj
-            obj = 0
-        self._vartype = as_vartype(vartype)  # map to correct type
+            try:
+                vartype = obj.vartype
+            except AttributeError:
+                vartype = obj
+                obj = 0
+        self._vartype = as_vartype(vartype)
 
         if isinstance(obj, Integral):
             adj.update((v, {v: dtype.type(0)}) for v in range(obj))

--- a/dimod/bqm/adjdictbqm.py
+++ b/dimod/bqm/adjdictbqm.py
@@ -24,6 +24,7 @@ from numbers import Integral
 import numpy as np
 
 from dimod.core.bqm import ShapeableBQM
+from dimod.vartypes import as_vartype
 
 __all__ = ['AdjDictBQM']
 
@@ -31,7 +32,7 @@ __all__ = ['AdjDictBQM']
 class AdjDictBQM(ShapeableBQM):
     """
     """
-    def __init__(self, obj=0):
+    def __init__(self, obj=0, vartype=None):
         # we could actually have these variable but to keep this consistent
         # with the other BQMs we fix them for now
         self.dtype = dtype = np.dtype(np.double)
@@ -43,6 +44,12 @@ class AdjDictBQM(ShapeableBQM):
         # with the dict which would be more performant but complicate the
         # implementation
         self._adj = adj = OrderedDict()
+
+        # handle the case where only vartype is given
+        if vartype is None:
+            vartype = obj
+            obj = 0
+        self._vartype = as_vartype(vartype)  # map to correct type
 
         if isinstance(obj, Integral):
             adj.update((v, {v: dtype.type(0)}) for v in range(obj))
@@ -97,6 +104,14 @@ class AdjDictBQM(ShapeableBQM):
     def num_interactions(self):
         """int: The number of interactions in the model."""
         return (sum(map(len, self._adj.values())) - len(self._adj)) // 2
+
+    @property
+    def vartype(self):
+        """:class:`.Vartype`: The vartype of the binary quadratic model. One of
+        :class:`.Vartype.SPIN` or :class:`.Vartype.BINARY`.
+        """
+        # so it's readonly
+        return self._vartype
 
     def add_variable(self, v=None):
         """Add a variable to the binary quadratic model.

--- a/dimod/bqm/adjdictbqm.py
+++ b/dimod/bqm/adjdictbqm.py
@@ -56,6 +56,8 @@ class AdjDictBQM(ShapeableBQM):
         elif isinstance(obj, tuple):
             if len(obj) == 2:
                 linear, quadratic = obj
+            elif len(obj) == 3:
+                linear, quadratic, self.offset = obj
             else:
                 raise ValueError()
 
@@ -104,6 +106,24 @@ class AdjDictBQM(ShapeableBQM):
     def num_interactions(self):
         """int: The number of interactions in the model."""
         return (sum(map(len, self._adj.values())) - len(self._adj)) // 2
+
+    @property
+    def offset(self):
+        try:
+            return self._offset
+        except AttributeError:
+            pass
+        self.offset = 0  # type coersion etc
+        return self.offset
+
+    @offset.setter
+    def offset(self, offset):
+        # we would actually like to use dtype:
+        # self._offset = self.dtype.type(offset)
+        # however, cython by default returns floats for our current bias type
+        # so to keep this consistent with the other bqms we return a python
+        # float
+        self._offset = float(offset)
 
     @property
     def vartype(self):

--- a/dimod/bqm/adjdictbqm.py
+++ b/dimod/bqm/adjdictbqm.py
@@ -153,7 +153,7 @@ class AdjDictBQM(ShapeableBQM):
 
         Examples:
 
-            >>> bqm = dimod.AdjDictBQM()
+            >>> bqm = dimod.AdjDictBQM('SPIN')
             >>> bqm.add_variable()
             0
             >>> bqm.add_variable('a')
@@ -161,7 +161,7 @@ class AdjDictBQM(ShapeableBQM):
             >>> bqm.add_variable()
             2
 
-            >>> bqm = dimod.AdjDictBQM()
+            >>> bqm = dimod.AdjDictBQM('SPIN')
             >>> bqm.add_variable(1)
             1
             >>> bqm.add_variable()  # 1 is taken

--- a/dimod/bqm/adjmapbqm.pxd
+++ b/dimod/bqm/adjmapbqm.pxd
@@ -33,6 +33,8 @@ ctypedef double Bias
 cdef class cyAdjMapBQM:
     cdef vector[pair[map[VarIndex, Bias], Bias]] adj_
 
+    cdef public Bias offset
+
     cdef readonly object vartype
 
     cdef readonly object dtype

--- a/dimod/bqm/adjmapbqm.pxd
+++ b/dimod/bqm/adjmapbqm.pxd
@@ -33,6 +33,8 @@ ctypedef double Bias
 cdef class cyAdjMapBQM:
     cdef vector[pair[map[VarIndex, Bias], Bias]] adj_
 
+    cdef readonly object vartype
+
     cdef readonly object dtype
     cdef readonly object index_dtype
 

--- a/dimod/bqm/adjmapbqm.pyx
+++ b/dimod/bqm/adjmapbqm.pyx
@@ -82,6 +82,8 @@ cdef class cyAdjMapBQM:
         elif isinstance(obj, tuple):
             if len(obj) == 2:
                 linear, quadratic = obj
+            elif len(obj) == 3:
+                linear, quadratic, self.offset = obj
             else:
                 raise ValueError()
 
@@ -412,6 +414,8 @@ cdef class cyAdjMapBQM:
             for outvar in self.adj_[u].first:
                 bqm.outvars_[outvar_idx] = outvar
                 outvar_idx += 1
+
+        bqm.offset = self.offset
 
         # set up the variable labels
         bqm._label_to_idx.update(self._label_to_idx)

--- a/dimod/bqm/adjmapbqm.pyx
+++ b/dimod/bqm/adjmapbqm.pyx
@@ -59,8 +59,11 @@ cdef class cyAdjMapBQM:
 
         # handle the case where only vartype is given
         if vartype is None:
-            vartype = obj
-            obj = 0
+            try:
+                vartype = obj.vartype
+            except AttributeError:
+                vartype = obj
+                obj = 0
         self.vartype = as_vartype(vartype)
 
         cdef Bias [:, :] D  # in case it's dense

--- a/dimod/bqm/adjmapbqm.pyx
+++ b/dimod/bqm/adjmapbqm.pyx
@@ -182,7 +182,7 @@ cdef class cyAdjMapBQM:
 
         Examples:
 
-            >>> bqm = dimod.AdjMapBQM()
+            >>> bqm = dimod.AdjMapBQM('SPIN')
             >>> bqm.add_variable()
             0
             >>> bqm.add_variable('a')
@@ -190,7 +190,7 @@ cdef class cyAdjMapBQM:
             >>> bqm.add_variable()
             2
 
-            >>> bqm = dimod.AdjMapBQM()
+            >>> bqm = dimod.AdjMapBQM('SPIN')
             >>> bqm.add_variable(1)
             1
             >>> bqm.add_variable()  # 1 is taken

--- a/dimod/bqm/adjvectorbqm.pxd
+++ b/dimod/bqm/adjvectorbqm.pxd
@@ -31,6 +31,8 @@ ctypedef double Bias
 cdef class cyAdjVectorBQM:
     cdef vector[pair[vector[pair[VarIndex, Bias]], Bias]] adj_
 
+    cdef public Bias offset
+
     cdef readonly object vartype
 
     cdef readonly object dtype

--- a/dimod/bqm/adjvectorbqm.pxd
+++ b/dimod/bqm/adjvectorbqm.pxd
@@ -31,6 +31,8 @@ ctypedef double Bias
 cdef class cyAdjVectorBQM:
     cdef vector[pair[vector[pair[VarIndex, Bias]], Bias]] adj_
 
+    cdef readonly object vartype
+
     cdef readonly object dtype
     cdef readonly object index_dtype
 

--- a/dimod/bqm/adjvectorbqm.pyx
+++ b/dimod/bqm/adjvectorbqm.pyx
@@ -32,6 +32,7 @@ from dimod.bqm.cppbqm cimport (num_variables, num_interactions,
                                add_variable, add_interaction,
                                pop_variable, remove_interaction)
 from dimod.core.bqm import ShapeableBQM
+from dimod.vartypes import as_vartype
 
 
 cdef class cyAdjVectorBQM:
@@ -48,7 +49,13 @@ cdef class cyAdjVectorBQM:
         self._label_to_idx = dict()
         self._idx_to_label = dict()
 
-    def __init__(self, object arg1=0):
+    def __init__(self, object obj=0, object vartype=None):
+
+        # handle the case where only vartype is given
+        if vartype is None:
+            vartype = obj
+            obj = 0
+        self.vartype = as_vartype(vartype)
 
         cdef Bias [:, :] D  # in case it's dense
         cdef size_t num_variables, i
@@ -56,18 +63,17 @@ cdef class cyAdjVectorBQM:
         cdef Bias b
         cdef VarIndex ui, vi
 
-
-        if isinstance(arg1, Integral):
-            if arg1 < 0:
+        if isinstance(obj, Integral):
+            if obj < 0:
                 raise ValueError
-            num_variables = arg1
+            num_variables = obj
             # we could do this in bulk with a resize but let's try using the
             # functions instead
             for i in range(num_variables):
                 add_variable(self.adj_)
-        elif isinstance(arg1, tuple):
-            if len(arg1) == 2:
-                linear, quadratic = arg1
+        elif isinstance(obj, tuple):
+            if len(obj) == 2:
+                linear, quadratic = obj
             else:
                 raise ValueError()
 
@@ -84,7 +90,7 @@ cdef class cyAdjVectorBQM:
                 raise NotImplementedError
         else:
             # assume it's dense
-            D = np.atleast_2d(np.asarray(arg1, dtype=self.dtype))
+            D = np.atleast_2d(np.asarray(obj, dtype=self.dtype))
 
             num_variables = D.shape[0]
 

--- a/dimod/bqm/adjvectorbqm.pyx
+++ b/dimod/bqm/adjvectorbqm.pyx
@@ -53,8 +53,11 @@ cdef class cyAdjVectorBQM:
 
         # handle the case where only vartype is given
         if vartype is None:
-            vartype = obj
-            obj = 0
+            try:
+                vartype = obj.vartype
+            except AttributeError:
+                vartype = obj
+                obj = 0
         self.vartype = as_vartype(vartype)
 
         cdef Bias [:, :] D  # in case it's dense

--- a/dimod/bqm/adjvectorbqm.pyx
+++ b/dimod/bqm/adjvectorbqm.pyx
@@ -74,6 +74,8 @@ cdef class cyAdjVectorBQM:
         elif isinstance(obj, tuple):
             if len(obj) == 2:
                 linear, quadratic = obj
+            elif len(obj) == 3:
+                linear, quadratic, self.offset = obj
             else:
                 raise ValueError()
 

--- a/dimod/vartypes.py
+++ b/dimod/vartypes.py
@@ -100,15 +100,20 @@ def as_vartype(vartype):
 
     try:
         if isinstance(vartype, str):
-            vartype = Vartype[vartype]
+            vartype = Vartype[vartype]  # raises KeyError
         elif isinstance(vartype, frozenset):
-            vartype = Vartype(vartype)
+            vartype = Vartype(vartype)  # raise ValueError
         else:
+            # raises ValueError if not a bqm
+            # raises TypeError if not iterable
             vartype = Vartype(frozenset(vartype))
+    except (ValueError, KeyError, TypeError):
+        # avoid the "During handling of the above exception..." message that
+        # removes the full traceback
+        pass
+    else:
+        return vartype
 
-    except (ValueError, KeyError):
-        raise TypeError(("expected input vartype to be one of: "
-                         "Vartype.SPIN, 'SPIN', {-1, 1}, "
-                         "Vartype.BINARY, 'BINARY', or {0, 1}."))
-
-    return vartype
+    raise TypeError(("expected input vartype to be one of: "
+                     "Vartype.SPIN, 'SPIN', {-1, 1}, "
+                     "Vartype.BINARY, 'BINARY', or {0, 1}."))

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -22,6 +22,8 @@ from collections import OrderedDict
 
 import numpy as np
 
+import dimod
+
 
 class TestBQMAPI:
     """
@@ -29,11 +31,37 @@ class TestBQMAPI:
     """
 
     def test__len__(self):
-        bqm = self.BQM(np.ones((107, 107)))
+        bqm = self.BQM(np.ones((107, 107)), dimod.BINARY)
         self.assertEqual(len(bqm), 107)
 
+    def test_construction_args(self):
+        # make sure all the orderes are ok
+
+        with self.assertRaises(TypeError):
+            self.BQM()
+
+        bqm = self.BQM('SPIN')
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+        self.assertEqual(bqm.shape, (0, 0))
+
+        bqm = self.BQM(vartype='SPIN')
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+        self.assertEqual(bqm.shape, (0, 0))
+
+        bqm = self.BQM(5, 'SPIN')
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+        self.assertEqual(bqm.shape, (5, 0))
+
+        bqm = self.BQM(5, vartype='SPIN')
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+        self.assertEqual(bqm.shape, (5, 0))
+
+        bqm = self.BQM(vartype='SPIN', obj=5)
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+        self.assertEqual(bqm.shape, (5, 0))
+
     def test_construction_symmetric(self):
-        bqm = self.BQM(np.ones((5, 5)))
+        bqm = self.BQM(np.ones((5, 5)), 'BINARY')
         for u, v in itertools.combinations(range(5), 2):
             self.assertEqual(bqm.get_quadratic(u, v), 2)  # added
         for u in range(5):
@@ -46,14 +74,14 @@ class TestBQMAPI:
     #         self.assertEqual(bqm.get_linear(u), 0)
 
     def test_get_linear_disconnected_string_labels(self):
-        bqm = self.BQM(({'a': -1, 'b': 1}, {}))
+        bqm = self.BQM(({'a': -1, 'b': 1}, {}), dimod.BINARY)
         self.assertEqual(bqm.get_linear('a'), -1)
         self.assertEqual(bqm.get_linear('b'), 1)
         with self.assertRaises(ValueError):
             bqm.get_linear('c')
 
     def test_get_linear_disconnected(self):
-        bqm = self.BQM(5)
+        bqm = self.BQM(5, dimod.SPIN)
 
         for v in range(5):
             self.assertEqual(bqm.get_linear(v), 0)
@@ -65,7 +93,7 @@ class TestBQMAPI:
             bqm.get_linear(5)
 
     def test_get_quadratic_3x3array(self):
-        bqm = self.BQM([[0, 1, 2], [0, 0.5, 0], [0, 0, 1]])
+        bqm = self.BQM([[0, 1, 2], [0, 0.5, 0], [0, 0, 1]], dimod.SPIN)
 
         self.assertEqual(bqm.get_quadratic(0, 1), 1)
         self.assertEqual(bqm.get_quadratic(1, 0), 1)
@@ -84,7 +112,7 @@ class TestBQMAPI:
     def test_has_variable(self):
         h = OrderedDict([('a', -1), (1, -1), (3, -1)])
         J = {}
-        bqm = self.BQM((h, J))
+        bqm = self.BQM((h, J), dimod.SPIN)
 
         self.assertTrue(bqm.has_variable('a'))
         self.assertTrue(bqm.has_variable(1))
@@ -97,13 +125,13 @@ class TestBQMAPI:
     def test_iter_variables(self):
         h = OrderedDict([('a', -1), (1, -1), (3, -1)])
         J = {}
-        bqm = self.BQM((h, J))
+        bqm = self.BQM((h, J), dimod.SPIN)
 
         self.assertEqual(list(bqm.iter_variables()), ['a', 1, 3])
 
     def test_set_linear(self):
         # does not change shape
-        bqm = self.BQM(np.triu(np.ones((3, 3))))
+        bqm = self.BQM(np.triu(np.ones((3, 3))), dimod.BINARY)
 
         self.assertEqual(bqm.get_linear(0), 1)
         bqm.set_linear(0, .5)
@@ -111,7 +139,7 @@ class TestBQMAPI:
 
     def test_set_quadratic(self):
         # does not change shape
-        bqm = self.BQM(np.triu(np.ones((3, 3))))
+        bqm = self.BQM(np.triu(np.ones((3, 3))), dimod.BINARY)
 
         self.assertEqual(bqm.get_quadratic(0, 1), 1)
         bqm.set_quadratic(0, 1, .5)
@@ -122,38 +150,62 @@ class TestBQMAPI:
         self.assertEqual(bqm.get_quadratic(1, 0), -.5)
 
     def test_shape_3x3array(self):
-        bqm = self.BQM([[0, 1, 2], [0, 0.5, 0], [0, 0, 1]])
+        bqm = self.BQM([[0, 1, 2], [0, 0.5, 0], [0, 0, 1]], dimod.BINARY)
 
         self.assertEqual(bqm.shape, (3, 2))
         self.assertEqual(bqm.num_variables, 3)
         self.assertEqual(bqm.num_interactions, 2)
 
     def test_shape_disconnected(self):
-        bqm = self.BQM(5)
+        bqm = self.BQM(5, dimod.BINARY)
 
         self.assertEqual(bqm.shape, (5, 0))
         self.assertEqual(bqm.num_variables, 5)
         self.assertEqual(bqm.num_interactions, 0)
 
     def test_shape_empty(self):
-        self.assertEqual(self.BQM().shape, (0, 0))
-        self.assertEqual(self.BQM(0).shape, (0, 0))
+        self.assertEqual(self.BQM(dimod.SPIN).shape, (0, 0))
+        self.assertEqual(self.BQM(0, dimod.SPIN).shape, (0, 0))
 
-        self.assertEqual(self.BQM().num_variables, 0)
-        self.assertEqual(self.BQM(0).num_variables, 0)
+        self.assertEqual(self.BQM(dimod.SPIN).num_variables, 0)
+        self.assertEqual(self.BQM(0, dimod.SPIN).num_variables, 0)
 
-        self.assertEqual(self.BQM().num_interactions, 0)
-        self.assertEqual(self.BQM(0).num_interactions, 0)
+        self.assertEqual(self.BQM(dimod.SPIN).num_interactions, 0)
+        self.assertEqual(self.BQM(0, dimod.SPIN).num_interactions, 0)
+
+    def test_vartype(self):
+        bqm = self.BQM(vartype='SPIN')
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+
+        bqm = self.BQM(vartype=dimod.SPIN)
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+
+        bqm = self.BQM(vartype=(-1, 1))
+        self.assertEqual(bqm.vartype, dimod.SPIN)
+
+        bqm = self.BQM(vartype='BINARY')
+        self.assertEqual(bqm.vartype, dimod.BINARY)
+
+        bqm = self.BQM(vartype=dimod.BINARY)
+        self.assertEqual(bqm.vartype, dimod.BINARY)
+
+        bqm = self.BQM(vartype=(0, 1))
+        self.assertEqual(bqm.vartype, dimod.BINARY)
+
+    def test_vartype_readonly(self):
+        bqm = self.BQM(vartype='SPIN')
+        with self.assertRaises(AttributeError):
+            bqm.vartype = dimod.BINARY
 
 
 class TestShapeableBQMAPI(TestBQMAPI):
     def test_add_variable_exception(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         with self.assertRaises(TypeError):
             bqm.add_variable([])
 
     def test_add_variable_labelled(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         bqm.add_variable('a')
         bqm.add_variable(1)
         self.assertEqual(bqm.shape, (2, 0))
@@ -163,7 +215,7 @@ class TestShapeableBQMAPI(TestBQMAPI):
         self.assertEqual(list(bqm.iter_variables()), ['a', 1, 2])
 
     def test_add_variable_int_labelled(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         self.assertEqual(bqm.add_variable(1), 1)
         self.assertEqual(bqm.add_variable(), 0)  # 1 is already taken
         self.assertEqual(bqm.shape, (2, 0))
@@ -171,14 +223,14 @@ class TestShapeableBQMAPI(TestBQMAPI):
         self.assertEqual(bqm.shape, (3, 0))
 
     def test_add_variable_unlabelled(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         bqm.add_variable()
         bqm.add_variable()
         self.assertEqual(bqm.shape, (2, 0))
         self.assertEqual(list(bqm.iter_variables()), [0, 1])
 
     def test_pop_variable_labelled(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         bqm.add_variable('a')
         bqm.add_variable(1)
         bqm.add_variable(0)
@@ -189,14 +241,14 @@ class TestShapeableBQMAPI(TestBQMAPI):
             bqm.pop_variable()
 
     def test_pop_variable_unlabelled(self):
-        bqm = self.BQM(2)
+        bqm = self.BQM(2, dimod.BINARY)
         self.assertEqual(bqm.pop_variable(), 1)
         self.assertEqual(bqm.pop_variable(), 0)
         with self.assertRaises(ValueError):
             bqm.pop_variable()
 
     def test_remove_interaction(self):
-        bqm = self.BQM(np.triu(np.ones((3, 3))))
+        bqm = self.BQM(np.triu(np.ones((3, 3))), dimod.BINARY)
         self.assertTrue(bqm.remove_interaction(0, 1))
         self.assertFalse(bqm.remove_interaction(0, 1))
         self.assertEqual(bqm.shape, (3, 2))
@@ -204,7 +256,7 @@ class TestShapeableBQMAPI(TestBQMAPI):
             bqm.get_quadratic(0, 1)
 
     def test_set_quadratic_exception(self):
-        bqm = self.BQM()
+        bqm = self.BQM(dimod.SPIN)
         with self.assertRaises(TypeError):
             bqm.set_quadratic([], 1, .5)
         with self.assertRaises(TypeError):

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -129,6 +129,24 @@ class TestBQMAPI:
 
         self.assertEqual(list(bqm.iter_variables()), ['a', 1, 3])
 
+    def test_offset(self):
+        h = dict([('a', -1), (1, -1), (3, -1)])
+        J = {}
+        bqm = self.BQM((h, J), 'SPIN')
+        self.assertEqual(bqm.offset, 0)
+        # cython does not easily allow us to return numpy types
+        # self.assertIsInstance(bqm.offset, bqm.dtype.type)
+
+        h = dict([('a', -1), (1, -1), (3, -1)])
+        J = {}
+        bqm = self.BQM((h, J, 1.5), 'SPIN')
+        self.assertEqual(bqm.offset, 1.5)
+        # self.assertIsInstance(bqm.offset, bqm.dtype.type)
+
+        bqm.offset = 6
+        self.assertEqual(bqm.offset, 6)
+        # self.assertIsInstance(bqm.offset, bqm.dtype.type)
+
     def test_set_linear(self):
         # does not change shape
         bqm = self.BQM(np.triu(np.ones((3, 3))), dimod.BINARY)


### PR DESCRIPTION
Construction now looks like
```
bqm = BQM(dimod.BINARY)  # empty
bqm = BQM(np.ones((5, 5)), dimod.BINARY)
bqm = BQM((h, J), dimod.SPIN)
bqm = BQM((h, J, offset), dimod.SPIN)
bqm = BQM(5, dimod.BINARY)  # 5 variables, 0 interactions
```