### PR TITLE
fixed for dot-parsed networkx graphs

### DIFF
--- a/dimod/bqm/adjdictbqm.py
+++ b/dimod/bqm/adjdictbqm.py
@@ -195,16 +195,18 @@ class AdjDictBQM(ShapeableBQM):
         adj = self._adj
 
         if isinstance(quadratic, abc.Mapping):
-            for (u, v), bias in quadratic.items():
-                self.add_variable(u)
-                self.add_variable(v)
+            for quadraticitem in quadratic.items():
+                key = quadraticitem[0]
+                bias = quadraticitem[1]
+                self.add_variable(key[0])
+                self.add_variable(key[1])
 
-                if u == v and vartype is Vartype.SPIN:
+                if key[0] == key[1] and vartype is Vartype.SPIN:
                     offset = offset + bias  # not += on off-chance it's mutable
-                elif u in adj[v]:
-                    adj[u][v] = adj[v][u] = adj[u][v] + bias
+                elif key[0] in adj[key[1]]:
+                    adj[key[0]][key[1]] = adj[key[1]][key[0]] = adj[key[0]][key[1]] + bias
                 else:
-                    adj[u][v] = adj[v][u] = bias
+                    adj[key[0]][key[1]] = adj[key[1]][key[0]] = bias
         elif isinstance(quadratic, abc.Iterator):
             for u, v, bias in quadratic:
                 self.add_variable(u)


### PR DESCRIPTION
Hi, while using the dimod library with networkx to solve the minimum vertex cover problem, I noticed that the dimod library is having issues with networkx graph objects generated from dot files using read_dot function. 
The dimod function _init_components was using a (u,v) tuple in a for loop. It worked well for all other graphs except those generated from dot files. The quadratic parameter was a collection of dicts which in my case did not always have 2-element keys. When the bias was different than -1.0, the dict contained a 3-element key with a zero at the end (always). 
To solve this issue i changed how the function iterates over a quadratic collection to avoid the "too many values to unpack" error. 