### PR TITLE
Build sdk without dimod warnings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
                                  Apache License
+
                            Version 2.0, January 2004
+                           
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

--- a/dimod/core/composite.py
+++ b/dimod/core/composite.py
@@ -74,7 +74,7 @@ __all__ = ['Composite', 'ComposedSampler']
 class Composite:
     """Abstract base class for dimod composites.
 
-    Provides the :attr:`.child` mixin property and defines the :attr:`~.Composite.children`
+    Provides the :attr:`Composite.child` mixin property and defines the :attr:`Composite.children`
     abstract property to be implemented. These define the supported samplers for the composed sampler.
 
     """
@@ -87,7 +87,7 @@ class Composite:
 
     @property
     def child(self):
-        """:obj:`.Sampler`: The child sampler. First sampler in :attr:`.children`."""
+        """:obj:`.Sampler`: The child sampler. First sampler in :attr:`Composite.children`."""
         try:
             return self.children[0]
         except IndexError:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ add_module_names = False
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'sdk_index.rst']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/reference/bqm/binary_quadratic_model.rst
+++ b/docs/reference/bqm/binary_quadratic_model.rst
@@ -126,6 +126,8 @@ Converting To and From Other Formats
    BinaryQuadraticModel.to_pandas_dataframe
    BinaryQuadraticModel.to_serializable
 
+.. _COOrdinate: https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)
+
 Alias
 =====
 .. autoclass:: BQM

--- a/docs/reference/sampler_composites/composites.rst
+++ b/docs/reference/sampler_composites/composites.rst
@@ -8,11 +8,8 @@ The `dimod` package includes several example composed samplers.
 
 .. currentmodule:: dimod.reference.composites
 
-.. automodule:: dimod.reference.composites
-
-
 Connected Components Composite
-------------------------
+------------------------------
 
 .. automodule:: dimod.reference.composites.connectedcomponent
 
@@ -31,7 +28,7 @@ Properties
    ConnectedComponentsComposite.children
    ConnectedComponentsComposite.parameters
    ConnectedComponentsComposite.properties
-   
+
 Methods
 ~~~~~~~
 

--- a/docs/reference/sampler_composites/higher_order_composites.rst
+++ b/docs/reference/sampler_composites/higher_order_composites.rst
@@ -6,12 +6,10 @@ Higher-Order Composites
 
 The `dimod` package includes several example higher-order composed samplers.
 
+.. currentmodule:: dimod.reference.composites
+
 HigherOrderComposite
 ====================
-
-.. automodule:: dimod.reference.composites.higherordercomposites
-
-.. currentmodule:: dimod.reference.composites.higherordercomposites
 
 .. autoclass:: HigherOrderComposite
 
@@ -38,10 +36,6 @@ Methods
 
 PolyFixedVariableComposite
 ==========================
-
-.. automodule:: dimod.reference.composites.higherordercomposites
-
-.. currentmodule:: dimod.reference.composites.higherordercomposites
 
 .. autoclass:: PolyFixedVariableComposite
 


### PR DESCRIPTION
Currently SDK unified docs builds with >300 warnings. These changes get rid of all warnings generated by a dimod build.