### PR TITLE
Store an adjarray bqm in c++ as a pair (invars, outvars)

### DIFF
--- a/dimod/bqm/adjarraybqm.pxd
+++ b/dimod/bqm/adjarraybqm.pxd
@@ -41,8 +41,7 @@ ctypedef fused SampleVar:
 
 
 cdef class cyAdjArrayBQM:
-    cdef vector[pair[size_t, Bias]] invars_
-    cdef vector[pair[VarIndex, Bias]] outvars_
+    cdef pair[vector[pair[size_t, Bias]], vector[pair[VarIndex, Bias]]] adj_
 
     cdef Bias offset_
 

--- a/dimod/bqm/cppbqm.pxd
+++ b/dimod/bqm/cppbqm.pxd
@@ -28,27 +28,23 @@ cdef extern from "src/adjarray.cc":
 
 cdef extern from "src/adjarray.h" namespace "dimod" nogil:
 
-    size_t num_variables[V, B](const vector[pair[size_t, B]]&,
-                               const vector[pair[V, B]]&)
-    size_t num_interactions[V, B](const vector[pair[size_t, B]]&,
-                                  const vector[pair[V, B]]&)
+    size_t num_variables[V, B](const pair[vector[pair[size_t, B]],
+                                          vector[pair[V, B]]]&)
+    size_t num_interactions[V, B](const pair[vector[pair[size_t, B]],
+                                             vector[pair[V, B]]]&)
 
-    B get_linear[V, B](const vector[pair[size_t, B]]&,
-                       const vector[pair[V, B]]&,
+    B get_linear[V, B](const pair[vector[pair[size_t, B]], vector[pair[V, B]]]&,
                        V)
-    pair[B, bool] get_quadratic[V, B](const vector[pair[size_t, B]]&,
-                                      const vector[pair[V, B]]&,
+    pair[B, bool] get_quadratic[V, B](const pair[vector[pair[size_t, B]], vector[pair[V, B]]]&,
                                       V, V)
 
     pair[vector[pair[V, B]].const_iterator,
          vector[pair[V, B]].const_iterator] neighborhood[V, B](
-        const vector[pair[size_t, B]]&, const vector[pair[V, B]]&, V)
+        const pair[vector[pair[size_t, B]], vector[pair[V, B]]]&, V)
 
-    void set_linear[V, B](vector[pair[size_t, B]]&,
-                          vector[pair[V, B]]&,
+    void set_linear[V, B](pair[vector[pair[size_t, B]], vector[pair[V, B]]]&,
                           V, B)
-    bool set_quadratic[V, B](vector[pair[size_t, B]]&,
-                             vector[pair[V, B]]&,
+    bool set_quadratic[V, B](pair[vector[pair[size_t, B]], vector[pair[V, B]]]&,
                              V, V, B)
 
 

--- a/dimod/bqm/shapeablebqm.pyx.src
+++ b/dimod/bqm/shapeablebqm.pyx.src
@@ -490,8 +490,8 @@ cdef class cyAdj@name@BQM:
 
         # create an empty adjarraybqm of the correct size
         cdef cyAdjArrayBQM bqm = cyAdjArrayBQM(vartype=self.vartype)
-        bqm.invars_.resize(num_variables(self.adj_))
-        bqm.outvars_.resize(2*num_interactions(self.adj_))
+        bqm.adj_.first.resize(num_variables(self.adj_))
+        bqm.adj_.second.resize(2*num_interactions(self.adj_))
 
         cdef pair[VarIndex, Bias] outvar
         cdef VarIndex ui
@@ -499,12 +499,12 @@ cdef class cyAdj@name@BQM:
         for ui in range(self.adj_.size()):
 
             # set the linear bias
-            bqm.invars_[ui].second = self.adj_[ui].second
-            bqm.invars_[ui].first = outvar_idx
+            bqm.adj_.first[ui].second = self.adj_[ui].second
+            bqm.adj_.first[ui].first = outvar_idx
 
             # set the quadratic biases
             for outvar in self.adj_[ui].first:
-                bqm.outvars_[outvar_idx] = outvar
+                bqm.adj_.second[outvar_idx] = outvar
                 outvar_idx += 1
 
         bqm.offset_ = self.offset_

--- a/dimod/bqm/src/adjarray.h
+++ b/dimod/bqm/src/adjarray.h
@@ -26,28 +26,28 @@ using AdjArrayInVars = typename std::vector<std::pair<std::size_t, Bias>>;
 template<typename VarIndex, typename Bias>
 using AdjArrayOutVars = typename std::vector<std::pair<VarIndex, Bias>>;
 
+template<typename VarIndex, typename Bias>
+using AdjArrayBQM = typename std::pair<AdjArrayInVars<Bias>,
+                                       AdjArrayOutVars<VarIndex, Bias>>;
+
 // Read the BQM
 
 template<typename V, typename B>
-std::size_t num_variables(const AdjArrayInVars<B>&,
-                            const AdjArrayOutVars<V, B>&);
+std::size_t num_variables(const AdjArrayBQM<V, B>&);
 
 template<typename V, typename B>
-std::size_t num_interactions(const AdjArrayInVars<B>&,
-                                const AdjArrayOutVars<V, B>&);
+std::size_t num_interactions(const AdjArrayBQM<V, B>&);
 
 template<typename V, typename B>
-B get_linear(const AdjArrayInVars<B>&, const AdjArrayOutVars<V, B>&, V);
+B get_linear(const AdjArrayBQM<V, B>&, V);
 
 template<typename V, typename B>
-std::pair<B, bool> get_quadratic(const AdjArrayInVars<B>&,
-                                    const AdjArrayOutVars<V, B>&,
-                                    V, V);
+std::pair<B, bool> get_quadratic(const AdjArrayBQM<V, B>&, V, V);
 
 template<typename V, typename B>
 std::pair<typename AdjArrayOutVars<V, B>::const_iterator,
             typename AdjArrayOutVars<V, B>::const_iterator>
-neighborhood(const AdjArrayInVars<B>&, const AdjArrayOutVars<V, B>&, V);
+neighborhood(const AdjArrayBQM<V, B>&, V);
 
 // todo: variable_iterator
 // todo: interaction_iterator
@@ -56,10 +56,10 @@ neighborhood(const AdjArrayInVars<B>&, const AdjArrayOutVars<V, B>&, V);
 // Change the values in the BQM
 
 template<typename V, typename B>
-void set_linear(AdjArrayInVars<B>&, AdjArrayOutVars<V, B>&, V, B);
+void set_linear(AdjArrayBQM<V, B>&, V, B);
 
 template<typename V, typename B>
-bool set_quadratic(AdjArrayInVars<B>&, AdjArrayOutVars<V, B>&, V, V, B);
+bool set_quadratic(AdjArrayBQM<V, B>&, V, V, B);
 
 }  // namespace dimod
 


### PR DESCRIPTION
This makes function overloading a lot nicer e.g.
```
num_variables(bqm) // for all
```
rather than
```
num_variables(invars, outvars)  // for array
num_variables(bqm)  // for map, vector
```