### PR TITLE
Add a unified include path for dimod headers

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include dimod/roof_duality *.cpp *.pyx *.hpp
 recursive-include dimod/bqm *.cc *.h *.pyx *.pxd *.pyx.src
+recursive-include dimod/include *h

--- a/dimod/include/dimod/README.rst
+++ b/dimod/include/dimod/README.rst
@@ -1,0 +1,2 @@
+Note: These files should not be considered stable and do not (yet) respect
+dimod's semantic versioning.

--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -12,11 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# ================================================================================================
-"""
-Utility functions useful for samplers.
-"""
+# =============================================================================
 import copy
+import os
 import itertools
 
 from six import iteritems, itervalues
@@ -28,6 +26,7 @@ __all__ = ['ising_energy',
            'ising_to_qubo',
            'qubo_to_ising',
            'child_structure_dfs',
+           'get_include',
            ]
 
 
@@ -492,3 +491,8 @@ class LockableDict(dict):
     @lockable_method
     def update(self, *args, **kwargs):
         return super(LockableDict, self).update(*args, **kwargs)
+
+
+def get_include():
+    """Return the directory with dimod's header files."""
+    return os.path.join(os.path.dirname(__file__), 'include')

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ from distutils.extension import Extension
 from distutils.command.build_ext import build_ext
 
 # add __version__, __author__, __authoremail__, __description__ to this namespace
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
-exec(open(os.path.join(".", "dimod", "package_info.py")).read())
+exec(open(os.path.join(os.path.dirname(__file__), "dimod", "package_info.py")).read())
 
 install_requires = ['numpy>=1.16.0,<2.0.0',
                     'six>=1.10.0,<2.0.0',
@@ -82,9 +81,13 @@ extra_link_args = {
 
 class build_ext_compiler_check(build_ext):
     def run(self):
+        # add numpy headers
         import numpy
-
         self.include_dirs.append(numpy.get_include())
+
+        # add dimod headers
+        include = os.path.join(os.path.dirname(__file__), 'dimod', 'include')
+        self.include_dirs.append(include)
 
         build_ext.run(self)
 


### PR DESCRIPTION
Follows NumPy's pattern.

#630 should be rebased to use it.
Also roof duality's code, see #519.