### PR TITLE
Cythonize the variables object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,8 @@ ENV/
 # cython intermediate files
 dimod/roof_duality/_fix_variables.cpp
 dimod/roof_duality/*.html
+dimod/*.cpp
+dimod/*.html
 dimod/bqm/*.cpp
 dimod/bqm/*.html
 dimod/discrete/*.cpp

--- a/dimod/cyvariables.pxd
+++ b/dimod/cyvariables.pxd
@@ -1,0 +1,30 @@
+# distutils: language = c++
+# cython: language_level=3
+
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+__all__ = ['cyVariables']
+
+cdef class cyVariables:
+    cdef object _index_to_label
+    cdef object _label_to_index
+    cdef Py_ssize_t _stop
+
+    cpdef object _append(self, object v=*, bint permissive=*)
+    cpdef object _extend(self, object iterable, bint permissive=*)
+    cpdef bint _is_range(self)
+    cdef Py_ssize_t _count_int(self, object) except -1
+    cpdef Py_ssize_t count(self, object) except -1
+    cpdef Py_ssize_t index(self, object, bint permissive=*) except -1

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -51,13 +51,12 @@ cdef class cyVariables:
         if self._is_range():
             v = pyidx
         else:
-            # I am reasonably confident that this is safe and it's faster
-            # than self._index_to_label.get
+            # faster than self._index_to_label.get
             obj = PyDict_GetItemWithError(self._index_to_label, pyidx)
             if obj == NULL:
                 v = pyidx
             else:
-                v = <object>obj
+                v = <object>obj  # correctly handles the ref count
 
         return v
 
@@ -179,7 +178,7 @@ cdef class cyVariables:
 
         # handle other numeric types
         if isinstance(v, Number):
-            v_int = int(v)  # assume this is safe...
+            v_int = int(v)  # assume this is safe because it's a number
             if v_int == v:
                 return self._count_int(v_int)  # it's an integer afterall!
 
@@ -216,12 +215,11 @@ cdef class cyVariables:
         if self._is_range():
             return v if PyLong_Check(v) else int(v)
 
-        # I am reasonably confident that this is safe and it's faste
-        # than self._label_to_index.get
+        # faster than self._label_to_index.get
         cdef PyObject* obj = PyDict_GetItemWithError(self._label_to_index, v)
         if obj == NULL:
             pyobj = v
         else:
-            pyobj = <object>obj
+            pyobj = <object>obj  # correctly updates ref count
 
         return pyobj if PyLong_Check(pyobj) else int(pyobj)

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -66,6 +66,22 @@ cdef class cyVariables:
     cpdef object _append(self, object v=None, bint permissive=False):
         """Append a new variable.
 
+        Args:
+            v (hashable, optional):
+                Add a new variable. If `None`, a new label will be generated.
+
+            permissive (bool, optional, default=False):
+                If `False`, appending a variable that already exists will raise
+                a `ValueError`. If `True`, appending a variable that already
+                exists will not change the container.
+
+        Returns:
+            hashable: The label of the appended variable.
+
+        Raises:
+            ValueError: If the variable is present and `permissive` is
+            False.
+
         This method is semi-public. it is intended to be used by
         classes that have :class:`.Variables` as an attribute, not by the
         the user.
@@ -100,6 +116,19 @@ cdef class cyVariables:
     cpdef object _extend(self, object iterable, bint permissive=False):
         """Add new variables.
 
+        Args:
+            iterable (iterable[hashable], optional):
+                An iterable of hashable objects.
+
+            permissive (bool, optional, default=False):
+                If `False`, appending a variable that already exists will raise
+                a `ValueError`. If `True`, appending a variable that already
+                exists will not change the container.
+
+        Raises:
+            ValueError: If a variable is present and `permissive` is
+            False.
+
         This method is semi-public. it is intended to be used by
         classes that have :class:`.Variables` as an attribute, not by the
         the user.
@@ -127,6 +156,12 @@ cdef class cyVariables:
     def _relabel(self, mapping):
         """Relabel the variables in-place.
 
+        Args:
+            mapping (dict):
+                Mapping from current variable labels to new, as a dict. If
+                an incomplete mapping is specified, unmapped variables keep
+                their current labels.
+
         This method is semi-public. it is intended to be used by
         classes that have :class:`.Variables` as an attribute, not by the
         the user.
@@ -146,6 +181,9 @@ cdef class cyVariables:
 
     def _relabel_as_integers(self):
         """Relabel the variables as integers in-place.
+
+        Returns:
+            dict: The mapping that would restore the original labels.
 
         This method is semi-public. it is intended to be used by
         classes that have :class:`.Variables` as an attribute, not by the

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -69,6 +69,9 @@ cdef class cyVariables:
         Args:
             v (hashable, optional):
                 Add a new variable. If `None`, a new label will be generated.
+                The generated label will be the index of the new variable if
+                that index is available, otherwise it will be the lowest
+                available non-negative integer.
 
             permissive (bool, optional, default=False):
                 If `False`, appending a variable that already exists will raise
@@ -110,7 +113,7 @@ cdef class cyVariables:
         return v
 
     cpdef bint _is_range(self):
-        """Return whether the Variables are current labelled [0, n)."""
+        """Return whether the variables are currently labelled [0, n)."""
         return not PyDict_Size(self._label_to_index)
 
     cpdef object _extend(self, object iterable, bint permissive=False):
@@ -183,7 +186,19 @@ cdef class cyVariables:
         """Relabel the variables as integers in-place.
 
         Returns:
-            dict: The mapping that would restore the original labels.
+            dict: A mapping that will restore the original labels.
+
+        Examples:
+
+            >>> variables = dimod.variables.Variables(['a', 'b', 'c', 'd'])
+            >>> print(variables)
+            Variables(['a', 'b', 'c', 'd'])
+            >>> mapping = variables._relabel_as_integers()
+            >>> print(variables)
+            Variables([0, 1, 2, 3])
+            >>> variables._relabel(mapping)  # restore the original labels
+            >>> print(variables)
+            Variables(['a', 'b', 'c', 'd'])
 
         This method is semi-public. it is intended to be used by
         classes that have :class:`.Variables` as an attribute, not by the
@@ -207,7 +222,7 @@ cdef class cyVariables:
                 or PyDict_Contains(self._label_to_index, v))
 
     cpdef Py_ssize_t count(self, object v) except -1:
-        """Return the number of times `v` appears in Variables.
+        """Return the number of times `v` appears in the variables.
 
         Because the variables are always unique, this will always return 1 or 0.
         """

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -1,0 +1,227 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from numbers import Number
+
+from cpython.long cimport PyLong_Check
+from cpython.dict cimport PyDict_Size, PyDict_Contains
+from cpython.ref cimport PyObject
+
+from dimod.utilities import iter_safe_relabels
+
+cdef extern from "Python.h":
+    # not yet available as of cython 0.29.22
+    PyObject* PyDict_GetItemWithError(object p, object key) except? NULL
+
+
+cdef class cyVariables:
+    def __init__(self, object iterable=None):
+        self._index_to_label = dict()
+        self._label_to_index = dict()
+        self._stop = 0
+
+        if iterable is not None:
+            self._extend(iterable, permissive=True)
+
+    def __contains__(self, v):
+        return bool(self.count(v))
+
+    # todo: support slices
+    def __getitem__(self, Py_ssize_t idx):
+        if idx < 0:
+            idx = self._stop + idx
+
+        if idx >= self._stop:
+            raise IndexError('index out of range')
+
+        cdef object v
+        cdef object pyidx = idx
+        cdef PyObject* obj
+        if self._is_range():
+            v = pyidx
+        else:
+            # I am reasonably confident that this is safe and it's faster
+            # than self._index_to_label.get
+            obj = PyDict_GetItemWithError(self._index_to_label, pyidx)
+            if obj == NULL:
+                v = pyidx
+            else:
+                v = <object>obj
+
+        return v
+
+    def __len__(self):
+        return self._stop
+
+    cpdef object _append(self, object v=None, bint permissive=False):
+        """Append a new variable.
+
+        This method is semi-public. it is intended to be used by
+        classes that have :class:`.Variables` as an attribute, not by the
+        the user.
+        """
+        if v is None:
+            v = self._stop
+
+            if not self._is_range() and self.count(v):
+                v = 0
+                while self.count(v):
+                    v += 1
+
+        elif self.count(v):
+            if permissive:
+                return v
+            else:
+                raise ValueError('{!r} is already a variable'.format(v))
+
+        idx = self._stop
+
+        if idx != v:
+            self._label_to_index[v] = idx
+            self._index_to_label[idx] = v
+
+        self._stop += 1
+        return v
+
+    cpdef bint _is_range(self):
+        """Return whether the Variables are current labelled [0, n)."""
+        return not PyDict_Size(self._label_to_index)
+
+    cpdef object _extend(self, object iterable, bint permissive=False):
+        """Add new variables.
+
+        This method is semi-public. it is intended to be used by
+        classes that have :class:`.Variables` as an attribute, not by the
+        the user.
+        """
+        # todo: performance improvements for range etc
+        for v in iterable:
+            self._append(v, permissive=permissive)
+
+    def _pop(self):
+        """Remove the last variable.
+
+        This method is semi-public. it is intended to be used by
+        classes that have :class:`.Variables` as an attribute, not by the
+        the user.
+        """
+        if not self:
+            raise IndexError("Cannot pop when Variables is empty")
+
+        self._stop = idx = self._stop - 1
+
+        label = self._index_to_label.pop(idx, idx)
+        self._label_to_index.pop(label, None)
+        return label
+
+    def _relabel(self, mapping):
+        """Relabel the variables in-place.
+
+        This method is semi-public. it is intended to be used by
+        classes that have :class:`.Variables` as an attribute, not by the
+        the user.
+        """
+        for submap in iter_safe_relabels(mapping, self):
+            for old, new in submap.items():
+                if old == new:
+                    continue
+
+                idx = self._label_to_index.pop(old, old)
+
+                if new != idx:
+                    self._label_to_index[new] = idx
+                    self._index_to_label[idx] = new  # overwrites old idx
+                else:
+                    self._index_to_label.pop(idx, None)
+
+    def _relabel_as_integers(self):
+        """Relabel the variables as integers in-place.
+
+        This method is semi-public. it is intended to be used by
+        classes that have :class:`.Variables` as an attribute, not by the
+        the user.
+        """
+        mapping = self._index_to_label.copy()
+        self._index_to_label.clear()
+        self._label_to_index.clear()
+        return mapping
+
+    cdef Py_ssize_t _count_int(self, object v) except -1:
+        # only works when v is an int
+        cdef Py_ssize_t vi = v
+
+        if self._is_range():
+            return 0 <= vi < self._stop
+
+        # need to make sure that we're not using the integer elsewhere
+        return (0 <= vi < self._stop
+                and not PyDict_Contains(self._index_to_label, v)
+                or PyDict_Contains(self._label_to_index, v))
+
+    cpdef Py_ssize_t count(self, object v) except -1:
+        """Return the number of times ``v`` appears in Variables.
+
+        Because the variables are always unique, this will always return 1 or 0.
+        """
+        if PyLong_Check(v):
+            return self._count_int(v)
+
+        # handle other numeric types
+        if isinstance(v, Number):
+            v_int = int(v)  # assume this is safe...
+            if v_int == v:
+                return self._count_int(v_int)  # it's an integer afterall!
+
+        try:
+            return v in self._label_to_index
+        except TypeError:
+            # unhashable
+            return False
+
+    cpdef Py_ssize_t index(self, object v, bint permissive=False) except -1:
+        """Return the index of v.
+
+        Args:
+            v (hashable):
+                A variable.
+
+            permissive (bool, optional, default=False):
+                If True, the variable will be inserted, guaranteeing an index
+                can be returned.
+
+        Returns:
+            int: The index of the given variable.
+
+        Raises:
+            ValueError: If the variable is not present and `permissive` is
+            False.
+
+        """
+        if permissive:
+            self._append(v, permissive=True)
+        if not self.count(v):
+            raise ValueError('unknown variable {!r}'.format(v))
+
+        if self._is_range():
+            return v if PyLong_Check(v) else int(v)
+
+        # I am reasonably confident that this is safe and it's faste
+        # than self._label_to_index.get
+        cdef PyObject* obj = PyDict_GetItemWithError(self._label_to_index, v)
+        if obj == NULL:
+            pyobj = v
+        else:
+            pyobj = <object>obj
+
+        return pyobj if PyLong_Check(pyobj) else int(pyobj)

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -170,7 +170,7 @@ cdef class cyVariables:
                 or PyDict_Contains(self._label_to_index, v))
 
     cpdef Py_ssize_t count(self, object v) except -1:
-        """Return the number of times ``v`` appears in Variables.
+        """Return the number of times `v` appears in Variables.
 
         Because the variables are always unique, this will always return 1 or 0.
         """
@@ -190,7 +190,7 @@ cdef class cyVariables:
             return False
 
     cpdef Py_ssize_t index(self, object v, bint permissive=False) except -1:
-        """Return the index of v.
+        """Return the index of `v`.
 
         Args:
             v (hashable):

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -195,6 +195,9 @@ class DiscreteQuadraticModel:
         self.variables = Variables()
         self._cydqm = cyDiscreteQuadraticModel()
 
+    variables = None  # overwritten by __init__, here for the docstring
+    """:class:`~.variables.Variables` of variable labels."""
+
     @property
     def adj(self):
         """dict[hashable, set]: The adjacency structure of the variables."""

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -876,10 +876,9 @@ class SampleSet(abc.Iterable, abc.Sized):
 
     @property
     def variables(self):
-        """:class:`.VariableIndexView` of variable labels.
+        """:class:`~.variables.Variables` of variable labels.
 
         Corresponds to columns of the sample field of :attr:`.SampleSet.record`.
-
         """
         self.resolve()
         return self._variables

--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -18,7 +18,7 @@ A class and utilities for encoding variable objects.
 The :class:`Variables` class is intended to be used as an attribute of other
 classes, such as :class:`.DiscreteQuadraticModel` and :class:`.SampleSet`.
 
-The goals of the class are:
+The requirements for the class are:
     *   Have a minimal memory footprint when the variables are labeled `[0, n)`
     *   Behave like a list for iteration and getting items
     *   Behave like a set for determining if it contains an item

--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -12,6 +12,20 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+"""
+A class and utilities for encoding variable objects.
+
+The :class:`Variables` class is intended to be used as an attribute of other
+classes, such as :class:`.DiscreteQuadraticModel` and :class:`.SampleSet`.
+
+The goals of the class are:
+    *   Have a minimal memory footprint when the variables are labeled `[0, n)`
+    *   Behave like a list for iteration and getting items
+    *   Behave like a set for determining if it contains an item
+    *   Constant time for finding the index of an item
+
+"""
+
 import collections.abc as abc
 import io
 import warnings
@@ -96,13 +110,14 @@ class Variables(cyVariables, abc.Set, abc.Sequence):
 
     @property
     def is_range(self):
+        """Return True if the variables are labeled `[0,n)`."""
         return self._is_range()
 
     def to_serializable(self):
-        """Return an object that (should be) json-serializable.
+        """Return an object that is json-serializable.
 
         Returns:
-            list: A list of (hopefully) json-serializable objects. Handles some
+            list: A list of json-serializable objects. Handles some
             common cases like NumPy scalars.
             See :func:`iter_serialize_variables`.
 

--- a/docs/reference/dqm.rst
+++ b/docs/reference/dqm.rst
@@ -21,6 +21,7 @@ Attributes
    :toctree: generated/
 
    ~DiscreteQuadraticModel.adj
+   ~DiscreteQuadraticModel.variables
 
 Methods
 -------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -14,6 +14,7 @@ Reference Documentation
    dqm
    higherorder
    utilities
+   variables
    vartypes
    exceptions
    cpp

--- a/docs/reference/variables.rst
+++ b/docs/reference/variables.rst
@@ -1,0 +1,49 @@
+.. _variables:
+
+=========
+Variables
+=========
+
+.. currentmodule:: dimod.variables
+
+.. automodule:: dimod.variables
+
+Variables Class
+===============
+
+.. autoclass:: Variables
+
+Properties
+----------
+
+.. autosummary::
+   :toctree: generated/
+
+    ~Variables.is_range
+
+Methods
+-------
+
+.. autosummary::
+   :toctree: generated/
+
+    ~Variables.index
+    ~Variables.count
+    ~Variables.to_serializable
+
+Mutation Methods
+----------------
+
+The :class:`.Variables` object comes with a number of semi-private methods
+that allow other classes to manipulate its contents. These are intended to
+by used by parent classes, not by the user. Modifying a :class:`.Variables`
+object that is an attribute of a class results in undefined behaviour.
+
+.. autosummary::
+   :toctree: generated/
+
+    ~Variables._append
+    ~Variables._extend
+    ~Variables._pop
+    ~Variables._relabel
+    ~Variables._relabel_as_integers

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,8 @@ extensions = [Extension("dimod.roof_duality._fix_variables",
               Extension("dimod.bqm.common",
                         ['dimod/bqm/common'+ext]),
               Extension("dimod.discrete.cydiscrete_quadratic_model",
-                        ["dimod/discrete/cydiscrete_quadratic_model"+ext])
+                        ["dimod/discrete/cydiscrete_quadratic_model"+ext]),
+              Extension("dimod.cyvariables", ["dimod/cyvariables"+ext]),
               ]
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -25,6 +25,15 @@ from parameterized import parameterized_class
 from dimod.variables import Variables
 
 
+class TestAppend(unittest.TestCase):
+    def test_conflict(self):
+        variables = Variables()
+        variables._append(1)
+        variables._append()  # should take the label 0
+        variables._append()
+
+        self.assertEqual(variables, [1, 0, 2])
+
 class TestDuplicates(unittest.TestCase):
     def test_duplicates(self):
         # should have no duplicates
@@ -63,6 +72,16 @@ class TestIndex(unittest.TestCase):
         self.assertEqual(variables.index(0, permissive=True), 0)
         self.assertEqual(variables.index('a', permissive=True), 1)
 
+
+class TestPop(unittest.TestCase):
+    def test_empty(self):
+        with self.assertRaises(IndexError):
+            Variables()._pop()
+
+    def test_simple(self):
+        variables = Variables('abc')
+        self.assertEqual(variables._pop(), 'c')
+        self.assertEqual(variables, 'ab')
 
 class TestPrint(unittest.TestCase):
     def test_pprint(self):
@@ -114,6 +133,9 @@ class TestRelabel(unittest.TestCase):
     [dict(name='list', iterable=list(range(5))),
      dict(name='string', iterable='abcde'),
      dict(name='range', iterable=range(5)),
+     dict(name='range_reversed', iterable=range(4, -1, -1)),
+     dict(name='range_start', iterable=range(2, 7)),
+     dict(name='range_step', iterable=range(0, 10, 2)),
      dict(name='mixed', iterable=[0, ('b',), 2.1, 'c', frozenset('d')]),
      dict(name='floats', iterable=[0., 1., 2., 3., 4.]),
      ],


### PR DESCRIPTION
Results in 10-20x speedup on many common operations in SampleSet and DQM classes. Also opens up the path for accessing it from cython for even more improvement for performance-critical applications.