### PR TITLE
Allow ising_to_qubo to be provided with an underspecified linear

### DIFF
--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -199,8 +199,8 @@ def ising_to_qubo(h, J, offset=0.0):
         if bias == 0.0:
             continue
         q[(u, v)] = 4. * bias
-        q[(u, u)] -= 2. * bias
-        q[(v, v)] -= 2. * bias
+        q[(u, u)] = q.setdefault((u, u), 0) - 2. * bias
+        q[(v, v)] = q.setdefault((v, v), 0) - 2. * bias
 
     # finally calculate the offset
     offset += sum(J.values()) - sum(h.values())

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -214,6 +214,15 @@ class TestIsingToQubo(unittest.TestCase):
 
         self.assertAlmostEqual(offset + 3, offset2)
 
+    def test_underspecified_h(self):
+        h = {}
+        J = {'ab': -1}
+
+        Q, offset = ising_to_qubo(h, J)
+
+        self.assertEqual(Q, {('a', 'b'): -4, ('a', 'a'): 2, ('b', 'b'): 2})
+        self.assertEqual(offset, -1.0)
+
 
 class TestQuboToIsing(unittest.TestCase):
     def test_trivial(self):


### PR DESCRIPTION
Closes #650 