### PR TITLE
Refresh circleci and support python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,82 +4,109 @@ orbs:
   win: circleci/windows@2.2.0
 
 jobs:
-  test-py38: &full-test-template
-    docker:
-      - image: circleci/python:3.8-buster
+  build-manylinux:
 
-    working_directory: ~/repo
+    parameters:
+      python-minor:
+        type: integer
+      architecture:
+        type: string
+
+    docker:
+      - image: quay.io/pypa/manylinux1_<< parameters.architecture >>
+
+    working_directory: /dimod
 
     steps:
-
       - checkout
 
-      - run: &install-boost-linux-template
+      - run:
           name: install boost
           command: |
-            sudo apt-get install libboost-dev
-
-      - restore_cache: &restore-cache-template
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
-
-      - run: &create-virtualenv-template
-          name: create virtualenv
-          command: |
-            python -m virtualenv env
-
-      - run: &install-dependencies-template
-          name: install dependencies
-          command: |
-            . env/bin/activate
-            python --version
-            pip install -r requirements.txt
-            pip install -r tests/requirements.txt
-
-      - save_cache: &save-cache-template
-          paths:
-            - ./env
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
-
-      - run: &build-ext-template
-          name: build extension
-          command: |
-            . env/bin/activate
-            python setup.py build_ext --inplace --build-tests
-
-      - run: &run-tests-template
-          name: run unittests
-          command: |
-            . env/bin/activate
-            python --version
-            coverage run -m unittest discover
+            yum install -y boost-devel
 
       - run:
-          name: codecov
+          name: build wheels
+          command: |
+            for PYBIN in /opt/python/*/bin; do
+              if "${PYBIN}/python" -c "import sys; sys.exit(sys.version_info.major == 3)"; then continue; fi;
+              if "${PYBIN}/python" -c "import sys; sys.exit(sys.version_info.minor == << parameters.python-minor >>)"; then continue; fi;
+              "${PYBIN}/pip" install -r requirements.txt --only-binary=:all:
+              "${PYBIN}/pip" wheel . -w ./wheelhouse
+            done
+
+      - run:
+          name: bundle shared libraries into wheels
+          command: |
+            for whl in ./wheelhouse/dimod*.whl; do
+              auditwheel repair "$whl" -w ./dist
+            done
+
+      - store_artifacts:
+          path: .\dist
+
+      - persist_to_workspace:
+          root: /dimod/dist/
+          paths: .
+
+  test-linux:
+    parameters:
+      image:
+        type: string
+      numpy-version:
+        type: string
+
+    docker:
+      - image: circleci/python:<< parameters.image >>
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: dist
+
+      # Make sure that we're using the built dimod and not one from pypi
+      - run:
+          name: install
+          command: |
+            python -m virtualenv env
+            . env/bin/activate
+            pip install -r tests/requirements.txt
+            pip install numpy=='<< parameters.numpy-version >>'
+            pip install dimod --no-index -f dist/ --no-deps --force-reinstall
+
+      - run:
+          name: run tests
           command: |
             . env/bin/activate
-            codecov
+            cd tests/
+            python -m unittest
 
-  test-py37:
-    <<: *full-test-template
+  deploy-linux:
     docker:
-      - image: circleci/python:3.7-stretch
+      - image: circleci/python:3.9-buster
 
-  test-py36:
-    <<: *full-test-template
-    docker:
-      - image: circleci/python:3.6-jessie
+    steps:
+      - attach_workspace:
+          at: dist
 
-  test-py35:
-    <<: *full-test-template
-    docker:
-      - image: circleci/python:3.5-jessie
+      - run: &upload-template
+          name: deploy
+          command: |
+            python -m virtualenv env
+            . env/bin/activate
+            python -m pip install twine
+            twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing ./dist/*
 
-  test-osx-py38: &osx-tests-template
+  test-osx:
+    parameters:
+      python-version:
+        type: string
+
     macos:
-      xcode: "11.2.1"
+      xcode: "12.2.0"
+
     environment:
-      PYTHON: 3.8.0
       HOMEBREW_NO_AUTO_UPDATE: 1
 
       # Force (lie about) macOS 10.9 binary compatibility.
@@ -87,9 +114,7 @@ jobs:
       # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
       MACOSX_DEPLOYMENT_TARGET: 10.9
 
-    working_directory: ~/repo
-
-    steps: 
+    steps:
       - checkout
 
       - run: 
@@ -104,77 +129,129 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode12.2.0
 
       - run:
           name: install python
           command: |
-            pyenv install $PYTHON -s
+            pyenv install << parameters.python-version>> -s
 
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.1
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode12.2.0
 
-      - restore_cache: *restore-cache-template
-
-      - run:
-          name: create virtualenv
+      - run: &osx-install-template
+          name: install
           command: |
             eval "$(pyenv init -)"
-            pyenv local $PYTHON
+            pyenv local << parameters.python-version >>
             python -m pip install virtualenv
             python -m virtualenv env
+            . env/bin/activate
+            pip install -r requirements.txt
+            pip install -r tests/requirements.txt
 
-      - run: *install-dependencies-template
+      - run: &unix-build-ext-template
+          name: build
+          command: |
+            . env/bin/activate
+            python setup.py build_ext --inplace --build-tests
 
-      - save_cache: *save-cache-template
+      - run:
+          name: run tests
+          command: |
+            . env/bin/activate
+            python --version
+            coverage run -m unittest discover
 
-      - run: *build-ext-template
-        
-      - run: *run-tests-template
+      - run:
+          name: codecov
+          command: |
+            . env/bin/activate
+            codecov
 
-  test-osx-py37:
-    <<: *osx-tests-template
+  deploy-osx:
+    parameters:
+      python-version:
+        type: string
+
+    macos:
+      xcode: "12.2.0"
+
     environment:
-      PYTHON: 3.7.4
       HOMEBREW_NO_AUTO_UPDATE: 1
+
+      # Force (lie about) macOS 10.9 binary compatibility.
+      # Needed for properly versioned wheels.
+      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
       MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  test-osx-py36:
-    <<: *osx-tests-template
-    environment:
-      PYTHON: 3.6.5
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  test-osx-py35:
-    <<: *osx-tests-template
-    environment:
-      PYTHON: 3.5.5
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  test-win-py38: &win-tests-template
-    executor:
-      name: win/default
-
-    environment:
-      PYTHON: 3.8.0
-      CL: /d2FH4-
-
-    working_directory: ~/repo
 
     steps:
       - checkout
 
-      - run:  &win-install-python-template
+      - run: 
+          name: install pyenv
+          command: |
+            brew install pyenv
+
+      - run: &install-boost-osx-template
+          name: install boost
+          command: |
+            brew install boost
+
+      - restore_cache:
+          keys:
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode12.2.0
+
+      - run:
+          name: install python
+          command: |
+            pyenv install << parameters.python-version>> -s
+
+      - save_cache:
+          paths:
+            - ~/.pyenv
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode12.2.0
+
+      - run: *osx-install-template
+      
+      - run:
+          name: create bdist_wheel and sdist
+          command: |
+            . env/bin/activate
+            python setup.py bdist_wheel sdist
+
+      - run:
+          name: deploy
+          command: |
+            . env/bin/activate
+            python -m pip install twine
+            twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing ./dist/*
+
+  test-win:
+    parameters:
+      python-version:
+        type: string
+      architecture:
+        type: string
+
+    executor:
+      name: win/default
+
+    environment:
+      CL: /d2FH4-
+
+    steps:
+      - checkout
+
+      - run: &win-install-python-template
           name: install python and create virtualenv
           command: |
-            nuget install python -Version $env:PYTHON -ExcludeVersion -OutputDirectory .
-            .\python\tools\python.exe --version
-            .\python\tools\python.exe -m pip install virtualenv
-            .\python\tools\python.exe -m virtualenv env
+            nuget install python<< parameters.architecture >> -Version << parameters.python-version >> -ExcludeVersion -OutputDirectory .
+            .\python<< parameters.architecture >>\tools\python.exe --version
+            .\python<< parameters.architecture >>\tools\python.exe -m pip install virtualenv
+            .\python<< parameters.architecture >>\tools\python.exe -m virtualenv env
 
       - run: &win-install-dependencies-template
           name: install dependencies
@@ -189,19 +266,47 @@ jobs:
           command: |
              nuget install boost -ExcludeVersion -OutputDirectory .
 
-      - run: &win-build-ext-template
+      - run:
           name: build extension
           command: |
             env\Scripts\activate.ps1
             python setup.py build_ext --inplace --build-tests --include-dirs boost\lib\native\include\
 
-      - run: &win-run-unittests-template
+      - run:
           name: run unittests
           command: |
             env\Scripts\activate.ps1
             coverage run -m unittest discover
 
-      - run: &win-build-wheel-template
+      - run:
+          name: codecov
+          command: |
+            env\Scripts\activate.ps1
+            codecov
+
+  deploy-win:
+    parameters:
+      python-version:
+        type: string
+      architecture:
+        type: string
+
+    executor:
+      name: win/default
+
+    environment:
+      CL: /d2FH4-
+
+    steps:
+      - checkout
+
+      - run: *win-install-python-template
+
+      - run: *win-install-dependencies-template
+
+      - run: *win-install-boost-template
+
+      - run:
           name: create wheel
           command: |
             env\Scripts\activate.ps1
@@ -211,95 +316,13 @@ jobs:
       - store_artifacts:
           path: .\dist
 
-      - run: &win-codecov-template
-          name: codecov
+      - run: &win-twine-template
+          name: install twine and deploy
           command: |
             env\Scripts\activate.ps1
-            codecov
+            python -m pip install twine
+            twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD --skip-existing ./dist/*
 
-  test-win-py38x86: &win-tests-template-x86
-    executor:
-      name: win/default
-
-    environment:
-      PYTHON: 3.8.0
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - run:  &win-install-pythonx86-template
-          name: install python and create virtualenv
-          command: |
-            nuget install pythonx86 -Version $env:PYTHON -ExcludeVersion -OutputDirectory .
-            .\pythonx86\tools\python.exe --version
-            .\pythonx86\tools\python.exe -m pip install virtualenv
-            .\pythonx86\tools\python.exe -m virtualenv env
-
-      - run: *win-install-dependencies-template
-
-      - run: *win-install-boost-template
-
-      - run: *win-build-ext-template
-
-      - run: *win-run-unittests-template
-
-      - run: *win-build-wheel-template
-
-      - store_artifacts:
-          path: .\dist
-
-      - run: *win-codecov-template
-
-  test-win-py37:
-    <<: *win-tests-template
-    environment:
-      PYTHON: 3.7.5
-      CL: /d2FH4-
-
-  test-win-py37x86:
-    <<: *win-tests-template-x86
-    environment:
-      PYTHON: 3.7.5
-      CL: /d2FH4-
-
-  test-win-py36:
-    <<: *win-tests-template
-    environment:
-      PYTHON: 3.6.8
-      CL: /d2FH4-
-
-  test-win-py36x86:
-    <<: *win-tests-template-x86
-    environment:
-      PYTHON: 3.6.8
-      CL: /d2FH4-
-
-  test-win-py35:
-    <<: *win-tests-template
-    environment:
-      PYTHON: 3.5.4
-
-  test-win-py35x86:
-    <<: *win-tests-template-x86
-    environment:
-      PYTHON: 3.5.4
-
-  test-linux-cpp11:
-    docker:
-      # just use a python image, all we really want is debian
-      - image: circleci/python:3.6-jessie
-    
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-      - run: *install-boost-linux-template
-      - run: &run-cpp-template
-          name: run cpp tests
-          command: |
-            make -C testscpp/ --always-make
 
   test-doctest:
     docker:
@@ -310,22 +333,20 @@ jobs:
     steps:
       - checkout
 
-      - run: *install-boost-linux-template
-
-      - restore_cache: *restore-cache-template
-
-      - run: *create-virtualenv-template
+      - run: &linux-install-boost-template
+          name: install boost
+          command: |
+            sudo apt-get install libboost-dev
 
       - run:
           name: install dependencies
           command: |
+            python -m virtualenv env
             . env/bin/activate
             pip install -r requirements.txt
             pip install -r docs/requirements.txt
 
-      - save_cache: *save-cache-template
-
-      - run: *build-ext-template
+      - run: *unix-build-ext-template
 
       - run:
           name: build docs
@@ -342,342 +363,101 @@ jobs:
             . env/bin/activate
             make -C docs/ doctest
 
-##################################################################################################
-# Deploy
-##################################################################################################
-
-  deploy-manylinux-64: &manylinux-deploy-template
+  test-linux-cpp11:
     docker:
-      - image: quay.io/pypa/manylinux1_x86_64
-
+      # just use a python image, all we really want is debian
+      - image: circleci/python:3.6-jessie
+    
     working_directory: ~/repo
 
     steps:
       - checkout
-
+      - run: *linux-install-boost-template
       - run:
-          name: install boost
+          name: run cpp tests
           command: |
-            yum install -y boost-devel
-
-      - run:
-          name: build wheels
-          command: |
-            for PYBIN in /opt/python/*/bin; do
-              if "${PYBIN}/python" -c "import sys; sys.exit((3, 5) <= sys.version_info < (3, 9))"; then continue; fi;
-              "${PYBIN}/pip" install -r requirements.txt
-              "${PYBIN}/pip" wheel . -w ./wheelhouse
-              "${PYBIN}/python" setup.py sdist -d ./dist
-            done
-
-      - run:
-          name: bundle shared libraries into wheels
-          command: |
-            for whl in ./wheelhouse/dimod*.whl; do
-              auditwheel repair "$whl" -w ./dist
-            done
-
-      - store_artifacts:
-          path: ./dist
-
-      - run:
-          name: create a virtualenv
-          command: |
-            pythons=(/opt/python/*/bin)
-            python="${pythons[0]}"
-            "$python/pip" install virtualenv
-            "$python/python" -m virtualenv env
-
-      - run: &upload-template
-          name: install twine and deploy
-          command: |
-            . env/bin/activate
-            python -m pip install twine
-            twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing ./dist/*
-
-  deploy-manylinux-32:
-    <<: *manylinux-deploy-template
-    docker:
-      - image: quay.io/pypa/manylinux1_i686
-
-  deploy-osx-py38: &osx-deploy-template
-    macos:
-      xcode: "11.2.0"
-    environment:
-      PYTHON: 3.8.0
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-    working_directory: ~/repo
-
-    steps: 
-      - checkout
-
-      - run: 
-          name: install pyenv
-          command: |
-            brew install pyenv
-
-      - run: *install-boost-osx-template
-
-      # - run: *install-openmp-osx-template
-
-      - restore_cache:
-          keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.0
-
-      - run:
-          name: install python
-          command: |
-            pyenv install $PYTHON -s
-
-      - save_cache:
-          paths:
-            - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode11.2.0
-
-      - run:
-          name: create virtualenv
-          command: |
-            eval "$(pyenv init -)"
-            pyenv local $PYTHON
-            python -m pip install virtualenv
-            python -m virtualenv env
-
-      - run: *install-dependencies-template
-
-      - run: *build-ext-template
-        
-      - run:
-          name: create bdist_wheel
-          command: |
-            . env/bin/activate
-            python setup.py bdist_wheel
-
-      - store_artifacts:
-          path: ./dist
-
-      - run: *upload-template
-
-  deploy-osx-py37:
-    <<: *osx-deploy-template
-    environment:
-      PYTHON: 3.7.4
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  deploy-osx-py36:
-    <<: *osx-deploy-template
-    environment:
-      PYTHON: 3.6.5
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  deploy-osx-py35:
-    <<: *osx-deploy-template
-    environment:
-      PYTHON: 3.5.5
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      MACOSX_DEPLOYMENT_TARGET: 10.9
-
-  deploy-win-py38: &win-deploy-template
-    executor:
-      name: win/default
-
-    environment:
-      PYTHON: 3.8.0
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - run: *win-install-python-template
-
-      - run: *win-install-dependencies-template
-
-      - run: *win-install-boost-template
-
-      - run: *win-build-ext-template
-
-      - run: *win-build-wheel-template
-
-      - store_artifacts:
-          path: .\dist
-
-      - run: &win-twine-template
-          name: install twine and deploy
-          command: |
-            env\Scripts\activate.ps1
-            python -m pip install twine
-            twine upload -u $env:PYPI_USERNAME -p $env:PYPI_PASSWORD --skip-existing ./dist/*
-
-  deploy-win-py38x86: &win-deploy-template-x86
-    executor:
-      name: win/default
-
-    environment:
-      PYTHON: 3.8.0
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - run: *win-install-pythonx86-template
-
-      - run: *win-install-dependencies-template
-
-      - run: *win-install-boost-template
-
-      - run: *win-build-ext-template
-
-      - run: *win-build-wheel-template
-
-      - store_artifacts:
-          path: .\dist
-
-      - run: *win-twine-template
-
-  deploy-win-py37:
-    <<: *win-deploy-template
-    environment:
-      PYTHON: 3.7.0
-      CL: /d2FH4-
-
-  deploy-win-py37x86:
-    <<: *win-deploy-template-x86
-    environment:
-      PYTHON: 3.7.0
-      CL: /d2FH4-
-
-  deploy-win-py36:
-    <<: *win-deploy-template
-    environment:
-      PYTHON: 3.6.8
-      CL: /d2FH4-
-
-  deploy-win-py36x86:
-    <<: *win-deploy-template-x86
-    environment:
-      PYTHON: 3.6.8
-      CL: /d2FH4-
-
-  deploy-win-py35:
-    <<: *win-deploy-template
-    environment:
-      PYTHON: 3.5.4
-
-  deploy-win-py35x86:
-    <<: *win-deploy-template-x86
-    environment:
-      PYTHON: 3.5.4
+            make -C testscpp/ --always-make
 
 workflows:
-  version: 2
   tests:
     jobs:
-      - test-py38
-      - test-py37
-      - test-py36
-      - test-py35
-      - test-osx-py38
-      - test-osx-py37
-      - test-osx-py36
-      - test-osx-py35
-      - test-win-py38
-      - test-win-py37
-      - test-win-py36
-      - test-win-py35
-      - test-win-py38x86
-      - test-win-py37x86
-      - test-win-py36x86
-      - test-win-py35x86
+      - build-manylinux:
+          name: build-manylinux1_<< matrix.architecture >>-py3<< matrix.python-minor >>
+          matrix:
+            parameters:
+              python-minor: [5, 6, 7, 8, 9]
+              # We could build for 32bit as well, but since we don't have any
+              # way to test it and it slows down compilation, we don't for
+              # now.
+              architecture: ["x86_64"]
+      - test-linux:
+          # We could break each of these out into seperate jobs so that we
+          # don't need to wait for the entire above matrix to complete, but
+          # this is cleaner
+          requires:
+            - build-manylinux
+          matrix:
+            parameters:
+              # We could make the second numpy version unbounded, but for now
+              # let's pin it for reproducability 
+              numpy-version: ['1.17.3', '1.18.5', '1.19.4']
+              image:
+                - 3.9-buster
+                - 3.8-buster
+                - 3.7-stretch
+                - 3.6-jessie
+                - 3.5-jessie
+            exclude:
+              - numpy-version: '1.19.4'
+                image: 3.5-jessie
+              - numpy-version: '1.18.5'
+                image: 3.9-buster
+              - numpy-version: '1.17.3'
+                image: 3.9-buster
+      - test-osx:
+          matrix:
+            parameters:
+              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+      - test-win:
+          matrix:
+            parameters:
+              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              architecture: ["", "x86"]
       - test-doctest
       - test-linux-cpp11
+
   deploy:
     jobs:
-      - deploy-manylinux-64:
+      - build-manylinux:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
             branches:
               ignore: /.*/
-      - deploy-manylinux-32:
+          name: build-manylinux1_<< matrix.architecture >>-py3<< matrix.python-minor >>
+          matrix:
+            parameters:
+              python-minor: [5, 6, 7, 8, 9]
+              architecture: ["x86_64", "i686"]
+      - deploy-linux:
+          requires:
+            - build-manylinux
+      - deploy-osx:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
             branches:
               ignore: /.*/
-      - deploy-osx-py38:
+          matrix:
+            parameters:
+              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+      - deploy-win:
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
             branches:
               ignore: /.*/
-      - deploy-osx-py37:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-osx-py36:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-osx-py35:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py38:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py37:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py36:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py35:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py38x86:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py37x86:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py36x86:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
-      - deploy-win-py35x86:
-          filters:
-            tags:
-              only: /^[0-9]+(\.[0-9]+)*(\.dev([0-9]+)?)?$/
-            branches:
-              ignore: /.*/
+          matrix:
+            parameters:
+              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              architecture: ["", "x86"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy==1.17.3
+numpy==1.19.4; python_version >= '3.6'
+numpy==1.18.5; python_version == '3.5'
 cython==0.29.21

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ from distutils.command.build_ext import build_ext as _build_ext
 # add __version__, __author__, __authoremail__, __description__ to this namespace
 exec(open(os.path.join(os.path.dirname(__file__), "dimod", "package_info.py")).read())
 
-install_requires = ['numpy>=1.16.0,<2.0.0',
-                    ]
+# if the numpy ranges change here, don't forget to update the circle-ci job
+install_requires = ['numpy>=1.17.3,<2.0.0']
 
-setup_requires = ['numpy>=1.16.0,<2.0.0']
+setup_requires = ['numpy>=1.17.3,<2.0.0']
 
 extras_require = {'all': ['networkx>=2.0,<3.0',
                           'pandas>=0.22.0,<0.23.0',
@@ -55,6 +55,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     ]
 
 python_requires = '>=3.5'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ codecov
 
 parameterized==0.7.4
 
-pandas==0.25.3
+pandas==0.25.3; python_version < '3.9'
 networkx==2.0
 simplejson==3.16.0
-pymongo==3.7.1
+pymongo==3.7.1; python_version < '3.9'


### PR DESCRIPTION
Makes extensive use of circle-ci's matrix functionality. Also adds tests for numpy ranges.

Closes #733 as redundant.