### PR TITLE
Features/extended roof duality

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -1174,12 +1174,12 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         if not ignore_info:
             self.info.update(bqm.info)
 
-    def contract_variables(self, u, v, uv_equal=True):
+    def contract_variables(self, u, v, equal=True):
         """Enforce u, v being the same variable in a binary quadratic model.
 
-        The resulting variable is labeled 'u'. Values of interactions between `v` and
-        variables that `u` interacts with are added to the corresponding interactions
-        of `u`.
+        The resulting variable is labeled 'u'. Values of interactions between
+        `v` and variables that `u` interacts with are added to the corresponding
+        interactions of `u`.
 
         Args:
             u (variable):
@@ -1188,18 +1188,13 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
             v (variable):
                 Variable in the binary quadratic model.
 
-            uv_equal (bool, optional, default=True):
+            equal (bool, optional, default=True):
                 Indicates if u and v take the same or opposite values.
-                If uv_equal=True, then u=v. If uv_equal=False, then u=-v for spins and u=1-v for binary.
+                If equal, then `u==v`, otherwise `u=-v` for spins and `u=1-v`
+                for binary.
 
         Examples:
-           This example creates a binary quadratic model representing the K4 complete graph
-           and contracts node (variable) 3 into node 2. The interactions between
-           3 and its neighbors 1 and 4 are added to the corresponding interactions
-           between 2 and those same neighbors.
 
-           >>> import dimod
-           ...
            >>> linear = {1: 1, 2: 2, 3: 3, 4: 4}
            >>> quadratic = {(1, 2): 12, (1, 3): 13, (1, 4): 14,
            ...              (2, 3): 23, (2, 4): 24,
@@ -1215,16 +1210,19 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         adj = self.adj
 
         if u not in adj:
-            raise ValueError("{} is not a variable in the binary quadratic model".format(u))
+            msg = "{} is not a variable in the binary quadratic model"
+            raise ValueError(msg.format(u))
         if v not in adj:
-            raise ValueError("{} is not a variable in the binary quadratic model".format(v))
+            msg = "{} is not a variable in the binary quadratic model"
+            raise ValueError(msg.format(v))
 
-        sign = 1 if uv_equal else -1
+        sign = 1 if equal else -1
 
-        # if there is an interaction between u, v it becomes linear for u plus an offset
+        # if there is an interaction between u, v it becomes linear for u plus
+        # an offset
         if v in adj[u]:
             if self.vartype is Vartype.BINARY:
-                if uv_equal:
+                if equal:
                     self.add_variable(u, adj[u][v])
             elif self.vartype is Vartype.SPIN:
                 self.add_offset(sign * adj[u][v])
@@ -1236,34 +1234,31 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
         neighbors = list(adj[v])
         for w in neighbors:
             self.add_interaction(u, w, sign * adj[v][w])
-            if self.vartype is Vartype.BINARY and not uv_equal:
+            if self.vartype is Vartype.BINARY and not equal:
                 self.add_variable(w, adj[v][w])
             self.remove_interaction(v, w)
 
         # finally remove v
         self.add_variable(u, sign * self.linear[v])
-        if self.vartype is Vartype.BINARY and not uv_equal:
+        if self.vartype is Vartype.BINARY and not equal:
             self.add_offset(self.linear[v])
         self.remove_variable(v)
 
-    def contract_all_variables(self, contractible_variables):
+    def contract_variables_from(self, contractible):
         """Contract all pairs of variables in a list.
 
-        Input:
-            bqm: a BinaryQuadraticModel.
-
-            contractible_variables: a dictionary with keys (x,y) and values indicating the sign of the contraction: +1
-                indicates x=y and -1 indicates x=~y.
+        Args:
+            contractible (iterable/mapping):
+                An iterable of pairs of variables to be contracted. If a
+                mapping, the keys should be pairs of variables and the values
+                should indicate whether they are equal or not.
 
         Returns:
-            variable_map: a dictionary indicating variable contractions that took place.
-                variable_map[u] = (v, sign) indicates that variable u was contracted to variable v, with u=v if sign=1
-                and u=~v if sign=-1.
+            dict: The contractions that took place.
+            For `variable_map[u] = (v, equal)`, variable `u` was contracted to
+            variable `v`, with `u==v` if `equal` and `u!=v` otherwise.
 
         """
-
-        # variable_map[u] = (v, uv_equal), where v is the variable u is mapped to, and uv_equal = (u==v).
-        # inverse_map[u] is the set of variables mapped to u.
         variable_map = {u: (u, True) for u in self.variables}
         inverse_map = {u: [u] for u in self.variables}
 
@@ -1276,7 +1271,13 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
                 inverse_map[u].append(x)
             inverse_map[v] = []
 
-        for (u, v), uv_equal in contractible_variables.items():
+        if isinstance(contractible, abc.Mapping):
+            contractions = contractible.items()
+        else:
+            # assume it's a sequence
+            contractions = ((uv, True) for uv in contractible)
+
+        for (u, v), uv_equal in contractions:
             new_u, u_equal = variable_map[u]
             new_v, v_equal = variable_map[v]
             if new_u != new_v:
@@ -1285,7 +1286,6 @@ class BinaryQuadraticModel(abc.Sized, abc.Container, abc.Iterable):
                 update_maps(new_u, new_v, new_uv_equal)
 
         return variable_map
-
 
 ###################################################################################################
 # transformations

--- a/dimod/reference/composites/__init__.py
+++ b/dimod/reference/composites/__init__.py
@@ -16,7 +16,7 @@
 
 from dimod.reference.composites.fixedvariable import FixedVariableComposite
 from dimod.reference.composites.higherordercomposites import *
-from dimod.reference.composites.roofduality import RoofDualityComposite
+from dimod.reference.composites.roofduality import RoofDualityComposite, ExtendedRoofDualityComposite
 from dimod.reference.composites.scalecomposite import *
 from dimod.reference.composites.spin_transform import *
 from dimod.reference.composites.structure import *

--- a/dimod/reference/composites/roofduality.py
+++ b/dimod/reference/composites/roofduality.py
@@ -27,8 +27,10 @@ sampler.
 
 from dimod.reference.composites.fixedvariable import FixedVariableComposite
 from dimod.roof_duality import fix_variables
+from dimod.roof_duality.extended_fix_variables import find_and_contract_all_variables_roof_duality, uncontract_solution
+from dimod.core.composite import ComposedSampler
 
-__all__ = ['RoofDualityComposite']
+__all__ = ['RoofDualityComposite', 'ExtendedRoofDualityComposite']
 
 
 class RoofDualityComposite(FixedVariableComposite):
@@ -77,3 +79,85 @@ class RoofDualityComposite(FixedVariableComposite):
         # use roof-duality to decide which variables to fix
         parameters['fixed_variables'] = fix_variables(bqm, sampling_mode=sampling_mode)
         return super(RoofDualityComposite, self).sample(bqm, **parameters)
+
+
+class ExtendedRoofDualityComposite(ComposedSampler):
+    """Uses extended roof duality to assign some variables before invoking child sampler.
+
+    Uses the :func:`~dimod.roof_duality.find_and_contract_all_variables_roof_duality` function to determine
+    variable assignments, then fixes them before calling the child sampler. Variables may be fixed to values or to
+    other variables.
+    Returned samples include all original variables.
+    Extended roof duality can potentially fix more variables than roof duality, but it can also be significantly slower.
+
+    Args:
+       child (:obj:`dimod.Sampler`):
+            A dimod sampler. Used to sample the bqm after variables have been
+            fixed.
+
+    """
+
+
+    def __init__(self, child_sampler):
+        self._children = [child_sampler]
+
+    @property
+    def children(self):
+        return self._children
+
+    @property
+    def parameters(self):
+        params = self.child.parameters.copy()
+        params['sampling_mode'] = []
+        return params
+
+    @property
+    def properties(self):
+        return {'child_properties': self.child.properties.copy()}
+
+
+    def sample(self, bqm, sampling_mode=True, **parameters):
+        """Sample from the provided binary quadratic model.
+
+        Uses the :func:`~dimod.roof_duality.find_and_contract_all_variables_roof_duality` function to determine
+        which variables to fix.
+
+        Args:
+            bqm (:obj:`dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from.
+
+            sampling_mode (bool, optional, default=True):
+                In sampling mode, only roof-duality is used. When
+                `sampling_mode` is false, strongly connected components are used
+                to fix more variables, but in some optimal solutions these
+                variables may take different values.
+
+            **parameters:
+                Parameters for the child sampler.
+
+        Returns:
+            :obj:`dimod.SampleSet`
+
+        """
+
+        # use extended roof duality to decide which variables to fix and contract
+        bqm_small, variable_map, fixed_variables = find_and_contract_all_variables_roof_duality(bqm,
+                                                                                            sampling_mode=sampling_mode)
+
+        # solve the problem on the child system
+        sampleset_small = self.child.sample(bqm_small, **parameters)
+
+        # add fixed variables back in
+        if len(sampleset_small):
+            sampleset = sampleset_small.append_variables(fixed_variables)
+        elif fixed_variables:
+            sampleset = type(sampleset_small).from_samples_bqm(fixed_variables, bqm=bqm)
+        else:
+            # no fixed variables and sampleset is empty
+            sampleset = sampleset_small
+
+        # uncontract variables.
+        return uncontract_solution(sampleset, variable_map)
+
+
+

--- a/dimod/reference/composites/roofduality.py
+++ b/dimod/reference/composites/roofduality.py
@@ -27,7 +27,7 @@ sampler.
 
 from dimod.reference.composites.fixedvariable import FixedVariableComposite
 from dimod.roof_duality import fix_variables
-from dimod.roof_duality.extended_fix_variables import find_and_contract_all_variables_roof_duality, uncontract_solution
+from dimod.roof_duality.extended_fix_variables import find_and_contract_all_variables_roof_duality, uncontract_sampleset
 from dimod.core.composite import ComposedSampler
 
 __all__ = ['RoofDualityComposite', 'ExtendedRoofDualityComposite']
@@ -157,7 +157,7 @@ class ExtendedRoofDualityComposite(ComposedSampler):
             sampleset = sampleset_small
 
         # uncontract variables.
-        return uncontract_solution(sampleset, variable_map)
+        return uncontract_sampleset(sampleset, variable_map)
 
 
 

--- a/dimod/roof_duality/__init__.py
+++ b/dimod/roof_duality/__init__.py
@@ -14,3 +14,5 @@
 #
 # ================================================================================================
 from dimod.roof_duality.fix_variables import *
+from dimod.roof_duality.extended_fix_variables import find_and_contract_all_variables_roof_duality, \
+    uncontract_solution, find_contractible_variables_roof_duality

--- a/dimod/roof_duality/__init__.py
+++ b/dimod/roof_duality/__init__.py
@@ -14,5 +14,4 @@
 #
 # ================================================================================================
 from dimod.roof_duality.fix_variables import *
-from dimod.roof_duality.extended_fix_variables import find_and_contract_all_variables_roof_duality, \
-    uncontract_solution, find_contractible_variables_roof_duality
+from dimod.roof_duality.extended_fix_variables import *

--- a/dimod/roof_duality/extended_fix_variables.py
+++ b/dimod/roof_duality/extended_fix_variables.py
@@ -80,7 +80,7 @@ def find_and_contract_all_variables_naive(bqm):
         if len(contractible_variables):
             # found something to contract.
             finished = False
-            new_map = bqm2.contract_all_variables(contractible_variables)
+            new_map = bqm2.contract_variables_from(contractible_variables)
             variable_map = {u: (new_map[v][0], new_map[v][1] == uv_equal) for u, (v, uv_equal) in variable_map.items()}
 
     return bqm2, variable_map
@@ -219,7 +219,7 @@ def find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True):
                 if len(contractible_variables):
                     # found something to contract.
                     finished = False
-                    new_map = bqm2.contract_all_variables(contractible_variables)
+                    new_map = bqm2.contract_variables_from(contractible_variables)
                     variable_map = {u: (new_map[v][0], new_map[v][1] == uv_equal) for u, (v, uv_equal) in
                                     variable_map.items()}
 

--- a/dimod/roof_duality/extended_fix_variables.py
+++ b/dimod/roof_duality/extended_fix_variables.py
@@ -1,0 +1,224 @@
+import numpy as np
+import dimod
+from dimod.vartypes import Vartype
+
+
+def find_contractible_variables_naive(bqm):
+    """
+    Given a bqm, find pairs of variables (x, y) such that ground states satisfy x=y (or x = ~y).
+
+    Input:
+        bqm: a BinaryQuadraticModel.
+
+    Returns:
+        contractible_variables: a dictionary with keys (x,y) and values True if x=y and False if x=-y in the ground
+        states.
+
+    Method: if the magnitude of an interaction J_xy is larger than the magnitude of the sum of the magnitudes of the
+    other couplers and bias of either x or y, then x and y should be fixed.
+    """
+
+    # Use the spin version
+    bqm = bqm.spin
+
+    contractible_variables = dict()
+    magnitudes = dict()
+    for x, neighbours in bqm.adj.items():
+        magnitudes[x] = sum([np.abs(j) for j in neighbours.values()])
+        if x in bqm.linear.keys():
+            magnitudes[x] += np.abs(bqm.linear[x])
+
+    for (x, y), val in bqm.quadratic.items():
+        if np.abs(val) > min(magnitudes[x], magnitudes[y]) - np.abs(val):
+            # value in contractible_variables is True if x=y, False if x=-y.
+            contractible_variables[(x, y)] = np.sign(val) < 0
+
+    return contractible_variables
+
+
+def find_and_contract_all_variables_naive(bqm):
+    """
+    Given a bqm, naively find pairs of variables (x, y) such that ground states satisfy x=y (or x = ~y) and contract
+    them, repeating until no further contractions are possible.
+
+    Input:
+        bqm: a BinaryQuadraticModel.
+
+    Returns:
+        bqm2: a BinaryQuadraticModel with variables contracted.
+
+        variable_map: a dictionary indicating variable contractions that took place.
+            variable_map[u] = (v, uv_equal) indicates that variable u was contracted to variable v, with u=v if
+            uv_equal=1 and u=~v otherwise.
+
+    """
+
+    bqm2 = bqm.copy()
+    variable_map = {u: (u, True) for u in bqm2.linear}
+    finished = False
+    while not finished:
+
+        finished = True
+        contractible_variables = find_contractible_variables_naive(bqm2)
+
+        if len(contractible_variables):
+            # found something to contract.
+            finished = False
+            new_map = bqm2.contract_all_variables(contractible_variables)
+            variable_map = {u: (new_map[v][0], new_map[v][1] == uv_equal) for u, (v, uv_equal) in variable_map.items()}
+
+    return bqm2, variable_map
+
+
+def find_contractible_variables_roof_duality(bqm, sampling_mode=True, vars_to_test=None):
+    """
+    Given a bqm, find pairs of variables (x, y) such that ground states satisfy x=y (or x = ~y) by "extended roof
+    duality".
+
+
+    Args:
+        bqm (:obj:`.BinaryQuadraticModel`)
+            A binary quadratic model.
+
+        sampling_mode (bool, optional, default=True):
+            In sampling mode, only roof-duality is used. When `sampling_mode` is false, strongly
+            connected components are used to fix more variables, but in some optimal solutions
+            these variables may take different values.
+
+        vars_to_test (list, optional, default=None):
+            List of variables to probe. If not provided, all variables are tested.
+
+    Returns:
+        contractible_variables: a dictionary with keys (x,y) and values True if x=y and False if x=-y in the ground
+        states.
+
+        fixable_variables: a dictionary of variable assignments that can be fixed in the ground states.
+
+    Method: pick a variable x, and probe it by fixing to both 1 and then -1. Run roof duality on both of these
+    smaller problems. If y gets fixed in both smaller problems, we can fix y (to x, ~x, 1, or -1).
+    Details are described in https://pub.ist.ac.at/~vnk/papers/RKLS-CVPR07.pdf.
+
+    This implementation is very simple and inefficient. It seems that there are several open source implementations
+    available, all of which wrap Kolmogorov's original roof duality implementation. (For example, opengm.)
+    """
+
+    if vars_to_test is None:
+        # test all vars.
+        vars_to_test = bqm.variables
+
+    not_one = -1 if bqm.vartype == Vartype.SPIN else 0
+
+    contractible_variables = dict()
+    fixable_variables = dict()
+    for x in vars_to_test:
+        bqm2 = bqm.copy()
+        bqm2.fix_variable(x, 1)
+        fixed_vars = dimod.roof_duality.fix_variables(bqm2, sampling_mode=sampling_mode)
+        if fixed_vars:
+            bqm2 = bqm.copy()
+            bqm2.fix_variable(x, not_one)
+            fixed_vars_2 = dimod.roof_duality.fix_variables(bqm2, sampling_mode=sampling_mode)
+            for y in fixed_vars_2:
+                if y in fixed_vars and (y, x) not in contractible_variables and y not in fixable_variables:
+                    if fixed_vars[y] == fixed_vars_2[y]:
+                        # in this case y should simply be fixed to its value.
+                        fixable_variables[y] = fixed_vars[y]
+                    # otherwise, y is fixed to x or ~x.
+                    contractible_variables[(x, y)] = (fixed_vars[y] == 1)
+
+    return contractible_variables, fixable_variables
+
+
+def find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True):
+    """
+    Given a bqm, find all pairs of variables (x, y) such that ground states satisfy x=y (or x = ~y) by "extended roof
+    duality" and contract them, repeating until no further contractions are possible.
+
+    Input:
+        bqm: a BinaryQuadraticModel.
+
+        sampling_mode: boolean indicating if variables are contractible for all ground states (sampling_mode=True) or
+            some ground state (sampling_mode=False).
+
+    Returns:
+        bqm2: a BinaryQuadraticModel with variables contracted.
+
+        variable_map: a dictionary indicating variable contractions that took place.
+            variable_map[u] = (v, uv_equal) indicates that variable u was contracted to variable v, with u=v if
+            uv_equal=1 and u=~v otherwise.
+
+        fixable_variables: a dictionary of variable assignments that were fixed in the ground states.
+
+    Method: pick a variable to probe by extended roof duality, and if it contractible, contract it right away.
+    Repeat until no contractions are possible.
+    (When there are many contractible variables, this method is much faster than first identifying all contractible
+    variables, contracting them, and repeating.)
+
+    Note: it is possible to modify the roof duality algorithm to incorporate probing more directly, which would
+    accompligh the same thing as this function but be a lot faster. See:
+    https://pub.ist.ac.at/~vnk/papers/RKLS-CVPR07.pdf, section 3.1.1.
+    """
+
+    bqm2 = bqm.copy()
+    variable_map = {u: (u, True) for u in bqm2.linear}
+    fixed_variables = dict()
+    finished = False
+    while not finished:
+        finished = True
+        # choose a good variable order: order by size of interaction magnitude.
+        max_e = {v: max(abs(e) for e in nbrs.values()) if nbrs else 0 for v, nbrs in bqm.adj.items()}
+        all_vars = sorted(max_e.items(), key=lambda k: -k[1])
+        all_vars = [k for k, v in all_vars]   # variables only
+        for x in all_vars:
+            if x in bqm2.variables:
+                contractible_variables, fixable_variables = \
+                    find_contractible_variables_roof_duality(bqm2, sampling_mode=sampling_mode, vars_to_test=[x])
+
+                if len(fixed_variables):
+                    # found something to fix.
+                    bqm2.fix_variables(fixable_variables)
+                    fixed_variables.update(fixable_variables)
+
+                if len(contractible_variables):
+                    # found something to contract.
+                    finished = False
+                    new_map = bqm2.contract_all_variables(contractible_variables)
+                    variable_map = {u: (new_map[v][0], new_map[v][1] == uv_equal) for u, (v, uv_equal) in
+                                    variable_map.items()}
+
+    return bqm2, variable_map, fixed_variables
+
+
+def uncontract_solution(sampleset, variable_map):
+    """Translation solutions to a contracted bqm into solutions for an uncontracted bqm.
+
+    Input:
+        sampleset: a dimod.SampleSet for the contracted bqm.
+
+        variable_map: a dictionary indicating variable contractions that took place.
+            variable_map[u] = (v, uv_equal) indicates that variable u was contracted to variable v, with u=v if
+            uv_equal=1 and u=~v otherwise.
+
+    Returns:
+        new_sampleset: a dimod.SampleSet for the uncontracted bqm.
+
+
+    Note: This should probably be turned into a composite layer.
+    """
+
+    if sampleset.vartype != Vartype.SPIN:
+        raise NotImplementedError
+
+    samples, labels = dimod.sampleset.as_samples(sampleset)
+    new_labels = list(variable_map.keys())
+    new_samples = np.zeros((samples.shape[0], len(variable_map)))
+    label_index = {v: labels.index(v) for v in labels}
+    for i, sample in enumerate(samples):
+        if sampleset.vartype == Vartype.SPIN:
+            new_samples[i] = [sample[label_index[v]]*(2*uv_equal - 1) for u, (v, uv_equal) in variable_map.items()]
+        else:
+            new_samples[i] = [int(sample[label_index[v]] == uv_equal) for u, (v, uv_equal) in variable_map.items()]
+
+    new_sampleset = dimod.sampleset.SampleSet.from_samples((new_samples, new_labels), vartype=Vartype.SPIN,
+                                                           **sampleset.data_vectors)
+    return new_sampleset

--- a/dimod/roof_duality/extended_fix_variables.py
+++ b/dimod/roof_duality/extended_fix_variables.py
@@ -51,6 +51,22 @@ def find_and_contract_all_variables_naive(bqm):
             variable_map[u] = (v, uv_equal) indicates that variable u was contracted to variable v, with u=v if
             uv_equal=1 and u=~v otherwise.
 
+    Example:
+        This example creates a binary quadratic model with a strong interaction between variables 0 and 3,
+        and contracts that pair of variables to a single variable. After sampling from the contracted bqm,
+        solutions are expanded to produce solutions to the original bqm.
+
+        >>> J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2)]}
+        >>> J[(0, 3)] = -10
+        >>> bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        >>> contracted_bqm, variable_map, _ = find_and_contract_all_variables_roof_naive(bqm, sampling_mode=True)
+        >>> print(contracted_bqm)
+
+        >>> contracted_sampleset = dimod.ExactSolver().sample(contracted_bqm)
+        >>> sampleset = uncontract_solution(contracted_sampleset, variable_map)
+        >>> print(sampleset)
+
     """
 
     bqm2 = bqm.copy()
@@ -149,6 +165,23 @@ def find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True):
 
         fixable_variables: a dictionary of variable assignments that were fixed in the ground states.
 
+    Example:
+        This example creates a binary quadratic model with a strong interaction between variables 0 and 3,
+        and contracts that pair of variables to a single variable. After sampling from the contracted bqm,
+        solutions are expanded to produce solutions to the original bqm.
+
+        >>> J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2)]}
+        >>> J[(0, 3)] = -10
+        >>> bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        >>> contracted_bqm, variable_map, _ = find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True)
+        >>> print(contracted_bqm)
+
+        >>> contracted_sampleset = dimod.ExactSolver().sample(contracted_bqm)
+        >>> sampleset = uncontract_solution(contracted_sampleset, variable_map)
+        >>> print(sampleset)
+
+
     Method: pick a variable to probe by extended roof duality, and if it contractible, contract it right away.
     Repeat until no contractions are possible.
     (When there are many contractible variables, this method is much faster than first identifying all contractible
@@ -203,7 +236,6 @@ def uncontract_solution(sampleset, variable_map):
         new_sampleset: a dimod.SampleSet for the uncontracted bqm.
 
 
-    Note: This should probably be turned into a composite layer.
     """
 
     if sampleset.vartype != Vartype.SPIN:

--- a/docs/reference/bqm/binary_quadratic_model.rst
+++ b/docs/reference/bqm/binary_quadratic_model.rst
@@ -71,6 +71,7 @@ Transformations
    :toctree: generated/
 
    BinaryQuadraticModel.contract_variables
+   BinaryQuadraticModel.contract_variables_from
    BinaryQuadraticModel.fix_variable
    BinaryQuadraticModel.fix_variables
    BinaryQuadraticModel.flip_variable

--- a/tests/test_binary_quadratic_model.py
+++ b/tests/test_binary_quadratic_model.py
@@ -1080,7 +1080,7 @@ class TestBinaryQuadraticModel(unittest.TestCase):
 
         bqm = original_bqm.copy()
 
-        bqm.contract_variables('a', 'b', uv_equal=False)
+        bqm.contract_variables('a', 'b', equal=False)
         self.assertNotIn('b', bqm.linear)
         self.assertConsistentBQM(bqm)
 
@@ -1105,7 +1105,7 @@ class TestBinaryQuadraticModel(unittest.TestCase):
 
         bqm = original_bqm.copy()
 
-        bqm.contract_variables('a', 'b', uv_equal=False)
+        bqm.contract_variables('a', 'b', equal=False)
         self.assertNotIn('b', bqm.linear)
         self.assertConsistentBQM(bqm)
 
@@ -1122,20 +1122,48 @@ class TestBinaryQuadraticModel(unittest.TestCase):
         with self.assertRaises(ValueError):
             bqm.contract_variables('a', 1)
 
-    def test_contract_all_variables(self):
-        original_bqm = dimod.BinaryQuadraticModel({'a': .3, 'b': -.7},
-                                                  {('a', 'b'): -1, ('b', 'c'): 1, ('c', 'd'): 0.5}, 1.2,
-                                                  dimod.BINARY)
-        bqm = original_bqm.copy()
-        contractible_variables = {('a', 'b'): True, ('b','c'): False, ('c','d'): False}
+    def test_contract_variables_from(self):
+        original = dimod.BinaryQuadraticModel({'a': .3, 'b': -.7},
+                                              {('a', 'b'): -1,
+                                               ('b', 'c'): 1,
+                                               ('c', 'd'): 0.5},
+                                              1.2,
+                                              dimod.BINARY)
+        bqm = original.copy()
+        contractible_variables = {('a', 'b'): True,
+                                  ('b', 'c'): False,
+                                  ('c', 'd'): False}
 
-        variable_map = bqm.contract_all_variables(contractible_variables)
+        variable_map = bqm.contract_variables_from(contractible_variables)
         self.assertNotIn('b', bqm.linear)
         self.assertConsistentBQM(bqm)
 
-        self.assertAlmostEqual(bqm.energy({'a': 0}), original_bqm.energy({'a': 0, 'b': 0, 'c': 1, 'd': 0}))
-        self.assertAlmostEqual(bqm.energy({'a': 1}), original_bqm.energy({'a': 1, 'b': 1, 'c': 0, 'd': 1}))
-        self.assertEqual(variable_map, {'a': ('a', True), 'b': ('a', True), 'c': ('a', False), 'd': ('a', True)})
+        self.assertAlmostEqual(bqm.energy({'a': 0}),
+                               original.energy({'a': 0, 'b': 0, 'c': 1, 'd': 0}))
+        self.assertAlmostEqual(bqm.energy({'a': 1}),
+                               original.energy({'a': 1, 'b': 1, 'c': 0, 'd': 1}))
+        self.assertEqual(variable_map,
+                         {'a': ('a', True),
+                          'b': ('a', True),
+                          'c': ('a', False),
+                          'd': ('a', True)})
+
+    def test_constract_variables_from_sequence(self):
+        original = dimod.BinaryQuadraticModel({'a': .3, 'b': -.7},
+                                              {('a', 'b'): -1,
+                                               ('b', 'c'): 1,
+                                               ('c', 'd'): 0.5},
+                                              1.2,
+                                              dimod.BINARY)
+        bqm = original.copy()
+        contractible_variables = {('a', 'b'), ('b', 'c'), ('c', 'd')}
+        vm = bqm.contract_variables_from(contractible_variables)
+        self.assertNotIn('b', bqm.linear)
+        self.assertConsistentBQM(bqm)
+        self.assertAlmostEqual(bqm.energy({'a': 0}),
+                               original.energy({'a': 0, 'b': 0, 'c': 0, 'd': 0}))
+        self.assertAlmostEqual(bqm.energy({'a': 1}),
+                               original.energy({'a': 1, 'b': 1, 'c': 1, 'd': 1}))
 
     def test_relabel_typical(self):
         linear = {0: .5, 1: 1.3}

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -2,6 +2,7 @@ import dimod
 import unittest
 
 try:
+    from dimod import fix_variables
     from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
         find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
         find_and_contract_all_variables_naive

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -35,8 +35,11 @@ class TestExtendedFixVariables(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel.from_ising({}, {(0, 1): -1, (1, 2): 3, (2, 3): 2})
 
         bqm2, variable_map, _ = find_and_contract_all_variables_roof_duality(bqm)
-        variable_map_check = {0: (1, True), 1: (1, True), 2: (1, False), 3: (1, True)}
-        self.assertEqual(variable_map, variable_map_check)
+
+        # 0, 1, and 3 should be contracted to the same value, 2 to the opposite value
+        self.assertEqual(variable_map[1], variable_map[0])
+        self.assertEqual(variable_map[3], variable_map[0])
+        self.assertEqual(variable_map[2], (variable_map[0][0], False))
         bqm_check = dimod.BinaryQuadraticModel.from_ising({1: 0}, {}, -6)
         self.assertEqual(bqm2, bqm_check)
 
@@ -47,9 +50,11 @@ class TestExtendedFixVariables(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
 
         bqm2, variable_map = find_and_contract_all_variables_naive(bqm)
-        variable_map_check = {i: (i, True) for i in [0, 1, 2, 4, 5]}
-        variable_map_check[3] = (0, True)
-        self.assertEqual(variable_map, variable_map_check)
+
+        # only 0 and 3 should be contracted
+        self.assertEqual(variable_map[0], variable_map[3])
+        for i in [1, 2, 4, 5]:
+            self.assertEqual(variable_map[i], (i, True))
         bqm_check = dimod.BinaryQuadraticModel.from_ising({},
                     {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (0, 4), (0, 5), (4, 5)]},
                     -10)

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -1,0 +1,79 @@
+import numpy as np
+import dimod
+import orang
+import unittest
+
+from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
+    find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
+    find_and_contract_all_variables_naive
+
+
+class TestLockableDict(unittest.TestCase):
+
+    def test_find_contractible_variables_naive(self):
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        contractible_variables = find_contractible_variables_naive(bqm)
+        self.assertEqual(contractible_variables, {(0, 3): True})
+
+    def test_find_contractible_variables_roof_duality(self):
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        contractible_variables, fixed_variables = find_contractible_variables_roof_duality(bqm)
+        self.assertEqual(contractible_variables, {(0, 3): True})
+        self.assertEqual(fixed_variables, {})
+
+
+    def test_find_and_contract_all_variables_roof_duality(self):
+
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {(0, 1): -1, (1, 2): 3, (2, 3): 2})
+
+        bqm2, variable_map, _ = find_and_contract_all_variables_roof_duality(bqm)
+        variable_map_check = {0: (1, True), 1: (1, True), 2: (1, False), 3: (1, True)}
+        self.assertEqual(variable_map, variable_map_check)
+        bqm_check = dimod.BinaryQuadraticModel.from_ising({1: 0}, {}, -6)
+        self.assertEqual(bqm2, bqm_check)
+
+    def test_find_and_contract_all_variables_naive(self):
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        bqm2, variable_map = find_and_contract_all_variables_naive(bqm)
+        variable_map_check = {i: (i, True) for i in [0, 1, 2, 4, 5]}
+        variable_map_check[3] = (0, True)
+        self.assertEqual(variable_map, variable_map_check)
+        bqm_check = dimod.BinaryQuadraticModel.from_ising({},
+                    {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (0, 4), (0, 5), (4, 5)]},
+                    -10)
+        self.assertEqual(bqm2, bqm_check)
+
+    def test_uncontract_solution(self):
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        bqm2, variable_map, _ = find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True)
+
+        sampleset2 = dimod.ExactSolver().sample(bqm2)
+        sampleset = uncontract_solution(sampleset2, variable_map)
+
+        # check that energies in uncontracted and contracted bqms match up:
+        dimod.testing.assert_response_energies(sampleset, bqm)
+
+        # check that lowest energies satisfy variable map conditions:
+        sampleset = dimod.ExactSolver().sample(bqm)
+        min_energy = min(sampleset.data(['energy']))
+        for sample, energy in sampleset.data(['sample', 'energy']):
+            if energy == min_energy:
+                for u, val in variable_map.items():
+                    (v, uv_equal) = val
+                    assert uv_equal == (sample[u] == sample[v])

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -1,11 +1,16 @@
 import dimod
 import unittest
 
-from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
-    find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
-    find_and_contract_all_variables_naive
+try:
+    from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
+        find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
+        find_and_contract_all_variables_naive
+except ImportError:
+    cpp = False
+else:
+    cpp = True
 
-
+@unittest.skipUnless(cpp, "no cpp extensions built")
 class TestExtendedFixVariables(unittest.TestCase):
 
     def test_find_contractible_variables_naive(self):

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -1,6 +1,4 @@
-import numpy as np
 import dimod
-import orang
 import unittest
 
 from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -8,7 +8,7 @@ from dimod.roof_duality.extended_fix_variables import find_contractible_variable
     find_and_contract_all_variables_naive
 
 
-class TestLockableDict(unittest.TestCase):
+class TestExtendedFixVariables(unittest.TestCase):
 
     def test_find_contractible_variables_naive(self):
 

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -30,15 +30,16 @@ class TestExtendedFixVariables(unittest.TestCase):
 
     def test_find_and_contract_all_variables_roof_duality(self):
 
-        bqm = dimod.BinaryQuadraticModel.from_ising({}, {(0, 1): -1, (1, 2): 3, (2, 3): 2})
 
-        bqm2, variable_map, _ = find_and_contract_all_variables_roof_duality(bqm)
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {(0, 1): -1, (1, 2): 1, (2, 3): 1})
+
+        bqm2, variable_map, fixed_variables = find_and_contract_all_variables_roof_duality(bqm, sampling_mode=True)
 
         # 0, 1, and 3 should be contracted to the same value, 2 to the opposite value
         self.assertEqual(variable_map[1], variable_map[0])
         self.assertEqual(variable_map[3], variable_map[0])
         self.assertEqual(variable_map[2], (variable_map[0][0], False))
-        bqm_check = dimod.BinaryQuadraticModel.from_ising({1: 0}, {}, -6)
+        bqm_check = dimod.BinaryQuadraticModel.from_ising({variable_map[0][0]: 0}, {}, -3)
         self.assertEqual(bqm2, bqm_check)
 
     def test_find_and_contract_all_variables_naive(self):

--- a/tests/test_extended_fix_variables.py
+++ b/tests/test_extended_fix_variables.py
@@ -1,11 +1,11 @@
 import dimod
 import unittest
+from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
+    find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
+    find_and_contract_all_variables_naive
 
 try:
     from dimod import fix_variables
-    from dimod.roof_duality.extended_fix_variables import find_contractible_variables_naive, \
-        find_contractible_variables_roof_duality, uncontract_solution, find_and_contract_all_variables_roof_duality, \
-        find_and_contract_all_variables_naive
 except ImportError:
     cpp = False
 else:

--- a/tests/test_roof_duality.py
+++ b/tests/test_roof_duality.py
@@ -18,10 +18,8 @@ import unittest
 import dimod.testing as dtest
 import dimod
 
-from dimod import ExtendedRoofDualityComposite
-
 try:
-    from dimod import fix_variables
+    from dimod import fix_variables, ExtendedRoofDualityComposite
 except ImportError:
     cpp = False
 else:

--- a/tests/test_roof_duality.py
+++ b/tests/test_roof_duality.py
@@ -17,9 +17,10 @@ import unittest
 
 import dimod.testing as dtest
 import dimod
+from dimod import ExtendedRoofDualityComposite
 
 try:
-    from dimod import fix_variables, ExtendedRoofDualityComposite
+    from dimod import fix_variables
 except ImportError:
     cpp = False
 else:

--- a/tests/test_roof_duality.py
+++ b/tests/test_roof_duality.py
@@ -15,7 +15,10 @@
 # ================================================================================================
 import unittest
 
+import dimod.testing as dtest
 import dimod
+
+from dimod import ExtendedRoofDualityComposite
 
 try:
     from dimod import fix_variables
@@ -31,3 +34,87 @@ class TestFixVariables(unittest.TestCase):
         bqm = dimod.BinaryQuadraticModel.from_ising({'a': 10}, {'ab': -1, 'bc': 1})
         fixed = dimod.fix_variables(bqm)
         self.assertEqual(fixed, {'a': -1, 'b': -1, 'c': 1})
+
+
+class TestExtendedRoofDualityComposite(unittest.TestCase):
+    @unittest.skipIf(cpp, "cpp extensions built")
+    def test_nocpp_error(self):
+        with self.assertRaises(ImportError):
+            ExtendedRoofDualityComposite(dimod.ExactSolver()).sample_ising({}, {})
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_construction(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+        dtest.assert_sampler_api(sampler)
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_3path(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+        sampleset = sampler.sample_ising({'a': 10},  {'ab': -1, 'bc': 1})
+
+        # all should be fixed, so should just see one solution
+        self.assertEqual(len(sampleset), 1)
+        self.assertEqual(set(sampleset.variables), set('abc'))
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_3path_contracted(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+        sampleset = sampler.sample_ising({},  {'ab': -1, 'bc': 1})
+
+        # all should be contracted, so should see two solutions
+        self.assertEqual(len(sampleset), 2)
+        self.assertEqual(set(sampleset.variables), set('abc'))
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_triangle(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1, 'bc': -1, 'ac': -1})
+
+        # two equally good solutions
+        sampleset = sampler.sample(bqm)
+
+        self.assertEqual(set(sampleset.variables), set('abc'))
+        dimod.testing.assert_response_energies(sampleset, bqm)
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_triangle_sampling_mode_off(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': -1, 'bc': -1, 'ac': -1})
+
+        # two equally good solutions, but with sampling mode off it will pick one
+        sampleset = sampler.sample(bqm, sampling_mode=False)
+
+        self.assertEqual(set(sampleset.variables), set('abc'))
+        self.assertEqual(len(sampleset), 1)  # all should be fixed
+        dimod.testing.assert_response_energies(sampleset, bqm)
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_bowtie(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, J)
+
+        # 18 optimal solutions
+        sampleset = sampler.sample(bqm)
+
+        self.assertEqual(set(sampleset.variables), set(range(6)))
+        dimod.testing.assert_response_energies(sampleset, bqm)
+
+    @unittest.skipUnless(cpp, "no cpp extensions built")
+    def test_bowtie_sampling_mode_off(self):
+        sampler = ExtendedRoofDualityComposite(dimod.ExactSolver())
+
+        J = {(u, v): 1 for (u, v) in [(0, 1), (0, 2), (1, 2), (3, 4), (3, 5), (4, 5)]}
+        J[(0, 3)] = -10
+        bqm = dimod.BinaryQuadraticModel.from_ising({0: 0.1}, J)
+
+        # With sampling mode off, should pick a single solution
+        sampleset = sampler.sample(bqm, sampling_mode=False)
+
+        self.assertEqual(set(sampleset.variables), set(range(6)))
+        self.assertEqual(len(sampleset), 1)  # all should be fixed
+        dimod.testing.assert_response_energies(sampleset, bqm)


### PR DESCRIPTION
Adds "extended roof duality" to the roof duality/fix_variables.

"Extended roof duality" by probing variables to see if they can be fixed to each other. That is, if a variable y can be fixed by roof duality when another variable x is fixed to 0 and also when x is fixed to 1, then y can be fixed to x. By identify the variables, the size of the bqm is reduced.

I've added some code to implement this - I'd appreciate some feedback about the structure. Also, there should be a composite layer to handle this functionality, but I haven't done that. 

Closes #380 