### PR TITLE
Parallelized AdjArrayBQM constructor.

### DIFF
--- a/dimod/include/dimod/adjarraybqm.h
+++ b/dimod/include/dimod/adjarraybqm.h
@@ -89,6 +89,131 @@ class AdjArrayBQM {
         }
     }
 
+    /**
+     * Construct a BQM from a dense array. This constructor is parallelized
+     * and temporarily zeroes out the diagonal of the dense array but restores
+     * it back.
+     *
+     * @param dense An array containing the biases. Assumed to contain
+     *     `num_variables`^2 elements. The upper and lower triangle are summed.
+     * @param num_variables The number of variables.
+     */
+    template <class B2>
+    AdjArrayBQM(B2 dense[], size_type num_variables, bool ignore_diagonal = false) {
+        // we know how big our linear is going to be.
+        invars.resize(num_variables);
+
+        // Aligned memory is to avoid false sharing between threads.
+        size_type* counters_cumsum = (size_type*)utils::aligned_calloc(num_variables, sizeof(size_type));
+
+        // Backup copy of the diagonal of the dense matrix.
+        std::vector<B2> dense_diagonal(num_variables);
+
+        #pragma omp parallel
+        {
+            // Zero out the diagonal to avoid expensive checks inside innermost
+            // loop in the code for reading the matrix. The diagonal will be
+            // restored so a backup copy is saved.
+            #pragma omp for schedule(static)
+            for (size_type u = 0; u < num_variables; ++u) {
+                dense_diagonal[u] = dense[u * (num_variables + 1)];
+                dense[u * (num_variables + 1)] = 0;
+            }
+
+            // We process the matrix in two passes, in the first pass we take note
+            // of the number of total elements and elements in each row for proper
+            // memory allocation. In the second pass we fill up our desired bqm.
+            // We process the matrix in blocks of size BLOCK_SIZE*BLOCK_SIZE to take
+            // advantage of cache locality. Dynamic scheduling is used as we know some
+            // blocks may be more sparse than others and processing them may finish earlier.
+            #pragma omp for schedule(dynamic)
+            for (size_type u_st = 0; u_st < num_variables; u_st += BLOCK_SIZE) {
+                size_type u_end = std::min(u_st + BLOCK_SIZE, num_variables);
+                for (size_type v_st = 0; v_st < num_variables; v_st += BLOCK_SIZE) {
+                    size_type v_end = std::min(v_st + BLOCK_SIZE, num_variables);
+                    for (size_type u = u_st; u < u_end; ++u) {
+                        size_type counter_u = counters_cumsum[u];
+                        size_type counter_u_old = counter_u;
+                        for (size_type v = v_st; v < v_end; ++v) {
+                            bias_type qbias = dense[u * num_variables + v] + dense[v * num_variables + u];
+                            if (qbias != 0) {
+                                counter_u++;
+                            }
+                        }
+                        if (counter_u != counter_u_old) {
+                            counters_cumsum[u] = counter_u;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Calculate the exclusive scan of the counters. Thus it will contain the
+        // starting indices in the bqm for inserting elements for each row of the dense
+        // matrix. This could be parallelized but has diminishing returns.
+        size_type sum_counters = 0;
+        for (size_type u = 0; u < num_variables; ++u) {
+            size_type prev_counter = counters_cumsum[u];
+            counters_cumsum[u] = sum_counters;
+            sum_counters += prev_counter;
+        }
+
+        // TODO : This is the bottleneck for moderately dense input arrays.
+        // stl vector initializes the values during resize. Update it if a
+        // resize function is made available that does not do initialization.
+        // Moreover we need to pass in an initialization value, as otherwise a
+        // constructor for pairs will be called slowing this part by a factor of two.
+        outvars.resize(sum_counters, {0, 0});
+
+        if (ignore_diagonal) {
+            #pragma omp for schedule(static)
+            for (size_type u = 0; u < num_variables; ++u) {
+                invars[u] = {counters_cumsum[u], 0};
+            }
+        } else {
+            #pragma omp for schedule(static)
+            for (size_type u = 0; u < num_variables; ++u) {
+                invars[u] = {counters_cumsum[u], dense_diagonal[u]};
+            }
+        }
+
+        #pragma omp parallel
+        {
+            // Now that we have allocated proper amounts of memory as calculated
+            // in the previou pass (see above) we cann directly assign the values.
+            // Note the array of counters now contains the starting indices for
+            // insertion in the bqm for each row of the dense matrix.
+            #pragma omp for schedule(dynamic)
+            for (size_type u_st = 0; u_st < num_variables; u_st += BLOCK_SIZE) {
+                size_type u_end = std::min(u_st + BLOCK_SIZE, num_variables);
+                for (size_type v_st = 0; v_st < num_variables; v_st += BLOCK_SIZE) {
+                    size_type v_end = std::min(v_st + BLOCK_SIZE, num_variables);
+                    for (size_type u = u_st; u < u_end; ++u) {
+                        size_type counter_u = counters_cumsum[u];
+                        size_type counter_u_old = counter_u;
+                        for (size_type v = v_st; v < v_end; ++v) {
+                            bias_type qbias = dense[u * num_variables + v] + dense[v * num_variables + u];
+                            if (qbias != 0) {
+                                outvars[counter_u++] = {v, qbias};
+                            }
+                        }
+                        if (counter_u != counter_u_old) {
+                            counters_cumsum[u] = counter_u;
+                        }
+                    }
+                }
+            }
+
+            // Restore the diagonal of the original dense matrix
+            #pragma omp for schedule(static)
+            for (size_type u = 0; u < num_variables; ++u) {
+                dense[u * (num_variables + 1)] = dense_diagonal[u];
+            }
+        }
+
+        utils::aligned_free(counters_cumsum);
+    }
+
     size_type num_interactions() const {
         return outvars.size() / 2;
     }

--- a/dimod/include/dimod/utils.h
+++ b/dimod/include/dimod/utils.h
@@ -18,6 +18,7 @@
 #include <utility>
 
 #define BLOCK_SIZE 64 // Block size for cache blocking.
+#define CACHE_LINE_SIZE 64 // General cache line size in bytes.
 
 namespace dimod {
 namespace utils {
@@ -25,6 +26,55 @@ namespace utils {
 template<class V, class B>
 bool comp_v(std::pair<V, B> ub, V v) {
     return ub.first < v;
+}
+
+// Allocate memory and make sure the returned pointer address
+// is a multiple of the given alignment
+void* aligned_malloc(size_t required_bytes, size_t alignment = 0) {
+    if (!alignment) {
+        alignment = CACHE_LINE_SIZE;
+    }
+
+    void* p1;   // original pointer
+    void** p2;  // aligned pointer
+    int extra_bytes = alignment - 1 + sizeof(void*);
+
+    if ((p1 = (void*)malloc(required_bytes + extra_bytes)) == NULL) {
+        return NULL;
+    }
+    p2 = (void**)(alignment * (((size_t)(p1) + extra_bytes) / alignment));
+    p2[-1] = p1;
+    return p2;
+}
+
+// Corresponding aligned free for the aligned malloc
+void aligned_free(void* p) { free(((void**)p)[-1]); }
+
+// Allocate memory and fill it with zeroes but also make sure
+// the returned address is a multiple of the given alignment
+void* aligned_calloc(size_t num, size_t size, size_t alignment = 0) {
+    if (!alignment) {
+        alignment = CACHE_LINE_SIZE;
+    }
+
+    size_t required_bytes = num * size;
+    void* ptr = aligned_malloc(required_bytes, alignment);
+    long long int* ptr_ll = (long long int*)ptr;
+    size_t numfill_by_ll = required_bytes / sizeof(long long int);
+
+    #pragma omp parallel for schedule(static)
+    for (size_t i_ll = 0; i_ll < numfill_by_ll; i_ll++) {
+        ptr_ll[i_ll] = 0;
+    }
+
+    char* ptr_char = (char*)(ptr_ll + numfill_by_ll);
+    size_t bytes_left = required_bytes - (numfill_by_ll * sizeof(long long int));
+
+    for (size_t i_char = 0; i_char < bytes_left; i_char++) {
+        ptr_char[i_char] = 0;
+    }
+
+    return ptr;
 }
 
 }  // namespace utils

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -1,14 +1,21 @@
 ROOT := ../
 SRC := $(ROOT)/dimod/include/
 
-all: catch2 test_main tests
+all: catch2 test_main test_main_parallel tests tests_parallel
 
 tests: test_main.out
 	./test_main 
 
+tests_parallel: test_main_parallel.out
+	./test_main_parallel
+
 test_main: test_main.cpp
 	g++ -std=c++11 -Wall -c test_main.cpp
 	g++ -std=c++11 -Wall test_main.o tests/*.cpp $(ROOT)/dimod/roof_duality/src/fix_variables.cpp -o test_main -I $(SRC)
+
+test_main_parallel: test_main.cpp
+	g++ -std=c++11 -fopenmp -Wall -c test_main.cpp -o test_main_parallel.o
+	g++ -std=c++11 -fopenmp -Wall test_main_parallel.o tests/*.cpp $(ROOT)/dimod/roof_duality/src/fix_variables.cpp -o test_main_parallel -I $(SRC)
 
 catch2:
 	git submodule init


### PR DESCRIPTION
Parallelized AdjArrayBQM constructor. There is a bottleneck in the parallel code,
which is the resizing of the vector representing the adjacency matrix of the bqm.
As long as a resize function is not available that does not do initialization during
resizing, we can only improve it through custom allocators, which we likely want
to avoid.