### PR TITLE
DQM Serialization

### DIFF
--- a/dimod/bqm/cppbqm.pxd
+++ b/dimod/bqm/cppbqm.pxd
@@ -81,6 +81,7 @@ cdef extern from "dimod/adjarraybqm.h" namespace "dimod" nogil:
         size_type degree(variable_type) except +
         bias_type get_linear(variable_type) except +
         pair[bias_type, bool] get_quadratic(variable_type, variable_type) except +
+        bias_type& linear(variable_type) except +
         pair[outvars_iterator, outvars_iterator] neighborhood(variable_type) except +
         pair[const_outvars_iterator, const_outvars_iterator] neighborhood(variable_type, variable_type) except +
         size_type num_interactions() except +
@@ -143,6 +144,7 @@ cdef extern from "dimod/adjmapbqm.h" namespace "dimod" nogil:
         size_type degree(variable_type) except +
         bias_type get_linear(variable_type) except +
         pair[bias_type, bool] get_quadratic(variable_type, variable_type) except +
+        bias_type& linear(variable_type) except +
         pair[outvars_iterator, outvars_iterator] neighborhood(variable_type) except +
         pair[const_outvars_iterator, const_outvars_iterator] neighborhood(variable_type, variable_type) except +
         size_type num_interactions() except +
@@ -211,6 +213,7 @@ cdef extern from "dimod/adjvectorbqm.h" namespace "dimod" nogil:
         size_type degree(variable_type) except +
         bias_type get_linear(variable_type) except +
         pair[bias_type, bool] get_quadratic(variable_type, variable_type) except +
+        bias_type& linear(variable_type) except +
         pair[outvars_iterator, outvars_iterator] neighborhood(variable_type) except +
         pair[const_outvars_iterator, const_outvars_iterator] neighborhood(variable_type, variable_type) except +
         size_type num_interactions() except +

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -27,6 +27,19 @@ ctypedef np.float64_t Bias
 ctypedef np.int64_t CaseIndex
 ctypedef np.int64_t VarIndex
 
+ctypedef fused Unsigned:
+    np.uint8_t
+    np.uint16_t
+    np.uint32_t
+    np.uint64_t
+
+ctypedef fused Integral:
+    Unsigned
+    np.int8_t
+    np.int16_t
+    np.int32_t
+    np.int64_t
+
 
 cdef class cyDiscreteQuadraticModel:
     cdef cppAdjVectorBQM[CaseIndex, Bias] bqm_
@@ -47,3 +60,8 @@ cdef class cyDiscreteQuadraticModel:
         self, VarIndex, CaseIndex, VarIndex, CaseIndex, Bias) except -1
     cpdef Bias get_quadratic_case(
         self, VarIndex, CaseIndex, VarIndex, CaseIndex)  except? -45.3
+
+    cdef void _into_numpy_vectors(self, Unsigned[:] starts, Bias[:] ldata,
+        Unsigned[:] irow, Unsigned[:] icol, Bias[:] qdata)
+    cdef void _from_numpy_vectors(self, Integral[:] starts, Bias[:] ldata,
+        Integral[:] irow, Integral[:] icol, Bias[:] qdata) except *

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -53,6 +53,8 @@ cdef class cyDiscreteQuadraticModel:
     cpdef Bias[:] energies(self, CaseIndex[:, :])
     cpdef Bias get_linear_case(self, VarIndex, CaseIndex) except? -45.3
     cpdef Py_ssize_t num_cases(self, Py_ssize_t v=*) except -1
+    cpdef Py_ssize_t num_case_interactions(self)
+    cpdef Py_ssize_t num_variable_interactions(self) except -1
     cpdef Py_ssize_t num_variables(self)
     cpdef Py_ssize_t set_linear(self, VarIndex, Bias[:]) except -1
     cpdef Py_ssize_t set_linear_case(self, VarIndex, CaseIndex, Bias) except -1

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -354,6 +354,20 @@ cdef class cyDiscreteQuadraticModel:
 
         return self.case_starts_[v+1] - self.case_starts_[v]
 
+    cpdef Py_ssize_t num_case_interactions(self):
+        """The total number of case interactions."""
+        return self.bqm_.num_interactions()
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    cpdef Py_ssize_t num_variable_interactions(self) except -1:
+        """The total number of case interactions."""
+        cdef Py_ssize_t num = 0
+        cdef Py_ssize_t v
+        for v in range(self.num_variables()):
+            num += self.adj_[v].size()
+        return num // 2
+
     cpdef Py_ssize_t num_variables(self):
         """The number of discrete variables in the DQM."""
         return self.adj_.size()

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -553,22 +553,23 @@ class DiscreteQuadraticModel:
         file.write(np.dtype('<u4').type(end - start).tobytes())
         file.seek(end)
 
-    def to_file(self, max_size=int(1e9), compressed=False, ignore_labels=False):
+    def to_file(self, compressed=False, ignore_labels=False,
+                spool_size=int(1e9)):
         """Convert the DQM to a file-like object.
 
         Args:
-            max_size (int, optional, default=int(1e9)):
-                Passed to the constructor of the returned
-                :class:`tempfile.SpooledTemporaryFile`. Determines whether
-                the returned file-like's contents will be kept on disk or in
-                memory.
-
             compressed (bool, optional default=False):
                 If True, most of the data will be compressed.
 
             ignore_labels (bool, optional, default=False):
                 Treat the DQM as unlabeled. This is useful for large DQMs to
                 save on space.
+
+            spool_size (int, optional, default=int(1e9)):
+                Defines the `max_size` passed to the constructor of
+                :class:`tempfile.SpooledTemporaryFile`. Determines whether
+                the returned file-like's contents will be kept on disk or in
+                memory.
 
         Returns:
             :class:`tempfile.SpooledTemporaryFile`: A file-like object
@@ -634,7 +635,7 @@ class DiscreteQuadraticModel:
 
         """
 
-        file = tempfile.SpooledTemporaryFile(max_size=max_size)
+        file = tempfile.SpooledTemporaryFile(max_size=spool_size)
 
         # attach the header
         header_parts = [DQM_MAGIC_PREFIX,

--- a/docs/reference/dqm.rst
+++ b/docs/reference/dqm.rst
@@ -29,15 +29,19 @@ Methods
    :toctree: generated/
 
    ~DiscreteQuadraticModel.add_variable
+   ~DiscreteQuadraticModel.from_file
    ~DiscreteQuadraticModel.from_numpy_vectors
    ~DiscreteQuadraticModel.get_linear
    ~DiscreteQuadraticModel.get_linear_case
    ~DiscreteQuadraticModel.get_quadratic
    ~DiscreteQuadraticModel.get_quadratic_case
    ~DiscreteQuadraticModel.num_cases
+   ~DiscreteQuadraticModel.num_case_interactions
+   ~DiscreteQuadraticModel.num_variable_interactions
    ~DiscreteQuadraticModel.num_variables
    ~DiscreteQuadraticModel.set_linear
    ~DiscreteQuadraticModel.set_linear_case
    ~DiscreteQuadraticModel.set_quadratic
    ~DiscreteQuadraticModel.set_quadratic_case
+   ~DiscreteQuadraticModel.to_file
    ~DiscreteQuadraticModel.to_numpy_vectors

--- a/docs/reference/dqm.rst
+++ b/docs/reference/dqm.rst
@@ -29,6 +29,7 @@ Methods
    :toctree: generated/
 
    ~DiscreteQuadraticModel.add_variable
+   ~DiscreteQuadraticModel.from_numpy_vectors
    ~DiscreteQuadraticModel.get_linear
    ~DiscreteQuadraticModel.get_linear_case
    ~DiscreteQuadraticModel.get_quadratic
@@ -39,3 +40,4 @@ Methods
    ~DiscreteQuadraticModel.set_linear_case
    ~DiscreteQuadraticModel.set_quadratic
    ~DiscreteQuadraticModel.set_quadratic_case
+   ~DiscreteQuadraticModel.to_numpy_vectors

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -352,7 +352,7 @@ class TestNumpyVectors(unittest.TestCase):
         dqm.set_linear_case(0, 3, 1.5)
         dqm.set_quadratic(0, 'b', {(0, 1): 1.5, (3, 4): 1})
 
-        vectors = dqm.to_numpy_vectors(return_labels=True)
+        vectors = dqm.to_numpy_vectors()
 
         new = dimod.DQM.from_numpy_vectors(*vectors)
 
@@ -415,7 +415,7 @@ class TestNumpyVectors(unittest.TestCase):
         vectors = dqm.to_numpy_vectors()
 
         # suffle the quadratic vectors so they are not ordered anymore
-        starts, ldata, (irow, icol, qdata) = vectors
+        starts, ldata, (irow, icol, qdata), labels = vectors
 
         shuffled = (starts, ldata,
                     (np.array(np.flip(icol), copy=True),

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -24,7 +24,7 @@ import numpy as np
 
 # will want to migrate this to generators at some point
 def gnp_random_dqm(num_variables, num_cases, p, p_case, seed=None):
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
 
     dqm = dimod.DiscreteQuadraticModel()
 
@@ -37,14 +37,14 @@ def gnp_random_dqm(num_variables, num_cases, p, p_case, seed=None):
 
     for nc in num_cases:
         v = dqm.add_variable(nc)
-        dqm.set_linear(v, np.random.uniform(size=dqm.num_cases(v)))
+        dqm.set_linear(v, rng.uniform(size=dqm.num_cases(v)))
 
     for u, v in itertools.combinations(range(num_variables), 2):
-        if np.random.uniform() < p:
+        if rng.uniform() < p:
             size = (dqm.num_cases(u), dqm.num_cases(v))
 
-            r = np.random.uniform(size=size)
-            r[np.random.binomial(1, 1-p_case, size=size) == 1] = 0
+            r = rng.uniform(size=size)
+            r[rng.binomial(1, 1-p_case, size=size) == 1] = 0
 
             dqm.set_quadratic(u, v, r)
 


### PR DESCRIPTION
Also adds intermediate representation in `DQM.to_numpy_vectors` and `.from_numpy_vectors`.

Also uses the API suggested in #599.