### PR TITLE
Decorator for nonblocking sample methods

### DIFF
--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -21,6 +21,7 @@ Decorators
    bqm_index_labelled_input
    bqm_structured
    graph_argument
+   nonblocking_sample_method
    vartype_argument
 
 


### PR DESCRIPTION
This decorator is intended to make it easier to construct non-blocking composites, (e.g. would have simplified #555,  #677).

This approach might be convenient for expert users, but I am worried that it obfuscates the implementation in a confusing way.