### PR TITLE
Fix some issues in the object returned by DQM.to_file

### DIFF
--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -788,13 +788,12 @@ class DiscreteQuadraticModel:
         # the section containing most of the data, encoded with numpy
 
         if compressed is not None:
-            warning.warn(
-                "Argument 'compressed' is deprecated and in future will raise an "
-                "exception; please use 'compress' instead.",
+            warnings.warn(
+                "Argument 'compressed' is deprecated and in future will raise "
+                "an exception; please use 'compress' instead.",
                 DeprecationWarning, stacklevel=2
                 )
             compress = compressed or compress
-
 
         self._to_file_numpy(file, compress)
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -54,14 +54,21 @@ if issubclass(tempfile.SpooledTemporaryFile, io.IOBase):
                   DeprecationWarning)
 
 
-class _SpooledTemporaryFile(tempfile.SpooledTemporaryFile, io.IOBase):
-    def seekable(self):
-        return self._file.seekable()
+class _SpooledTemporaryFile(tempfile.SpooledTemporaryFile):
 
     # This is not part of io.IOBase, but it is implemented in io.BytesIO
     # and io.TextIOWrapper
     def readinto(self, *args, **kwargs):
         return self._file.readinto(*args, **kwargs)
+
+    def readable(self):
+        return self._file.readable()
+
+    def seekable(self):
+        return self._file.seekable()
+
+    def writable(self):
+        return self._file.writable()
 
 
 # this is the third(!) variables implementation in dimod. It differs from
@@ -687,8 +694,8 @@ class DiscreteQuadraticModel:
         Returns:
             A file-like object that can be used to construct a copy of the DQM.
             The class is a thin wrapper of
-            :class:`tempfile.SpooledTemporaryFile` that also inherits from
-            `io.IOBase`.
+            :class:`tempfile.SpooledTemporaryFile` that includes some
+            methods from :class:`io.IOBase`
 
         Format Specification (Version 1.0):
 


### PR DESCRIPTION
Closes #729 
Closes #730 

This is technically a backwards compatibility break, but since it only affects a fairly internal object, I think it is OK.