### PR TITLE
Deprecate Variables.index mapping and add permissive kwarg

### DIFF
--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -221,8 +221,28 @@ class Variables(abc.Sequence, abc.Set):
         # everything is unique
         return int(v in self)
 
-    def index(self, v):
-        if v not in self:
+    def index(self, v, permissive=False):
+        """Return the index of v.
+
+        Args:
+            v (hashable):
+                A variable.
+
+            permissive (bool, optional, default=False):
+                If True, the variable will be inserted, guaranteeing an index
+                can be returned.
+
+        Returns:
+            int: The index of the given variable.
+
+        Raises:
+            ValueError: If the variable is not present and `permissive` is
+            False.
+
+        """
+        if permissive:
+            self._append(v, permissive=True)
+        elif v not in self:
             raise ValueError('unknown variable {!r}'.format(v))
         return self._label_to_idx.get(v, v)
 

--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -53,41 +53,6 @@ def iter_deserialize_variables(variables):
             yield v
 
 
-class _Index(abc.Callable, abc.Mapping):
-    # Deprecated API, in the future .index should be a normal method.
-    # Previous implementations of Variables treated .index as a dict.
-
-    __slots__ = ('variables',)
-
-    def __init__(self, variables):
-        self.variables = variables
-
-    def __call__(self, v):
-        # todo: support start and end like list.index
-        if v not in self.variables:
-            raise ValueError('unknown variable {!r}'.format(v))
-        return self.variables._label_to_idx.get(v, v)
-
-    def __getitem__(self, v):
-        warnings.warn("treating Variables.index as a mapping is deprecated, "
-                      "please use Variables.index(v) rather than "
-                      "Variables.index[v]",
-                      DeprecationWarning,
-                      stacklevel=2)
-        try:
-            return self(v)
-        except ValueError as err:
-            raise KeyError(*err.args)
-
-    def __iter__(self):
-        # as far as I know no one used this
-        raise NotImplementedError
-
-    def __len__(self):
-        # as far as I know no one used this
-        raise NotImplementedError
-
-
 class Variables(abc.Sequence, abc.Set):
     """Set-like and list-like variables tracking.
 
@@ -100,15 +65,12 @@ class Variables(abc.Sequence, abc.Set):
     __slots__ = ('_idx_to_label',
                  '_label_to_idx',
                  '_stop',
-                 '_writeable',
-                 'index')
+                 )
 
     def __init__(self, iterable=None):
         self._idx_to_label = dict()
         self._label_to_idx = dict()
         self._stop = 0
-
-        self.index = _Index(self)
 
         if iterable is not None:
             for v in iterable:
@@ -181,18 +143,6 @@ class Variables(abc.Sequence, abc.Set):
     @property
     def is_range(self):
         return not self._label_to_idx
-
-    @property
-    def is_writeable(self):
-        warnings.warn("Variables.is_writeable is deprecated",
-                      DeprecationWarning, stacklevel=2)
-        return getattr(self, '_writeable', True)
-
-    @is_writeable.setter
-    def is_writeable(self, b):
-        warnings.warn("Variables.is_writeable is deprecated",
-                      DeprecationWarning, stacklevel=2)
-        self._writeable = bool(b)
 
     def _append(self, v=None, *, permissive=False):
         """Append a new variable.
@@ -271,15 +221,10 @@ class Variables(abc.Sequence, abc.Set):
         # everything is unique
         return int(v in self)
 
-    # index is set by __init__ for now
-
-    @lockable_method
-    def relabel(self, *args, **kwargs):
-        warnings.warn("Variables.relabel is deprecated. Objects that have "
-                      "Variables as an attribute should use ._relabel() "
-                      "instead. Users should treat the Variables object as "
-                      "static", DeprecationWarning, stacklevel=3)
-        return self._relabel(*args, **kwargs)
+    def index(self, v):
+        if v not in self:
+            raise ValueError('unknown variable {!r}'.format(v))
+        return self._label_to_idx.get(v, v)
 
     def to_serializable(self):
         """Return an object that (should be) json-serializable.

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -97,14 +97,6 @@ class TestRelabel(unittest.TestCase):
 
         self.assertEqual(variables, Variables('ab'))
 
-    def test_permissive_deprecated_api(self):
-        variables = Variables([0, 1])
-
-        with self.assertWarns(DeprecationWarning):
-            variables.relabel({0: 'a', 1: 'b', 2: 'c'})
-
-        self.assertEqual(variables, Variables('ab'))     
-
 
 @parameterized_class(
     [dict(name='list', iterable=list(range(5))),
@@ -116,12 +108,6 @@ class TestRelabel(unittest.TestCase):
     class_name_func=lambda cls, i, inpt: '%s_%s' % (cls.__name__, inpt['name'])
     )
 class TestIterable(unittest.TestCase):
-    def test_index_api(self):
-        # deprecated API
-        variables = Variables(self.iterable)
-        self.assertTrue(hasattr(variables, 'index'))
-        self.assertTrue(callable(variables.index))
-        self.assertTrue(isinstance(variables.index, abc.Mapping))
 
     def test_contains_unhashable(self):
         variables = Variables(self.iterable)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -52,6 +52,18 @@ class TestDuplicates(unittest.TestCase):
             self.assertEqual(len(variables), len(set(zeros)))
 
 
+class TestIndex(unittest.TestCase):
+    def test_permissive(self):
+        variables = Variables()
+
+        with self.assertRaises(ValueError):
+            variables.index(0)
+
+        self.assertEqual(variables.index(0, permissive=True), 0)
+        self.assertEqual(variables.index(0, permissive=True), 0)
+        self.assertEqual(variables.index('a', permissive=True), 1)
+
+
 class TestPrint(unittest.TestCase):
     def test_pprint(self):
         import pprint


### PR DESCRIPTION
This kwarg argument is useful for other refactoring work I am doing but wanted to break it out so it's easier to review.