### PR TITLE
fix float index issue

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -1456,7 +1456,7 @@ class SampleSet(abc.Iterable, abc.Sized):
         vectors = {name: np.load(io.BytesIO(vector)) for name, vector in record.items()}
 
         # get the samples and unpack then
-        shape = obj['sample_shape']
+        shape = np.array(obj['sample_shape'],dtype=int)
         dtype = obj['sample_dtype']
         sample = np.unpackbits(vectors.pop('sample'))[:shape[0]*shape[1]].astype(dtype).reshape(shape)
 

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -1456,7 +1456,7 @@ class SampleSet(abc.Iterable, abc.Sized):
         vectors = {name: np.load(io.BytesIO(vector)) for name, vector in record.items()}
 
         # get the samples and unpack then
-        shape = np.array(obj['sample_shape'],dtype=int)
+        shape = np.array(obj['sample_shape'], dtype=int)
         dtype = obj['sample_dtype']
         sample = np.unpackbits(vectors.pop('sample'))[:shape[0]*shape[1]].astype(dtype).reshape(shape)
 


### PR DESCRIPTION
when trying to deserialize from version 2.0.0 of serialization, I encountered a problem in which the shape is saved as float hence causing issues in unpacking. I do not know how it managed to save it as float since I did not interfere with the process but changing it so that we are always passing an int for index and shape