### PR TITLE
Fix missing .pxd files in win wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include dimod/roof_duality *.cpp *.hpp
 recursive-include dimod/bqm *.cc *.h
 recursive-include dimod/include *h
-recursive-include dimod/ *.pyx *.pxd *.pyx.src
+recursive-include dimod *.pyx *.pxd *.pyx.src


### PR DESCRIPTION
Backporting fix from #811 
