### PR TITLE
Fix variables to one of the allowed values

### DIFF
--- a/dimod/reference/composites/connectedcomponent.py
+++ b/dimod/reference/composites/connectedcomponent.py
@@ -94,9 +94,10 @@ class ConnectedComponentsComposite(ComposedSampler):
         if isinstance(components, set):
             components = [components]
         sampleset = None
+        fixed_value = list(bqm.vartype.value)[0]
         for component in components:
             bqm_copy = bqm.copy()
-            bqm_copy.fix_variables({i: 0 for i in (variables - component)})
+            bqm_copy.fix_variables({i: fixed_value for i in (variables - component)})
             if sampleset is None:
                 # here .truncate(1) is used to pick the best solution only. The other options
                 # for future development is to combine all sample with all.

--- a/dimod/reference/composites/connectedcomponent.py
+++ b/dimod/reference/composites/connectedcomponent.py
@@ -94,7 +94,7 @@ class ConnectedComponentsComposite(ComposedSampler):
         if isinstance(components, set):
             components = [components]
         sampleset = None
-        fixed_value = list(bqm.vartype.value)[0]
+        fixed_value = min(bqm.vartype.value)
         for component in components:
             bqm_copy = bqm.copy()
             bqm_copy.fix_variables({i: fixed_value for i in (variables - component)})


### PR DESCRIPTION
When fixing the independent variables, the value of the fixed variable has no effect. However, if a solver checks for valid values only, we need to pass 0 or 1 for 'BINARY' and -1 or 1 for 'SPIN'. This pull request fixes this issue.