### PR TITLE
Add forwarding_method decorator

### DIFF
--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -20,6 +20,7 @@ Decorators
    bqm_index_labels
    bqm_index_labelled_input
    bqm_structured
+   forwarding_method
    graph_argument
    nonblocking_sample_method
    vartype_argument

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ sphinx_rtd_theme
 
 breathe
 
-networkx==2.0
+networkx==2.5

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,6 @@ codecov
 parameterized==0.7.4
 
 pandas==0.25.3; python_version < '3.9'
-networkx==2.0
+networkx==2.5
 simplejson==3.16.0
 pymongo==3.7.1; python_version < '3.9'


### PR DESCRIPTION
This gives the same result as
```
from functools import cached_property

class Inner:
    def func(self):
        return 1

class Outer:
    def __init__(self):
        self.inner = Inner()

    @cached_property
    def func(self):
        return self.inner.func
```
but also works with type annotations and docstrings.