### PR TITLE
Add references to additional sampler/composites 

### DIFF
--- a/docs/reference/sampler_composites/composites.rst
+++ b/docs/reference/sampler_composites/composites.rst
@@ -4,9 +4,17 @@
 Composites
 ==========
 
-The `dimod` package includes several example composed samplers.
+The `dimod` package includes several example composed samplers:
 
 .. currentmodule:: dimod.reference.composites
+
+.. contents::
+    :local:
+    :depth: 1
+
+The :std:doc:`dwave-system <oceandocs:docs_system/sdk_index>` package provides 
+additional :std:doc:`composites for D-Wave systems <oceandocs:docs_system/reference/composites>`
+such as those used for :term:`minor-embedding`.
 
 Connected Components Composite
 ------------------------------

--- a/docs/reference/sampler_composites/index.rst
+++ b/docs/reference/sampler_composites/index.rst
@@ -12,3 +12,7 @@ Samplers and Composites
    higher_order_samplers 
    higher_order_composites
    api
+
+Other Ocean packages provide additional samplers and composites; for example, 
+:std:doc:`dwave-system <oceandocs:docs_system/sdk_index>` provides samplers 
+and composites used for D-Wave systems. 

--- a/docs/reference/sampler_composites/samplers.rst
+++ b/docs/reference/sampler_composites/samplers.rst
@@ -7,7 +7,14 @@ Samplers
 The `dimod` package includes several example samplers.
 
 .. contents::
-    :depth: 3
+    :local:
+    :depth: 1
+
+Other Ocean packages provide production samplers; for example, the 
+:std:doc:`dwave-system <oceandocs:docs_system/sdk_index>` package provides 
+:std:doc:`samplers for D-Wave systems <oceandocs:docs_system/reference/samplers>`
+and :std:doc:`dwave-neal <oceandocs:docs_neal/sdk_index>` provides 
+a simulated-annealing sampler.
 
 .. automodule:: dimod.reference.samplers
 .. currentmodule:: dimod.reference.samplers


### PR DESCRIPTION
Dimod part of fix for https://github.com/dwavesystems/dwave-system/issues/380 together with https://github.com/dwavesystems/dwave-system/pull/381.
Also makes content lists of samplers/composites look nicer