### PR TITLE
Only make cybqms available in python 3.5+

### DIFF
--- a/dimod/bqm/__init__.py
+++ b/dimod/bqm/__init__.py
@@ -13,7 +13,13 @@
 #    limitations under the License.
 #
 # =============================================================================
-from dimod.bqm.adjarraybqm import AdjArrayBQM
+import sys
+
 from dimod.bqm.adjdictbqm import AdjDictBQM
-from dimod.bqm.adjmapbqm import AdjMapBQM
-from dimod.bqm.adjvectorbqm import AdjVectorBQM
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 5:
+    from dimod.bqm.adjarraybqm import AdjArrayBQM
+    from dimod.bqm.adjmapbqm import AdjMapBQM
+    from dimod.bqm.adjvectorbqm import AdjVectorBQM
+
+del sys  # so not in namespace

--- a/dimod/bqm/src/adjarray.cc
+++ b/dimod/bqm/src/adjarray.cc
@@ -22,24 +22,21 @@ namespace dimod {
     // Read the BQM
 
     template<typename VarIndex, typename Bias>
-    std::size_t num_variables(const std::vector<std::pair<std::size_t, Bias>>
-                                  &invars,
-                              const std::vector<std::pair<VarIndex, Bias>>
-                                  &outvars) {
+    std::size_t num_variables(const AdjArrayInVars<Bias> &invars,
+                              const AdjArrayOutVars<VarIndex, Bias> &outvars) {
         return invars.size();
     }
 
     template<typename VarIndex, typename Bias>
-    std::size_t num_interactions(const std::vector<std::pair<std::size_t, Bias>>
-                                    &invars,
-                                 const std::vector<std::pair<VarIndex, Bias>>
-                                 &outvars) {
+    std::size_t num_interactions(const AdjArrayInVars<Bias> &invars,
+                                 const AdjArrayOutVars<VarIndex, Bias>
+                                &outvars) {
         return outvars.size() / 2;
     }
 
     template<typename VarIndex, typename Bias>
-    Bias get_linear(const std::vector<std::pair<std::size_t, Bias>> &invars,
-                    const std::vector<std::pair<VarIndex, Bias>> &outvars,
+    Bias get_linear(const AdjArrayInVars<Bias> &invars,
+                    const AdjArrayOutVars<VarIndex, Bias> &outvars,
                     VarIndex v) {
         assert(v >= 0 && v < invars.size());
         return invars[v].second;
@@ -53,10 +50,9 @@ namespace dimod {
     }
 
     template<typename VarIndex, typename Bias>
-    std::pair<Bias, bool> get_quadratic(const std::vector<std::pair<std::size_t,
-                                        Bias>> &invars,
-                                        const std::vector<std::pair<VarIndex,
-                                        Bias>> &outvars,
+    std::pair<Bias, bool> get_quadratic(const AdjArrayInVars<Bias> &invars,
+                                        const AdjArrayOutVars<VarIndex, Bias>
+                                        &outvars,
                                         VarIndex u, VarIndex v) {
         assert(u >= 0 && u < invars.size());
         assert(v >= 0 && v < invars.size());
@@ -69,7 +65,7 @@ namespace dimod {
 
         const std::pair<VarIndex, Bias> target(v, 0);
 
-        typename std::vector<std::pair<VarIndex, Bias>>::const_iterator low;
+        typename AdjArrayOutVars<VarIndex, Bias>::const_iterator low;
         low = std::lower_bound(outvars.begin()+start, outvars.begin()+end,
                                target, pair_lt<VarIndex, Bias>);
 
@@ -81,8 +77,8 @@ namespace dimod {
     // Change the values in the BQM
 
     template<typename VarIndex, typename Bias>
-    void set_linear(std::vector<std::pair<std::size_t, Bias>> &invars,
-                    std::vector<std::pair<VarIndex, Bias>> &outvars,
+    void set_linear(AdjArrayInVars<Bias> &invars,
+                    AdjArrayOutVars<VarIndex, Bias> &outvars,
                     VarIndex v, Bias b) {
         assert(v >= 0 && v < invars.size());
         invars[v].second = b;
@@ -91,14 +87,14 @@ namespace dimod {
     // Q: Should we do something else if the user tries to set a non-existant
     //    quadratic bias? Error/segfault?
     template<typename VarIndex, typename Bias>
-    bool set_quadratic(std::vector<std::pair<std::size_t, Bias>> &invars,
-                       std::vector<std::pair<VarIndex, Bias>> &outvars,
+    bool set_quadratic(AdjArrayInVars<Bias> &invars,
+                       AdjArrayOutVars<VarIndex, Bias> &outvars,
                        VarIndex u, VarIndex v, Bias b) {
         assert(u >= 0 && u < invars.size());
         assert(v >= 0 && v < invars.size());
         assert(u != v);
 
-        typename std::vector<std::pair<VarIndex, Bias>>::iterator low;
+        typename AdjArrayOutVars<VarIndex, Bias>::iterator low;
         std::size_t start, end;
 
         // interaction (u, v)

--- a/dimod/bqm/src/adjarray.h
+++ b/dimod/bqm/src/adjarray.h
@@ -20,36 +20,28 @@
 
 namespace dimod {
 
-    // developer note: while we continue to support python2.7 we are stuck
-    // using visual studio 9.0 and consequently don't have access to template
-    // aliases. For now we'll just be more verbose but here they are for
-    // reference:
-    //
-    // template<typename Bias>
-    // using AdjArrayInVars = typename std::vector<std::pair<std::size_t,Bias>>;
-    //
-    // template<typename VarIndex, typename Bias>
-    // using AdjArrayOutVars = typename std::vector<std::pair<VarIndex, Bias>>;
+    template<typename Bias>
+    using AdjArrayInVars = typename std::vector<std::pair<std::size_t, Bias>>;
+
+    template<typename VarIndex, typename Bias>
+    using AdjArrayOutVars = typename std::vector<std::pair<VarIndex, Bias>>;
 
     // Read the BQM
 
     template<typename V, typename B>
-    std::size_t num_variables(const std::vector<std::pair<std::size_t, B>>&,
-                              const std::vector<std::pair<V, B>>&);
+    std::size_t num_variables(const AdjArrayInVars<B>&,
+                              const AdjArrayOutVars<V, B>&);
 
     template<typename V, typename B>
-    std::size_t num_interactions(const std::vector<std::pair<std::size_t, B>>&,
-                                 const std::vector<std::pair<V, B>>&);
+    std::size_t num_interactions(const AdjArrayInVars<B>&,
+                                 const AdjArrayOutVars<V, B>&);
 
     template<typename V, typename B>
-    B get_linear(const std::vector<std::pair<std::size_t, B>>&,
-                 const std::vector<std::pair<V, B>>&,
-                 V);
+    B get_linear(const AdjArrayInVars<B>&, const AdjArrayOutVars<V, B>&, V);
 
     template<typename V, typename B>
-    std::pair<B, bool> get_quadratic(const std::vector<std::pair<std::size_t,
-                                     B>>&,
-                                     const std::vector<std::pair<V, B>>&,
+    std::pair<B, bool> get_quadratic(const AdjArrayInVars<B>&,
+                                     const AdjArrayOutVars<V, B>&,
                                      V, V);
 
     // todo: variable_iterator
@@ -59,14 +51,10 @@ namespace dimod {
     // Change the values in the BQM
 
     template<typename V, typename B>
-    void set_linear(std::vector<std::pair<std::size_t, B>>&,
-                    std::vector<std::pair<V, B>>&,
-                    V, B);
+    void set_linear(AdjArrayInVars<B>&, AdjArrayOutVars<V, B>&, V, B);
 
     template<typename V, typename B>
-    bool set_quadratic(std::vector<std::pair<std::size_t, B>>&,
-                       std::vector<std::pair<V, B>>&,
-                       V, V, B);
+    bool set_quadratic(AdjArrayInVars<B>&, AdjArrayOutVars<V, B>&, V, V, B);
 
 }  // namespace dimod
 

--- a/dimod/bqm/src/adjmap.cc
+++ b/dimod/bqm/src/adjmap.cc
@@ -22,17 +22,14 @@ namespace dimod {
     // Read the BQM
 
     template<typename VarIndex, typename Bias>
-    std::size_t num_variables(const std::vector<std::pair<std::map<VarIndex,
-                              Bias>, Bias>> &bqm) {
+    std::size_t num_variables(const AdjMapBQM<VarIndex, Bias> &bqm) {
         return bqm.size();
     }
 
     template<typename VarIndex, typename Bias>
-    std::size_t num_interactions(const std::vector<std::pair<std::map<VarIndex,
-                                 Bias>, Bias>> &bqm) {
+    std::size_t num_interactions(const AdjMapBQM<VarIndex, Bias> &bqm) {
         std::size_t count = 0;
-        for (typename std::vector<std::pair<std::map<VarIndex, Bias>,
-             Bias>>::const_iterator it = bqm.begin();
+        for (typename AdjMapBQM<VarIndex, Bias>::const_iterator it = bqm.begin();
              it != bqm.end(); ++it) {
             count += (*it).first.size();
         }
@@ -40,15 +37,13 @@ namespace dimod {
     }
 
     template<typename VarIndex, typename Bias>
-    Bias get_linear(const std::vector<std::pair<std::map<VarIndex, Bias>, Bias>>
-                    &bqm, VarIndex v) {
+    Bias get_linear(const AdjMapBQM<VarIndex, Bias> &bqm, VarIndex v) {
         assert(v >= 0 && v < bqm.size());
         return bqm[v].second;
     }
 
     template<typename VarIndex, typename Bias>
-    std::pair<Bias, bool> get_quadratic(const std::vector<std::pair<
-                                        std::map<VarIndex, Bias>, Bias>> &bqm,
+    std::pair<Bias, bool> get_quadratic(const AdjMapBQM<VarIndex, Bias> &bqm,
                                         VarIndex u, VarIndex v) {
         assert(u >= 0 && u < bqm.size());
         assert(v >= 0 && v < bqm.size());
@@ -71,16 +66,15 @@ namespace dimod {
     // Change the values in the BQM
 
     template<typename VarIndex, typename Bias>
-    void set_linear(std::vector<std::pair<std::map<VarIndex, Bias>, Bias>> &bqm,
-                    VarIndex v, Bias b) {
+    void set_linear(AdjMapBQM<VarIndex, Bias> &bqm, VarIndex v, Bias b) {
         assert(v >= 0 && v < bqm.size());
         bqm[v].second = b;
     }
 
     // todo: decide and document what happens when u == v
     template<typename VarIndex, typename Bias>
-    void set_quadratic(std::vector<std::pair<std::map<VarIndex, Bias>, Bias>>
-                       &bqm, VarIndex u, VarIndex v, Bias b) {
+    void set_quadratic(AdjMapBQM<VarIndex, Bias> &bqm,
+                       VarIndex u, VarIndex v, Bias b) {
         assert(u >= 0 && u < bqm.size());
         assert(v >= 0 && v < bqm.size());
         assert(u != v);
@@ -92,15 +86,14 @@ namespace dimod {
     // Change the structure of the BQM
 
     template<typename VarIndex, typename Bias>
-    VarIndex add_variable(std::vector<std::pair<std::map<VarIndex, Bias>, Bias>>
-                          &bqm) {
+    VarIndex add_variable(AdjMapBQM<VarIndex, Bias> &bqm) {
         bqm.push_back(std::make_pair(std::map<VarIndex, Bias>(), 0));
         return bqm.size() - 1;
     }
 
     template<typename VarIndex, typename Bias>
-    bool add_interaction(std::vector<std::pair<std::map<VarIndex, Bias>, Bias>>
-                         &bqm, VarIndex u, VarIndex v) {
+    bool add_interaction(AdjMapBQM<VarIndex, Bias> &bqm,
+                         VarIndex u, VarIndex v) {
         assert(u >= 0 && u < bqm.size());
         assert(v >= 0 && v < bqm.size());
         assert(u != v);
@@ -117,8 +110,7 @@ namespace dimod {
     }
 
     template<typename VarIndex, typename Bias>
-    VarIndex pop_variable(std::vector<std::pair<std::map<VarIndex, Bias>, Bias>>
-                          &bqm) {
+    VarIndex pop_variable(AdjMapBQM<VarIndex, Bias> &bqm) {
         assert(bqm.size() > 0);  // undefined for empty
 
         VarIndex v = bqm.size() - 1;
@@ -135,8 +127,8 @@ namespace dimod {
 
     // todo: decide and document what happens when u == v
     template<typename VarIndex, typename Bias>
-    bool remove_interaction(std::vector<std::pair<std::map<VarIndex, Bias>,
-                            Bias>> &bqm, VarIndex u, VarIndex v) {
+    bool remove_interaction(AdjMapBQM<VarIndex, Bias> &bqm,
+                            VarIndex u, VarIndex v) {
         assert(u >= 0 && u < bqm.size());
         assert(v >= 0 && v < bqm.size());
         assert(u != v);

--- a/dimod/bqm/src/adjmap.h
+++ b/dimod/bqm/src/adjmap.h
@@ -21,33 +21,26 @@
 
 namespace dimod {
 
-    // developer note: while we continue to support python2.7 we are stuck
-    // using visual studio 9.0 and consequently don't have access to template
-    // aliases. For now we'll just be more verbose but here they are for
-    // reference:
-    //
-    // template<typename VarIndex, typename Bias>
-    // using Neighbourhood = typename std::map<VarIndex, Bias>;
-    //
-    // template<typename VarIndex, typename Bias>
-    // using AdjMapBQM = typename std::vector<
-    //     std::pair<Neighbourhood<VarIndex, Bias>, Bias>>;
+    template<typename VarIndex, typename Bias>
+    using Neighbourhood = typename std::map<VarIndex, Bias>;
+
+    template<typename VarIndex, typename Bias>
+    using AdjMapBQM = typename std::vector<
+        std::pair<Neighbourhood<VarIndex, Bias>, Bias>>;
 
     // Read the BQM
 
     template<typename V, typename B>
-    std::size_t num_variables(const std::vector<std::pair<std::map<V, B>, B>>&);
+    std::size_t num_variables(const AdjMapBQM<V, B>&);
 
     template<typename V, typename B>
-    std::size_t num_interactions(const std::vector<std::pair<std::map<V, B>,
-                                 B>>&);
+    std::size_t num_interactions(const AdjMapBQM<V, B>&);
 
     template<typename V, typename B>
-    B get_linear(const std::vector<std::pair<std::map<V, B>, B>>&, V);
+    B get_linear(const AdjMapBQM<V, B>&, V);
 
     template<typename V, typename B>
-    std::pair<B, bool> get_quadratic(const std::vector<std::pair<std::map<V, B>,
-                                      B>>&, V, V);
+    std::pair<B, bool> get_quadratic(const AdjMapBQM<V, B>&, V, V);
 
     // todo: variable_iterator
     // todo: interaction_iterator
@@ -56,26 +49,26 @@ namespace dimod {
     // Change the values in the BQM
 
     template<typename V, typename B>
-    void set_linear(std::vector<std::pair<std::map<V, B>, B>>&, V, B);
+    void set_linear(AdjMapBQM<V, B>&, V, B);
 
     // developer note: should this return a bool to be consistent with the
     // array version?
     template<typename V, typename B>
-    void set_quadratic(std::vector<std::pair<std::map<V, B>, B>>&, V, V, B);
+    void set_quadratic(AdjMapBQM<V, B>&, V, V, B);
 
     // Change the structure of the BQM
 
     template<typename V, typename B>
-    V add_variable(std::vector<std::pair<std::map<V, B>, B>>&);
+    V add_variable(AdjMapBQM<V, B>&);
 
     template<typename V, typename B>
-    bool add_interaction(std::vector<std::pair<std::map<V, B>, B>>&, V, V);
+    bool add_interaction(AdjMapBQM<V, B>&, V, V);
 
     template<typename V, typename B>
-    V pop_variable(std::vector<std::pair<std::map<V, B>, B>>&);
+    V pop_variable(AdjMapBQM<V, B>&);
 
     template<typename V, typename B>
-    bool remove_interaction(std::vector<std::pair<std::map<V, B>, B>>&, V, V);
+    bool remove_interaction(AdjMapBQM<V, B>&, V, V);
 }  // namespace dimod
 
 #endif  // DIMOD_BQM_SRC_ADJMAP_H_

--- a/dimod/bqm/src/adjvector.cc
+++ b/dimod/bqm/src/adjvector.cc
@@ -93,16 +93,13 @@ std::pair<Bias, bool> get_quadratic(const std::vector<std::pair<std::vector<
     assert(v >= 0 && v < bqm.size());
     assert(u != v);
 
-    std::pair<typename std::vector<std::pair<VarIndex, Bias>>::const_iterator,
-              bool> ret;
+    typename std::vector<std::pair<VarIndex, Bias>>::const_iterator it;
+    bool exists;
 
-    ret = directed_edge_iterator(bqm, u, v);
-    bool exists = ret.second;
-    typename std::vector<std::pair<VarIndex, Bias>>::const_iterator it
-        = ret.first;
-
+    std::tie(it, exists) = directed_edge_iterator(bqm, u, v);
     if (!exists)
         return std::make_pair(0, false);
+
     return std::make_pair((*it).second, true);
 }
 
@@ -123,14 +120,11 @@ bool set_quadratic(std::vector<std::pair<std::vector<std::pair<VarIndex, Bias>>,
     assert(v >= 0 && v < bqm.size());
     assert(u != v);
 
-    std::pair<typename std::vector<std::pair<VarIndex, Bias>>::iterator,
-              bool> ret;
     typename std::vector<std::pair<VarIndex, Bias>>::iterator it;
+    bool uv_exists, vu_exists;
 
     // u, v
-    ret = directed_edge_iterator(bqm, u, v);
-    bool uv_exists = ret.second;
-    it = ret.first;
+    std::tie(it, uv_exists) = directed_edge_iterator(bqm, u, v);
     if (uv_exists) {
         (*it).second = b;
     } else {
@@ -138,9 +132,7 @@ bool set_quadratic(std::vector<std::pair<std::vector<std::pair<VarIndex, Bias>>,
     }
 
     // v, u
-    ret = directed_edge_iterator(bqm, v, u);
-    bool vu_exists = ret.second;
-    it = ret.first;
+    std::tie(it, vu_exists) = directed_edge_iterator(bqm, v, u);
     if (vu_exists) {
         (*it).second = b;
     } else {
@@ -200,21 +192,16 @@ bool remove_interaction(std::vector<std::pair<std::vector<std::pair<VarIndex,
     assert(v >= 0 && v < bqm.size());
     assert(u != v);
 
-    std::pair<typename std::vector<std::pair<VarIndex, Bias>>::iterator,
-              bool> ret;
     typename std::vector<std::pair<VarIndex, Bias>>::iterator it;
+    bool uv_exists, vu_exists;
 
     // u, v
-    ret = directed_edge_iterator(bqm, u, v);
-    bool uv_exists = ret.second;
-    it = ret.first;
+    std::tie(it, uv_exists) = directed_edge_iterator(bqm, u, v);
     if (uv_exists)
         bqm[u].first.erase(it);
 
     // v, u
-    ret = directed_edge_iterator(bqm, v, u);
-    bool vu_exists = ret.second;
-    it = ret.first;
+    std::tie(it, vu_exists) = directed_edge_iterator(bqm, v, u);
     if (vu_exists)
         bqm[v].first.erase(it);
 

--- a/dimod/bqm/src/adjvector.cc
+++ b/dimod/bqm/src/adjvector.cc
@@ -24,8 +24,7 @@ namespace dimod {
 
 template<typename VarIndex, typename Bias>
 std::pair<typename std::vector<std::pair<VarIndex, Bias>>::const_iterator, bool>
-    directed_edge_iterator(const std::vector<std::pair<std::vector<std::pair<
-                           VarIndex, Bias>>, Bias>> &bqm,
+    directed_edge_iterator(const AdjVectorBQM<VarIndex, Bias> &bqm,
                            VarIndex u, VarIndex v) {
     assert(u >= 0 && u < bqm.size());
     assert(v >= 0 && v < bqm.size());
@@ -42,8 +41,7 @@ std::pair<typename std::vector<std::pair<VarIndex, Bias>>::const_iterator, bool>
 
 template<typename VarIndex, typename Bias>
 std::pair<typename std::vector<std::pair<VarIndex, Bias>>::iterator, bool>
-    directed_edge_iterator(std::vector<std::pair<std::vector<std::pair<
-                           VarIndex, Bias>>, Bias>> &bqm,
+    directed_edge_iterator(AdjVectorBQM<VarIndex, Bias> &bqm,
                            VarIndex u, VarIndex v) {
     assert(u >= 0 && u < bqm.size());
     assert(v >= 0 && v < bqm.size());
@@ -61,14 +59,12 @@ std::pair<typename std::vector<std::pair<VarIndex, Bias>>::iterator, bool>
 // Read the BQM
 
 template<typename VarIndex, typename Bias>
-std::size_t num_variables(const std::vector<std::pair<std::vector<
-                          std::pair<VarIndex, Bias>>, Bias>> &bqm) {
+std::size_t num_variables(const AdjVectorBQM<VarIndex, Bias> &bqm) {
     return bqm.size();
 }
 
 template<typename VarIndex, typename Bias>
-std::size_t num_interactions(const std::vector<std::pair<std::vector<
-                             std::pair<VarIndex, Bias>>, Bias>> &bqm) {
+std::size_t num_interactions(const AdjVectorBQM<VarIndex, Bias> &bqm) {
     std::size_t count = 0;
     for (typename std::vector<std::pair<std::vector<std::pair<VarIndex,
          Bias>>, Bias>>::const_iterator it = bqm.begin();
@@ -79,15 +75,13 @@ std::size_t num_interactions(const std::vector<std::pair<std::vector<
 }
 
 template<typename VarIndex, typename Bias>
-Bias get_linear(const std::vector<std::pair<std::vector<std::pair<VarIndex,
-                Bias>>, Bias>> &bqm, VarIndex v) {
+Bias get_linear(const AdjVectorBQM<VarIndex, Bias> &bqm, VarIndex v) {
     assert(v >= 0 && v < bqm.size());
     return bqm[v].second;
 }
 
 template<typename VarIndex, typename Bias>
-std::pair<Bias, bool> get_quadratic(const std::vector<std::pair<std::vector<
-                                    std::pair<VarIndex, Bias>>, Bias>> &bqm,
+std::pair<Bias, bool> get_quadratic(const AdjVectorBQM<VarIndex, Bias> &bqm,
                                     VarIndex u, VarIndex v) {
     assert(u >= 0 && u < bqm.size());
     assert(v >= 0 && v < bqm.size());
@@ -105,16 +99,14 @@ std::pair<Bias, bool> get_quadratic(const std::vector<std::pair<std::vector<
 
 // Change the values in the BQM
 template<typename VarIndex, typename Bias>
-void set_linear(std::vector<std::pair<std::vector<std::pair<VarIndex, Bias>>,
-                Bias>> &bqm,
+void set_linear(AdjVectorBQM<VarIndex, Bias> &bqm,
                 VarIndex v, Bias b) {
     assert(v >= 0 && v < bqm.size());
     bqm[v].second = b;
 }
 
 template<typename VarIndex, typename Bias>
-bool set_quadratic(std::vector<std::pair<std::vector<std::pair<VarIndex, Bias>>,
-                   Bias>> &bqm,
+bool set_quadratic(AdjVectorBQM<VarIndex, Bias> &bqm,
                    VarIndex u, VarIndex v, Bias b) {
     assert(u >= 0 && u < bqm.size());
     assert(v >= 0 && v < bqm.size());
@@ -147,8 +139,7 @@ bool set_quadratic(std::vector<std::pair<std::vector<std::pair<VarIndex, Bias>>,
 // Change the structure of the BQM
 
 template<typename VarIndex, typename Bias>
-VarIndex add_variable(std::vector<std::pair<std::vector<std::pair<VarIndex,
-                      Bias>>, Bias>> &bqm) {
+VarIndex add_variable(AdjVectorBQM<VarIndex, Bias> &bqm) {
     bqm.resize(num_variables(bqm)+1);
     return num_variables(bqm)-1;
 }
@@ -156,15 +147,13 @@ VarIndex add_variable(std::vector<std::pair<std::vector<std::pair<VarIndex,
 // todo: this should do nothing if the interaction is already present rather
 // than overriding with 0
 template<typename VarIndex, typename Bias>
-bool add_interaction(std::vector<std::pair<std::vector<std::pair<VarIndex,
-                     Bias>>, Bias>> &bqm,
+bool add_interaction(AdjVectorBQM<VarIndex, Bias> &bqm,
                      VarIndex u, VarIndex v, Bias b) {
     return set_quadratic(bqm, u, v, 0);
 }
 
 template<typename VarIndex, typename Bias>
-VarIndex pop_variable(std::vector<std::pair<std::vector<std::pair<VarIndex,
-                      Bias>>, Bias>> &bqm) {
+VarIndex pop_variable(AdjVectorBQM<VarIndex, Bias> &bqm) {
     assert(bqm.size() > 0);  // undefined for empty
 
     VarIndex v = bqm.size() - 1;
@@ -186,8 +175,7 @@ VarIndex pop_variable(std::vector<std::pair<std::vector<std::pair<VarIndex,
 }
 
 template<typename VarIndex, typename Bias>
-bool remove_interaction(std::vector<std::pair<std::vector<std::pair<VarIndex,
-                      Bias>>, Bias>> &bqm, VarIndex u, VarIndex v) {
+bool remove_interaction(AdjVectorBQM<VarIndex, Bias> &bqm, VarIndex u, VarIndex v) {
     assert(u >= 0 && u < bqm.size());
     assert(v >= 0 && v < bqm.size());
     assert(u != v);

--- a/dimod/bqm/src/adjvector.h
+++ b/dimod/bqm/src/adjvector.h
@@ -20,36 +20,26 @@
 
 namespace dimod {
 
+    template<typename VarIndex, typename Bias>
+    using VectorNeighbourhood = typename std::vector<std::pair<VarIndex, Bias>>;
 
-    // developer note: while we continue to support python2.7 we are stuck
-    // using visual studio 9.0 and consequently don't have access to template
-    // aliases. For now we'll just be more verbose but here they are for
-    // reference:
-    //
-    // template<typename VarIndex, typename Bias>
-    // using Neighbourhood = typename std::vector<std::pair<VarIndex, Bias>>;
-    //
-    // template<typename VarIndex, typename Bias>
-    // using AdjVectorBQM = typename std::vector<
-    //     std::pair<Neighbourhood<VarIndex, Bias>, Bias>>;
+    template<typename VarIndex, typename Bias>
+    using AdjVectorBQM = typename std::vector<
+        std::pair<VectorNeighbourhood<VarIndex, Bias>, Bias>>;
 
     // Read the BQM
 
     template<typename V, typename B>
-    std::size_t num_variables(
-        const std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&);
+    std::size_t num_variables(const AdjVectorBQM<V, B>&);
 
     template<typename V, typename B>
-    std::size_t num_interactions(
-        const std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&);
+    std::size_t num_interactions(const AdjVectorBQM<V, B>&);
 
     template<typename V, typename B>
-    B get_linear(
-        const std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V);
+    B get_linear(const AdjVectorBQM<V, B>&, V);
 
     template<typename V, typename B>
-    std::pair<B, bool> get_quadratic(
-        const std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V, V);
+    std::pair<B, bool> get_quadratic(const AdjVectorBQM<V, B>&, V, V);
 
     // todo: variable_iterator
     // todo: interaction_iterator
@@ -58,28 +48,24 @@ namespace dimod {
     // Change the values in the BQM
 
     template<typename V, typename B>
-    void set_linear(
-        std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V, B);
+    void set_linear(AdjVectorBQM<V, B>&, V, B);
 
     template<typename V, typename B>
-    bool set_quadratic(
-        std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V, V, B);
+    bool set_quadratic(AdjVectorBQM<V, B>&, V, V, B);
 
     // Change the structure of the BQM
 
     template<typename V, typename B>
-    V add_variable(std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&);
+    V add_variable(AdjVectorBQM<V, B>&);
 
     template<typename V, typename B>
-    bool add_interaction(
-        std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V, V);
+    bool add_interaction(AdjVectorBQM<V, B>&, V, V);
 
     template<typename V, typename B>
-    V pop_variable(std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&);
+    V pop_variable(AdjVectorBQM<V, B>&);
 
     template<typename V, typename B>
-    bool remove_interaction(
-        std::vector<std::pair<std::vector<std::pair<V, B>>, B>>&, V, V);
+    bool remove_interaction(AdjVectorBQM<V, B>&, V, V);
 }  // namespace dimod
 
 #endif  // DIMOD_BQM_SRC_ADJVECTOR_H_

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,11 @@ extensions = [Extension("dimod.roof_duality._fix_variables",
                         ['dimod/roof_duality/_fix_variables'+ext,
                          'dimod/roof_duality/src/fix_variables.cpp'],
                         include_dirs=['dimod/roof_duality/src/']),
+              ]
+
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 5:
+    extensions.extend([
               Extension("dimod.bqm.adjmapbqm",
                         ['dimod/bqm/adjmapbqm'+ext],
                         include_dirs=['dimod/bqm/src/'],
@@ -129,7 +134,7 @@ extensions = [Extension("dimod.roof_duality._fix_variables",
                         library_dirs=['dimod/bqm/src/']),
               Extension("dimod.bqm.utils",
                         ['dimod/bqm/utils'+ext]),
-              ]
+              ])
 
 if USE_CYTHON:
     from Cython.Build import cythonize

--- a/tests/test_adjarraybqm.py
+++ b/tests/test_adjarraybqm.py
@@ -13,18 +13,24 @@
 #    limitations under the License.
 #
 # =============================================================================
-
+import sys
 import unittest
 
 import numpy as np
-
-from dimod.bqm import AdjArrayBQM
 
 from tests.test_bqm import TestBQMAPI
 
 
 class TestAdjArray(TestBQMAPI, unittest.TestCase):
-    BQM = AdjArrayBQM
+
+    @classmethod
+    def setUpClass(cls):
+        if sys.version_info.major == 2 or sys.version_info.minor < 5:
+            raise unittest.SkipTest("Not supported in Python <= 3.5")
+
+        from dimod.bqm import AdjArrayBQM
+
+        cls.BQM = AdjArrayBQM
 
 
 # class TestEnergies(unittest.TestCase):

--- a/tests/test_adjmapbqm.py
+++ b/tests/test_adjmapbqm.py
@@ -13,15 +13,23 @@
 #    limitations under the License.
 #
 # =============================================================================
+import sys
 import unittest
 
-from dimod.bqm import AdjMapBQM
 
 from tests.test_bqm import TestShapeableBQMAPI
 
 
 class TestAdjMap(TestShapeableBQMAPI, unittest.TestCase):
-    BQM = AdjMapBQM
+
+    @classmethod
+    def setUpClass(cls):
+        if sys.version_info.major == 2 or sys.version_info.minor < 5:
+            raise unittest.SkipTest("Not supported in Python <= 3.5")
+
+        from dimod.bqm import AdjMapBQM
+
+        cls.BQM = AdjMapBQM
 
 
 # class TestQuadraticBase(unittest.TestCase):

--- a/tests/test_adjvectorbqm.py
+++ b/tests/test_adjvectorbqm.py
@@ -13,12 +13,20 @@
 #    limitations under the License.
 #
 # =============================================================================
+import sys
 import unittest
 
-from dimod.bqm import AdjVectorBQM
 
 from tests.test_bqm import TestShapeableBQMAPI
 
 
 class TestAdjVector(TestShapeableBQMAPI, unittest.TestCase):
-    BQM = AdjVectorBQM
+
+    @classmethod
+    def setUpClass(cls):
+        if sys.version_info.major == 2 or sys.version_info.minor < 5:
+            raise unittest.SkipTest("Not supported in Python <= 3.5")
+
+        from dimod.bqm import AdjVectorBQM
+
+        cls.BQM = AdjVectorBQM


### PR DESCRIPTION
Only the dictionary backend will be available in python2.7 and 3.4.

This allows us to use some of the newer c++ features like type aliases because we don't need to support visual studio 9.0