### PR TITLE
Add BQM.to_coo to cybqms

### DIFF
--- a/dimod/bqm/adjarraybqm.pxd
+++ b/dimod/bqm/adjarraybqm.pxd
@@ -26,6 +26,7 @@ from libcpp.vector cimport vector
 # does not allow fused types on cdef classes (yet) so for now we just fix them.
 ctypedef unsigned int VarIndex
 ctypedef double Bias
+ctypedef vector[pair[VarIndex, Bias]].const_iterator NeighborIterator
 
 ctypedef fused SampleVar:
     signed char  # np.int8

--- a/dimod/bqm/adjmapbqm.pxd
+++ b/dimod/bqm/adjmapbqm.pxd
@@ -28,6 +28,7 @@ from libcpp.vector cimport vector
 # does not allow fused types on cdef classes (yet) so for now we just fix them.
 ctypedef unsigned int VarIndex
 ctypedef double Bias
+ctypedef map[VarIndex, Bias].const_iterator NeighborIterator
 
 
 cdef class cyAdjMapBQM:

--- a/dimod/bqm/adjvectorbqm.pxd
+++ b/dimod/bqm/adjvectorbqm.pxd
@@ -26,6 +26,7 @@ from libcpp.vector cimport vector
 # does not allow fused types on cdef classes (yet) so for now we just fix them.
 ctypedef unsigned int VarIndex
 ctypedef double Bias
+ctypedef vector[pair[VarIndex, Bias]].const_iterator NeighborIterator
 
 
 cdef class cyAdjVectorBQM:

--- a/dimod/bqm/cppbqm.pxd
+++ b/dimod/bqm/cppbqm.pxd
@@ -41,6 +41,9 @@ cdef extern from "src/adjarray.h" namespace "dimod" nogil:
     pair[vector[pair[V, B]].const_iterator,
          vector[pair[V, B]].const_iterator] neighborhood[V, B](
         const pair[vector[pair[size_t, B]], vector[pair[V, B]]]&, V)
+    pair[vector[pair[V, B]].const_iterator,
+         vector[pair[V, B]].const_iterator] neighborhood[V, B](
+        const pair[vector[pair[size_t, B]], vector[pair[V, B]]]&, V, bool)
 
     void set_linear[V, B](pair[vector[pair[size_t, B]], vector[pair[V, B]]]&,
                           V, B)
@@ -66,6 +69,9 @@ cdef extern from "src/adjmap.h" namespace "dimod" nogil:
     pair[cppmap[V, B].const_iterator,
          cppmap[V, B].const_iterator] neighborhood[V, B](
         vector[pair[cppmap[V, B], B]]&, V)
+    pair[cppmap[V, B].const_iterator,
+         cppmap[V, B].const_iterator] neighborhood[V, B](
+        vector[pair[cppmap[V, B], B]]&, V, bool)
 
     size_t degree[V, B](vector[pair[cppmap[V, B], B]]&, V)
 
@@ -97,6 +103,9 @@ cdef extern from "src/adjvector.h" namespace "dimod" nogil:
     pair[vector[pair[V, B]].const_iterator,
          vector[pair[V, B]].const_iterator] neighborhood[V, B](
         vector[pair[vector[pair[V, B]], B]]&, V)
+    pair[vector[pair[V, B]].const_iterator,
+         vector[pair[V, B]].const_iterator] neighborhood[V, B](
+        vector[pair[vector[pair[V, B]], B]]&, V, bool)
 
     size_t degree[V, B](vector[pair[vector[pair[V, B]], B]]&, V)
 

--- a/dimod/bqm/shapeablebqm.pyx.src
+++ b/dimod/bqm/shapeablebqm.pyx.src
@@ -25,6 +25,10 @@ except ImportError:
 
 from numbers import Integral
 
+cimport cython
+
+from cython.operator cimport postincrement as inc, dereference as deref
+
 import numpy as np
 
 from dimod.bqm.adjarraybqm cimport cyAdjArrayBQM
@@ -33,6 +37,7 @@ from dimod.bqm.cppbqm cimport (add_variable,
                                degree,
                                get_linear,
                                get_quadratic,
+                               neighborhood,
                                num_variables,
                                num_interactions,
                                pop_variable,
@@ -514,6 +519,50 @@ cdef class cyAdj@name@BQM:
         bqm._idx_to_label.update(self._idx_to_label)
 
         return bqm
+
+    # note that this is identical to the implemenation in adjarraybqm.pyx
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def to_coo(self):
+        cdef Py_ssize_t nv = num_variables(self.adj_)
+        cdef Py_ssize_t ni = num_interactions(self.adj_)
+
+        # numpy arrays, we will return these
+        ldata = np.empty(nv, dtype=self.dtype)
+        irow = np.empty(ni, dtype=self.index_dtype)
+        icol = np.empty(ni, dtype=self.index_dtype)
+        qdata = np.empty(ni, dtype=self.dtype)
+
+        # views into the numpy arrays for faster cython access
+        cdef Bias[:] ldata_view = ldata
+        cdef VarIndex[:] irow_view = irow
+        cdef VarIndex[:] icol_view = icol
+        cdef Bias[:] qdata_view = qdata
+
+        # types needed for the loop
+        cdef pair[NeighborIterator, NeighborIterator] span
+        cdef VarIndex vi
+        cdef Py_ssize_t qi = 0  # index in the quadratic arrays
+
+        for vi in range(nv):
+            ldata_view[vi] = get_linear(self.adj_, vi)
+
+            # The last argument indicates we should only iterate over the
+            # neighbours that have higher index than vi
+            span = neighborhood(self.adj_, vi, True)
+
+            while span.first != span.second:
+                irow_view[qi] = vi
+                icol_view[qi] = deref(span.first).first
+                qdata_view[qi] = deref(span.first).second
+
+                qi += 1
+                inc(span.first)
+
+        # all python objects
+        labels = [self._idx_to_label.get(v, v) for v in range(nv)]
+
+        return ldata, (irow, icol, qdata), self.offset, labels
 
 
 class Adj@name@BQM(cyAdj@name@BQM, ShapeableBQM):

--- a/dimod/bqm/src/adjarray.cc
+++ b/dimod/bqm/src/adjarray.cc
@@ -71,24 +71,30 @@ std::pair<Bias, bool> get_quadratic(const AdjArrayBQM<VarIndex, Bias> &bqm,
 // Iterate over the neighbourhood of variable u.
 //
 // Returns iterators to beginning and end of neighborhood.
+// upper_triangular will gives the start iterator at the first index > u
 template<typename VarIndex, typename Bias>
 std::pair<typename AdjArrayOutVars<VarIndex, Bias>::const_iterator,
-            typename AdjArrayOutVars<VarIndex, Bias>::const_iterator>
-neighborhood(const AdjArrayBQM<VarIndex, Bias> &bqm,
-                VarIndex u) {
-    std::size_t start, stop;
-
-    start = bqm.first[u].first;
+          typename AdjArrayOutVars<VarIndex, Bias>::const_iterator>
+neighborhood(const AdjArrayBQM<VarIndex, Bias> &bqm, VarIndex u,
+             bool upper_triangular) {
+    typename AdjArrayOutVars<VarIndex, Bias>::const_iterator start, stop;
 
     if (u == bqm.first.size() - 1) {
         // last element so ends at the end out bqm.second
-        stop = bqm.second.size();
+        stop = bqm.second.end();
     } else {
-        stop = bqm.first[u+1].first;
+        stop = bqm.second.begin() + bqm.first[u+1].first;
+    }
+
+    start = bqm.second.begin() + bqm.first[u].first;
+    if (upper_triangular) {
+        // binary search to find the index of the starting position
+        const std::pair<VarIndex, Bias> target(u, 0);
+        start = std::lower_bound(start, stop, target, pair_lt<VarIndex, Bias>);
     }
 
     // random access iterators
-    return std::make_pair(bqm.second.begin() + start, bqm.second.begin() + stop);
+    return std::make_pair(start, stop);
 }
 
 // Change the values in the BQM

--- a/dimod/bqm/src/adjarray.h
+++ b/dimod/bqm/src/adjarray.h
@@ -47,7 +47,7 @@ std::pair<B, bool> get_quadratic(const AdjArrayBQM<V, B>&, V, V);
 template<typename V, typename B>
 std::pair<typename AdjArrayOutVars<V, B>::const_iterator,
             typename AdjArrayOutVars<V, B>::const_iterator>
-neighborhood(const AdjArrayBQM<V, B>&, V);
+neighborhood(const AdjArrayBQM<V, B>&, V, bool upper_triangular = false);
 
 // todo: variable_iterator
 // todo: interaction_iterator

--- a/dimod/bqm/src/adjmap.cc
+++ b/dimod/bqm/src/adjmap.cc
@@ -61,9 +61,18 @@ std::pair<Bias, bool> get_quadratic(const AdjMapBQM<VarIndex, Bias> &bqm,
 
 template<typename VarIndex, typename Bias>
 std::pair<typename MapNeighbourhood<VarIndex, Bias>::const_iterator,
-            typename MapNeighbourhood<VarIndex, Bias>::const_iterator>
-neighborhood(const AdjMapBQM<VarIndex, Bias> &bqm, VarIndex v) {
-    return std::make_pair(bqm[v].first.begin(), bqm[v].first.end());
+          typename MapNeighbourhood<VarIndex, Bias>::const_iterator>
+neighborhood(const AdjMapBQM<VarIndex, Bias> &bqm, VarIndex v,
+             bool upper_triangular) {
+    typename MapNeighbourhood<VarIndex, Bias>::const_iterator start;
+
+    if (upper_triangular) {
+        // std::pair<VarIndex, Bias> target(v, 0);
+        start = bqm[v].first.lower_bound(v);
+    } else {
+        start = bqm[v].first.begin();
+    }
+    return std::make_pair(start, bqm[v].first.end());
 }
 
 template<typename VarIndex, typename Bias>

--- a/dimod/bqm/src/adjmap.h
+++ b/dimod/bqm/src/adjmap.h
@@ -47,8 +47,8 @@ std::size_t degree(const AdjMapBQM<V, B>&, V);
 
 template<typename V, typename B>
 std::pair<typename MapNeighbourhood<V, B>::const_iterator,
-            typename MapNeighbourhood<V, B>::const_iterator>
-neighborhood(const AdjMapBQM<V, B>&, V);
+          typename MapNeighbourhood<V, B>::const_iterator>
+neighborhood(const AdjMapBQM<V, B>&, V, bool upper_triangular = false);
 
 // todo: variable_iterator
 // todo: interaction_iterator

--- a/dimod/bqm/src/adjvector.cc
+++ b/dimod/bqm/src/adjvector.cc
@@ -100,8 +100,18 @@ std::pair<Bias, bool> get_quadratic(const AdjVectorBQM<VarIndex, Bias> &bqm,
 template<typename VarIndex, typename Bias>
 std::pair<typename VectorNeighbourhood<VarIndex, Bias>::const_iterator,
           typename VectorNeighbourhood<VarIndex, Bias>::const_iterator>
-neighborhood(const AdjVectorBQM<VarIndex, Bias> &bqm, VarIndex v) {
-    return std::make_pair(bqm[v].first.begin(), bqm[v].first.end());
+neighborhood(const AdjVectorBQM<VarIndex, Bias> &bqm, VarIndex v,
+             bool upper_triangular) {
+    typename VectorNeighbourhood<VarIndex, Bias>::const_iterator start;
+
+    if (upper_triangular) {
+        std::pair<VarIndex, Bias> target(v, 0);
+        start = std::lower_bound(bqm[v].first.begin(), bqm[v].first.end(),
+                                 target, pair_lt<VarIndex, Bias>);
+    } else {
+        start = bqm[v].first.begin();
+    }
+    return std::make_pair(start, bqm[v].first.end());
 }
 
 template<typename VarIndex, typename Bias>

--- a/dimod/bqm/src/adjvector.h
+++ b/dimod/bqm/src/adjvector.h
@@ -47,7 +47,7 @@ std::size_t degree(const AdjVectorBQM<V, B>&, V);
 template<typename V, typename B>
 std::pair<typename VectorNeighbourhood<V, B>::const_iterator,
             typename VectorNeighbourhood<V, B>::const_iterator>
-neighborhood(const AdjVectorBQM<V, B>&, V);
+neighborhood(const AdjVectorBQM<V, B>&, V, bool upper_triangular = false);
 
 // todo: variable_iterator
 // todo: interaction_iterator

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -281,6 +281,20 @@ class TestBQMAPI:
         self.assertEqual(self.BQM(dimod.SPIN).num_interactions, 0)
         self.assertEqual(self.BQM(0, dimod.SPIN).num_interactions, 0)
 
+    def test_to_coo_empty(self):
+        bqm = self.BQM('SPIN')
+        ldata, (irow, icol, qdata), off, labels = bqm.to_coo()
+
+    def test_to_coo(self):
+        bqm = self.BQM(({'a': -1}, {'ab': 2}), 'SPIN')
+        ldata, (irow, icol, qdata), off, labels = bqm.to_coo()
+
+        np.testing.assert_array_equal(ldata, [-1, 0])
+        np.testing.assert_array_equal(irow, [0])
+        np.testing.assert_array_equal(icol, [1])
+        np.testing.assert_array_equal(qdata, [2])
+        self.assertEqual(labels, ['a', 'b'])
+
     def test_vartype(self):
         bqm = self.BQM(vartype='SPIN')
         self.assertEqual(bqm.vartype, dimod.SPIN)


### PR DESCRIPTION
Fast construction of numpy arrays from cyBQMs

This PR has some name issues, namely it has a similar api to [BQM.to_numpy_vectors](https://github.com/dwavesystems/dimod/blob/4bfd23c28917d160aa2bd06fac234eeeb472bbd0/dimod/binary_quadratic_model.py#L2341) but the same method name as [BQM.to_coo](https://github.com/dwavesystems/dimod/blob/4bfd23c28917d160aa2bd06fac234eeeb472bbd0/dimod/binary_quadratic_model.py#L1556). I think this way is much clearer and better named, but perhaps we should maintain the backwards compatibility.

On the other hand, this could also be confused with SciPy's [.tocoo](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.sparse.coo_matrix.tocoo.html#scipy.sparse.coo_matrix.tocoo)