### PR TITLE
Sort different types supported by Python 2 and 3

### DIFF
--- a/dimod/binary_quadratic_model.py
+++ b/dimod/binary_quadratic_model.py
@@ -285,12 +285,7 @@ class BinaryQuadraticModel(AdjDictBQM, Sized, Iterable, Container):
         schema_version = "3.0.0"
 
         variables = list(iter_serialize_variables(self.variables))
-
-        try:
-            variables.sort()
-        except TypeError:
-            # cannot unlike types in py3
-            pass
+        variables.sort(key=lambda x: str(x))
 
         num_variables = len(variables)
 


### PR DESCRIPTION
Something to consider, since the expected behaviour is that all variables are sorted deterministically and only Python 2.7 has the expected behaviour right now.

This change could be done to all other instances of `sort` not being done deterministically for Python 3.