### PR TITLE
Fix missing .pxd files in windows wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include dimod/roof_duality *.cpp *.hpp
 recursive-include dimod/bqm *.cc *.h
 recursive-include dimod/include *h
-recursive-include dimod/ *.pyx *.pxd *.pyx.src
+recursive-include dimod *.pyx *.pxd *.pyx.src


### PR DESCRIPTION
setuptools in windows couldn't handle the trailing `/`.

I tested with a different CI script. I don't think it makes sense to add it permanently to the CI as a test