### PR TITLE
add add_constraint_as_quadratic method to DQM and cyDQM

### DIFF
--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -59,3 +59,5 @@ cdef class cyDiscreteQuadraticModel:
 
     cdef void _into_numpy_vectors(self, Unsigned[:] starts, Bias[:] ldata,
         Unsigned[:] irow, Unsigned[:] icol, Bias[:] qdata)
+    cpdef void add_constraint_as_quadratic(self, vector[VarIndex], vector[CaseIndex],
+                                           vector[Bias], Bias, Bias)

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -279,7 +279,7 @@ cdef class cyDiscreteQuadraticModel:
             cv = cases[i]
             bv = biases[i]
             bias = self.get_linear_case(v, cv)
-            bias += 2 * lagrange_multiplier * (bv * constant + bv * bv)
+            bias += lagrange_multiplier * (2 * bv * constant + bv * bv)
             self.set_linear_case(v, cv, bias)
             for j in range(i + 1, num_terms):
                 u = variables[j]

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -263,6 +263,25 @@ cdef class cyDiscreteQuadraticModel:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
+    cpdef void add_constraint_as_quadratic(self, vector[VarIndex] variables, vector[CaseIndex] cases,
+                                           vector[Bias] biases, Bias lagrange_multiplier, Bias constant):
+        num_terms = len(variables)
+        for i in range(num_terms):
+            v = variables[i]
+            cv = cases[i]
+            bv = biases[i]
+            bias = self.get_linear_case(v, cv)
+            self.set_linear_case(v, cv, bias + 2 * lagrange_multiplier * bv * constant + lagrange_multiplier * bv * bv)
+            for j in range(i + 1, num_terms):
+                u = variables[j]
+                cu = cases[j]
+                bu = biases[j]
+                if v != u:
+                    bias = self.get_quadratic_case(v, cv, u, cu)
+                    self.set_quadratic_case(v, cv, u, cu, bias + 2 * lagrange_multiplier * bv * bu)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
     cpdef Bias get_linear_case(self, VarIndex v, CaseIndex case) except? -45.3:
 
         # self.num_cases checks that the variable is valid

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -267,8 +267,7 @@ cdef class cyDiscreteQuadraticModel:
                                            vector[Bias] biases, Bias lagrange_multiplier, Bias constant):
         if len(variables) != len(cases) or len(variables) != len(biases):
             raise ValueError("There should be equal number of variables, "
-                             "cases, and biases. Each term should be a "
-                             "3-tuple")
+                             "cases, and biases")
 
         cdef unsigned long int num_terms = len(variables)
         cdef unsigned long int i, j

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -421,10 +421,10 @@ class DiscreteQuadraticModel:
 
     def add_constraint_as_quadratic(self, terms: Linear, lagrange_multiplier: float,
                                     constant: float):
-        """Add a linear constraint of the form below
-         .. math::
-            \sum_{i,k} a_{i,k} x_{i,k} + C = 0
-         to dqm object as a quadratic objective.
+        """Add a linear constraint as a quadratic objective.
+
+        Adds a linear constraint of the form :math:`\sum_{i,k} a_{i,k} x_{i,k} + C = 0`
+        to the discrete quadratic model as a quadratic objective.
 
         Args:
             terms: A list of tuples of the type (variable, case, bias).

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -29,7 +29,7 @@ from dimod.serialization.fileview import VariablesSection, _BytesIO
 from dimod.variables import Variables
 from typing import List, Tuple, Union, Generator
 
-Linear = Union[List[Tuple], Generator[Tuple, None, None]]
+LinearTriplets = Union[List[Tuple], Generator[Tuple, None, None]]
 
 
 __all__ = ['DiscreteQuadraticModel', 'DQM']
@@ -419,7 +419,7 @@ class DiscreteQuadraticModel:
         return self._cydqm.get_quadratic_case(
             self.variables.index(u), u_case, self.variables.index(v), v_case)
 
-    def add_constraint_as_quadratic(self, terms: Linear, lagrange_multiplier: float,
+    def add_constraint_as_quadratic(self, terms: LinearTriplets, lagrange_multiplier: float,
                                     constant: float):
         """Add a linear constraint as a quadratic objective.
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -421,20 +421,25 @@ class DiscreteQuadraticModel:
 
     def add_constraint_as_quadratic(self, terms: Linear, lagrange_multiplier: float,
                                     constant: float):
-        """
-        Add a linear constraint of the form \\sum_{ik} a_{ik} x_{ik} + C = 0 to dqm object as a quadratic objective.
+        """Add a linear constraint of the form below
+         .. math::
+            \sum_{i,k} a_{i,k} x_{i,k} + C = 0
+         to dqm object as a quadratic objective.
+
         Args:
-            dqm: DiscreteQuadraticModel
-            terms: A list or a generator of tuples of the type (variable, case, bias).
-                Each tuple is evaluated to the term bias * variable_case. All terms in the list/generator are summed.
+            terms: A list of tuples of the type (variable, case, bias).
+                Each tuple is evaluated to the term (bias * variable_case).
+                All terms in the list are summed.
             lagrange_multiplier: The coefficient or the penalty strength
-            const: The constant value of the constraint.
+            constant: The constant value of the constraint.
 
-        Returns: None. Updates the dqm object
-
+        Returns: None
         """
-        variables, cases, biases = zip(*terms)
-        variables = list(map(self.variables.index, variables))
+        variables, cases, biases = [], [], []
+        for v, c, b in terms:
+            variables.append(self.variables.index(v))
+            cases.append(c)
+            biases.append(b)
         self._cydqm.add_constraint_as_quadratic(variables, cases, biases, lagrange_multiplier, constant)
 
     def num_cases(self, v=None):

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -27,6 +27,9 @@ from dimod.discrete.cydiscrete_quadratic_model import cyDiscreteQuadraticModel
 from dimod.sampleset import as_samples
 from dimod.serialization.fileview import VariablesSection, _BytesIO
 from dimod.variables import Variables
+from typing import List, Tuple, Union, Generator
+
+Linear = Union[List[Tuple], Generator[Tuple, None, None]]
 
 
 __all__ = ['DiscreteQuadraticModel', 'DQM']
@@ -415,6 +418,24 @@ class DiscreteQuadraticModel:
         """
         return self._cydqm.get_quadratic_case(
             self.variables.index(u), u_case, self.variables.index(v), v_case)
+
+    def add_constraint_as_quadratic(self, terms: Linear, lagrange_multiplier: float,
+                                    constant: float):
+        """
+        Add a linear constraint of the form \\sum_{ik} a_{ik} x_{ik} + C = 0 to dqm object as a quadratic objective.
+        Args:
+            dqm: DiscreteQuadraticModel
+            terms: A list or a generator of tuples of the type (variable, case, bias).
+                Each tuple is evaluated to the term bias * variable_case. All terms in the list/generator are summed.
+            lagrange_multiplier: The coefficient or the penalty strength
+            const: The constant value of the constraint.
+
+        Returns: None. Updates the dqm object
+
+        """
+        variables, cases, biases = zip(*terms)
+        variables = list(map(self.variables.index, variables))
+        self._cydqm.add_constraint_as_quadratic(variables, cases, biases, lagrange_multiplier, constant)
 
     def num_cases(self, v=None):
         """If v is provided, the number of cases associated with v, otherwise

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -429,7 +429,7 @@ class TestConstraint(unittest.TestCase):
             for j in x:
                 if j > i:
                     for case in range(num_cases):
-                        self.assertEqual(dqm.get_quadratic(x[i], x[j], case, case), 2.0)
+                        self.assertEqual(dqm.get_quadratic_case(x[i], case, x[j], case), 2.0)
 
 
 class TestNumpyVectors(unittest.TestCase):

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -431,6 +431,27 @@ class TestConstraint(unittest.TestCase):
                     for case in range(num_cases):
                         self.assertEqual(dqm.get_quadratic_case(x[i], case, x[j], case), 2.0)
 
+    def test_more_constraint(self):
+        dqm = dimod.DQM()
+        x = dqm.add_variable(5, label='x')
+        y = dqm.add_variable(3, label='y')
+        w = dqm.add_variable(4, label='w')
+
+        expression = [(x, 1, 1.0), (y, 2, 2.0), (w, 3, 1.0)]
+        constant = -2.0
+        dqm.add_constraint_as_quadratic(
+            expression,
+            lagrange_multiplier=1.0, constant=constant)
+
+        expression_dict = {v: (c, b) for v, c, b in expression}
+        for cx, cy, cw in itertools.product(range(5), range(3), range(4)):
+            s = constant
+            state = {'x': cx, 'y': cy, 'w': cw}
+            for v, cv, bias in expression:
+                if expression_dict[v][0] == state[v]:
+                    s += bias
+            self.assertAlmostEqual(dqm.energy(state) + constant ** 2, s ** 2)
+
 
 class TestNumpyVectors(unittest.TestCase):
 

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -409,6 +409,29 @@ class TestQuadratic(unittest.TestCase):
         dqm.set_quadratic(u, v, biases)
 
 
+class TestConstraint(unittest.TestCase):
+    def test_simple_constraint(self):
+        dqm = dimod.DQM()
+        num_variables = 2
+        num_cases = 3
+        x = {}
+        for i in range(num_variables):
+            x[i] = dqm.add_variable(num_cases, label=f'x_{i}')
+
+        for c in range(num_cases):
+            dqm.add_constraint_as_quadratic(
+                [(x[i], c, 1.0) for i in range(num_variables)],
+                lagrange_multiplier=1.0, constant=-1.0)
+
+        for i in x:
+            for case in range(num_cases):
+                self.assertEqual(dqm.get_linear_case(x[i], case), -1)
+            for j in x:
+                if j > i:
+                    for case in range(num_cases):
+                        self.assertEqual(dqm.get_quadratic(x[i], x[j], case, case), 2.0)
+
+
 class TestNumpyVectors(unittest.TestCase):
 
     def test_empty_functional(self):

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -416,7 +416,7 @@ class TestConstraint(unittest.TestCase):
         num_cases = 3
         x = {}
         for i in range(num_variables):
-            x[i] = dqm.add_variable(num_cases, label=f'x_{i}')
+            x[i] = dqm.add_variable(num_cases, label='x_{i}'.format(i=i))
 
         for c in range(num_cases):
             dqm.add_constraint_as_quadratic(

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -452,6 +452,32 @@ class TestConstraint(unittest.TestCase):
                     s += bias
             self.assertAlmostEqual(dqm.energy(state) + constant ** 2, s ** 2)
 
+    def test_random_constraint(self):
+        num_variables = 4
+        cases = np.random.randint(3, 6, size=num_variables)
+        dqm_0 = gnp_random_dqm(num_variables, cases, 0.5, 0.5, seed=123)
+        # copy doesn't work properly, so for now create the same dqm twice
+        dqm = gnp_random_dqm(num_variables, cases, 0.5, 0.5, seed=123)
+        x = dqm.variables
+
+        expression = [(x[i], np.random.randint(0, cases[i]), np.random.randint(0, 10)) for i in x]
+        constant = np.random.randint(1, 10) * num_variables
+        lagrange_multiplier = np.random.randint(1, 10)
+        dqm.add_constraint_as_quadratic(
+            expression,
+            lagrange_multiplier=lagrange_multiplier, constant=constant)
+
+        expression_dict = {v: (c, b) for v, c, b in expression}
+        for case_values in itertools.product(*(range(c) for c in cases)):
+            state = {x[i]: case_values[i] for i in x}
+            energy = dqm.energy(state) + lagrange_multiplier * constant ** 2
+            s = constant
+            for v, cv, bias in expression:
+                if expression_dict[v][0] == state[v]:
+                    s += bias
+
+            self.assertAlmostEqual(energy, lagrange_multiplier * s ** 2 + dqm_0.energy(state))
+
 
 class TestNumpyVectors(unittest.TestCase):
 


### PR DESCRIPTION
Add a method to `dimod.discrete_quadratic_model` to convert linear constraints to a quadratic objective.