### PR TITLE
remove the (non-implemented) handling of a Structured child sampler

### DIFF
--- a/dimod/reference/composites/spin_transform.py
+++ b/dimod/reference/composites/spin_transform.py
@@ -72,10 +72,6 @@ class SpinReversalTransformComposite(Sampler, Composite):
     def __init__(self, child):
         self.children = [child]
 
-        if isinstance(child, Structured):
-            # todo something like Structured.__init__(self)
-            raise NotImplementedError
-
         self.parameters = parameters = {'spin_reversal_variables': []}
         parameters.update(child.parameters)
 


### PR DESCRIPTION
Composed samplers don't need to be structured anymore:  https://github.com/dwavesystems/dwave-system/pull/191