### PR TITLE
Add Adj*BQM::linear

### DIFF
--- a/dimod/include/dimod/adjarraybqm.h
+++ b/dimod/include/dimod/adjarraybqm.h
@@ -47,7 +47,7 @@ class AdjArrayBQM {
         outvars.reserve(2*bqm.num_interactions());
 
         for (auto v = 0; v < bqm.num_variables(); ++v) {
-            invars.emplace_back(outvars.size(), bqm.get_linear(v));
+            invars.emplace_back(outvars.size(), bqm.linear(v));
 
             auto span = bqm.neighborhood(v);
             outvars.insert(outvars.end(), span.first, span.second);
@@ -97,8 +97,9 @@ class AdjArrayBQM {
         return invars.size();
     }
 
+    [[deprecated("Use AdjArrayBQM::linear(v)")]]
     bias_type get_linear(variable_type v) const {
-        return invars[v].second;
+        return linear(v);
     }
 
     std::pair<bias_type, bool>
@@ -124,6 +125,16 @@ class AdjArrayBQM {
             return outvars.size() - invars[v].first;
 
         return invars[v+1].first - invars[v].first;
+    }
+
+    bias_type& linear(variable_type v) {
+        assert(v >= 0 && v < invars.size());
+        return invars[v].second;
+    }
+
+    const bias_type& linear(variable_type v) const {
+        assert(v >= 0 && v < invars.size());
+        return invars[v].second;
     }
 
     std::pair<outvars_iterator, outvars_iterator>
@@ -154,9 +165,10 @@ class AdjArrayBQM {
         return std::make_pair(outvars.cbegin() + invars[u].first, end);
     }
 
+    [[deprecated("Use AdjArrayBQM::linear(v)")]]
     void set_linear(variable_type v, bias_type b) {
         assert(v >= 0 && v < invars.size());
-        invars[v].second = b;
+        linear(v) = b;
     }
 
     bool set_quadratic(variable_type u, variable_type v, bias_type b) {

--- a/dimod/include/dimod/adjmapbqm.h
+++ b/dimod/include/dimod/adjmapbqm.h
@@ -43,7 +43,7 @@ class AdjMapBQM {
         adj.resize(bqm.num_variables());
 
         for (variable_type v = 0; v < bqm.num_variables(); ++v) {
-            set_linear(v, bqm.get_linear(v));
+            linear(v) = bqm.linear(v);
 
             auto span = bqm.neighborhood(v);
             adj[v].first.insert(span.first, span.second);
@@ -94,8 +94,9 @@ class AdjMapBQM {
         return adj[v].first.size();
     }
 
+    [[deprecated("Use AdjMapBQM::linear(v)")]]
     bias_type get_linear(variable_type v) const {
-        return adj[v].second;
+        return linear(v);
     }
 
     std::pair<bias_type, bool>
@@ -110,6 +111,16 @@ class AdjMapBQM {
             return std::make_pair(0, false);
 
         return std::make_pair(it->second, true);
+    }
+
+    bias_type& linear(variable_type v) {
+        assert(v >= 0 && v < adj.size());
+        return adj[v].second;
+    }
+
+    const bias_type& linear(variable_type v) const {
+        assert(v >= 0 && v < adj.size());
+        return adj[v].second;
     }
 
     std::pair<outvars_iterator, outvars_iterator>
@@ -161,9 +172,10 @@ class AdjMapBQM {
         return false;
     }
 
+    [[deprecated("Use AdjMapBQM::linear(v)")]]
     void set_linear(variable_type v, bias_type b) {
-        assert(v >= 0 && v < invars.size());
-        adj[v].second = b;
+        assert(v >= 0 && v < adj.size());
+        linear(v) = b;
     }
 
     bool set_quadratic(variable_type u, variable_type v, bias_type b) {

--- a/dimod/include/dimod/adjvectorbqm.h
+++ b/dimod/include/dimod/adjvectorbqm.h
@@ -43,7 +43,7 @@ class AdjVectorBQM {
         adj.resize(bqm.num_variables());
 
         for (variable_type v = 0; v < bqm.num_variables(); ++v) {
-            set_linear(v, bqm.get_linear(v));
+            linear(v) = bqm.linear(v);
 
             auto span = bqm.neighborhood(v);
             adj[v].first.insert(adj[v].first.begin(), span.first, span.second);
@@ -94,8 +94,9 @@ class AdjVectorBQM {
         return adj[v].first.size();
     }
 
+    [[deprecated("Use AdjVectorBQM::linear(v)")]]
     bias_type get_linear(variable_type v) const {
-        return adj[v].second;
+        return linear(v);
     }
 
     std::pair<bias_type, bool>
@@ -111,6 +112,17 @@ class AdjVectorBQM {
         if (low == span.second || low->first != v)
             return std::make_pair(0, false);
         return std::make_pair(low->second, true);
+    }
+
+
+    bias_type& linear(variable_type v) {
+        assert(v >= 0 && v < adj.size());
+        return adj[v].second;
+    }
+
+    const bias_type& linear(variable_type v) const {
+        assert(v >= 0 && v < adj.size());
+        return adj[v].second;
     }
 
     std::pair<outvars_iterator, outvars_iterator>
@@ -179,9 +191,10 @@ class AdjVectorBQM {
         return exists;
     }
 
+    [[deprecated("Use AdjVectorBQM::linear(v)")]]
     void set_linear(variable_type v, bias_type b) {
-        assert(v >= 0 && v < invars.size());
-        adj[v].second = b;
+        assert(v >= 0 && v < adj.size());
+        linear(v) = b;
     }
 
     bool set_quadratic(variable_type u, variable_type v, bias_type b) {


### PR DESCRIPTION
Gives slightly nicer access to the linear biases in c++ BQMs. E.g.
```
bqm.linear(v) += 1;
```
rather than
```
bqm.set_linear(v, bqm_get_linear(v) + 1);
```

I would love to have `bqm.quadratic(u, v)` as well, but because we keep two copies of the bias around for quadratic, we can't just return a reference like we do with `.linear`. Open to suggestions.