### PR TITLE
Refactor DQM.from_numpy_vectors

### DIFF
--- a/dimod/bqm/shapeablebqm.pyx.src
+++ b/dimod/bqm/shapeablebqm.pyx.src
@@ -37,6 +37,7 @@ from dimod.bqm.utils cimport as_numpy_scalar
 from dimod.bqm.utils import coo_sort, cyenergies, cyrelabel
 from dimod.bqm.utils import cyrelabel_variables_as_integers
 from dimod.core.bqm import BQM, ShapeableBQM
+from dimod.utilities import asintegerarrays, asnumericarrays
 from dimod.vartypes import as_vartype, Vartype
 
 
@@ -664,41 +665,16 @@ cdef class cyAdj@name@BQM:
         except ValueError:
             raise ValueError("quadratic should be a 3-tuple")
 
-        # What follows is an overly complex process that boils down to coercing
-        # our inputs to a simpler and more consistent set of data types. We
-        # need:
+        # We need:
         # * numpy ndarrays
         # * contiguous memory
         # * ldata.dtype == qdata.dtype and irow.dtype == icol.dtype
         # * 32 or 64 bit dtypes
-        ldata = np.ascontiguousarray(linear, dtype=None if len(linear) else np.int8)
-        irow = np.ascontiguousarray(irow, dtype=None if len(irow) else np.int8)
-        icol = np.ascontiguousarray(icol, dtype=None if len(icol) else np.int8)
-        qdata = np.ascontiguousarray(qdata, dtype=None if len(qdata) else np.int8)
+        icol, irow = asintegerarrays(
+            icol, irow, min_itemsize=4, requirements='C')
+        ldata, qdata = asnumericarrays(
+            linear, qdata, min_itemsize=4, requirements='C')
 
-        integral_dtype = np.promote_types(irow.dtype, icol.dtype)
-        if np.issubdtype(integral_dtype, np.unsignedinteger):
-            integral_dtype = np.promote_types(integral_dtype, np.uint32)
-        elif np.issubdtype(integral_dtype, np.signedinteger):
-            integral_dtype = np.promote_types(integral_dtype, np.int32)
-        else:
-            raise TypeError("irow and icol must be arrays of integrals")
-        irow = np.asarray(irow, dtype=integral_dtype)
-        icol = np.asarray(icol, dtype=integral_dtype)
-
-        numeric_dtype = np.promote_types(ldata.dtype, qdata.dtype)
-        if np.issubdtype(numeric_dtype, np.unsignedinteger):
-            numeric_dtype = np.promote_types(numeric_dtype, np.uint32)
-        elif np.issubdtype(numeric_dtype, np.signedinteger):
-            numeric_dtype = np.promote_types(numeric_dtype, np.int32)
-        elif np.issubdtype(numeric_dtype, np.floating):
-            numeric_dtype = np.promote_types(numeric_dtype, np.float32)
-        else:
-            raise TypeError("biases must be arrays of integrals or reals")
-        ldata = np.asarray(ldata, dtype=numeric_dtype)
-        qdata = np.asarray(qdata, dtype=numeric_dtype)
-
-        # Now that everything is the right type...
         bqm = cls._from_numpy_vectors(ldata, irow, icol, qdata, vartype)
 
         bqm.offset += offset

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -21,7 +21,7 @@ from libcpp.vector cimport vector
 cimport numpy as np
 
 from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
-from dimod.bqm.common cimport Integral, Numeric
+from dimod.bqm.common cimport Integral32plus, Numeric, Numeric32plus
 
 
 ctypedef np.float64_t Bias
@@ -59,5 +59,3 @@ cdef class cyDiscreteQuadraticModel:
 
     cdef void _into_numpy_vectors(self, Unsigned[:] starts, Bias[:] ldata,
         Unsigned[:] irow, Unsigned[:] icol, Bias[:] qdata)
-    cdef void _from_numpy_vectors(self, Integral[:] case_starts, Bias[:] linear_biases,
-        Integral[:] irow, Integral[:] icol, Bias[:] quadratic_biases) except *

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -440,6 +440,37 @@ class TestNumpyVectors(unittest.TestCase):
             with self.assertRaises(ValueError):
                 dimod.DQM.from_numpy_vectors(starts, ldata, ([0], [0], [1]))
 
+    def test_selfloop(self):
+        # should raise an exception when given a self-loop
+        starts = [0, 3, 6]  # degree 3
+        ldata = range(9)
+        irow = []
+        icol = []
+        for ci in range(3):
+            for cj in range(3, 9):
+                irow.append(ci)
+                icol.append(cj)
+        for ci in range(3, 6):
+            for cj in range(3):
+                irow.append(ci)
+                icol.append(cj)
+            for cj in range(6, 9):
+                irow.append(ci)
+                icol.append(cj)
+        for ci in range(6, 9):
+            for cj in range(6):
+                irow.append(ci)
+                icol.append(cj)
+
+        # now add a single self-loop
+        irow.append(3)
+        icol.append(4)
+
+        qdata = [1]*len(irow)
+
+        with self.assertRaises(ValueError):
+            dimod.DQM.from_numpy_vectors(starts, ldata, (irow, icol, qdata))
+
     def test_two_var_functional(self):
         dqm = dimod.DQM()
         dqm.add_variable(5)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,14 +11,13 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
-# ================================================================================================
-
-from __future__ import division
 
 import unittest
-from itertools import groupby
 import itertools
+
+from itertools import groupby
+
+import numpy as np
 
 import dimod
 
@@ -349,3 +348,98 @@ class TestChildStructureDFS(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             dimod.child_structure_dfs(nested)
+
+
+class TestAsIntegerArrays(unittest.TestCase):
+    def test_empty(self):
+        with self.assertRaises(TypeError):
+            dimod.utilities.asintegerarrays()
+
+    def test_min_itemsize(self):
+        arrint8 = np.ones(5, dtype=np.int8)
+        arrint16 = np.ones(5, dtype=np.int16)
+
+        new0, new1 = dimod.utilities.asintegerarrays(
+            arrint8, arrint16, min_itemsize=4)
+        self.assertEqual(new0.dtype, np.int32)
+        self.assertEqual(new1.dtype, np.int32)
+
+    def test_partial_passthrough(self):
+        arrint8 = np.ones(5, dtype=np.int8)
+        arrint16 = np.ones(5, dtype=np.int16)
+
+        new0, new1 = dimod.utilities.asintegerarrays(
+            arrint8, arrint16, min_itemsize=2)
+        self.assertEqual(new0.dtype, np.int16)
+        self.assertEqual(new1.dtype, np.int16)
+        self.assertIs(arrint16, new1)  # passthrough
+
+        arruint8 = np.ones(5, dtype=np.uint8)
+        arruint16 = np.ones(5, dtype=np.uint16)
+
+        new2, new3 = dimod.utilities.asintegerarrays(
+            arruint8, arruint16, min_itemsize=2)
+        self.assertEqual(new2.dtype, np.uint16)
+        self.assertEqual(new3.dtype, np.uint16)
+        self.assertIs(arruint16, new3)  # passthrough
+
+    def test_single_passthrough(self):
+        arr = np.ones(5, dtype=np.uint8)
+        new = dimod.utilities.asintegerarrays(arr)
+
+        self.assertIs(arr, new)  # should not copy
+
+    def test_unsafe(self):
+        arr0 = np.ones(5, dtype=np.uint64)
+        arr1 = np.ones(5, dtype=np.int64)
+
+        with self.assertRaises(TypeError):
+            dimod.utilities.asintegerarrays(arr0, arr1)
+
+        with self.assertRaises(TypeError):
+            dimod.utilities.asintegerarrays(np.ones(5, dtype=np.float32))
+
+
+class TestAsNumericArrays(unittest.TestCase):
+    def test_complex(self):
+        arr = np.ones(5, dtype=np.complex)
+        with self.assertRaises(TypeError):
+            dimod.utilities.asnumericarrays(arr)
+
+    def test_empty(self):
+        with self.assertRaises(TypeError):
+            dimod.utilities.asnumericarrays()
+
+    def test_min_itemsize(self):
+        arrint8 = np.ones(5, dtype=np.int8)
+        arrint16 = np.ones(5, dtype=np.int16)
+
+        new0, new1 = dimod.utilities.asnumericarrays(
+            arrint8, arrint16, min_itemsize=4)
+        self.assertEqual(new0.dtype, np.int32)
+        self.assertEqual(new1.dtype, np.int32)
+
+    def test_partial_passthrough(self):
+        arrint8 = np.ones(5, dtype=np.int8)
+        arrint16 = np.ones(5, dtype=np.int16)
+
+        new0, new1 = dimod.utilities.asnumericarrays(
+            arrint8, arrint16, min_itemsize=2)
+        self.assertEqual(new0.dtype, np.int16)
+        self.assertEqual(new1.dtype, np.int16)
+        self.assertIs(arrint16, new1)  # passthrough
+
+        arruint8 = np.ones(5, dtype=np.uint8)
+        arruint16 = np.ones(5, dtype=np.uint16)
+
+        new2, new3 = dimod.utilities.asnumericarrays(
+            arruint8, arruint16, min_itemsize=2)
+        self.assertEqual(new2.dtype, np.uint16)
+        self.assertEqual(new3.dtype, np.uint16)
+        self.assertIs(arruint16, new3)  # passthrough
+
+    def test_single_passthrough(self):
+        arr = np.ones(5, dtype=np.uint8)
+        new = dimod.utilities.asnumericarrays(arr)
+
+        self.assertIs(arr, new)  # should not copy


### PR DESCRIPTION
And create some functions to abstract away some of the type coercion.

Closes #762 
See also #761, this PR disallows self loops when constructing from NumPy arrays