### PR TITLE
Add symbolic manipulation of BQM objects

### DIFF
--- a/dimod/__init__.py
+++ b/dimod/__init__.py
@@ -52,6 +52,8 @@ from dimod.sampleset import *
 
 from dimod.serialization.format import set_printoptions
 
+from dimod.sym import *
+
 from dimod.utilities import *
 import dimod.utilities
 

--- a/dimod/__init__.py
+++ b/dimod/__init__.py
@@ -52,8 +52,6 @@ from dimod.sampleset import *
 
 from dimod.serialization.format import set_printoptions
 
-from dimod.sym import *
-
 from dimod.utilities import *
 import dimod.utilities
 

--- a/dimod/sym.py
+++ b/dimod/sym.py
@@ -1,0 +1,38 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import contextlib
+
+__all__ = ['symbolic']
+
+
+class symbolic(contextlib.ContextDecorator):
+    """Context manager for creating quadratic models symbolically.
+
+    This context manager is reentrant but not thread safe.
+    """
+    _count: int = 0
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        symbolic._count += 1
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        symbolic._count -= 1
+
+    @classmethod
+    def active(cls) -> bool:
+        return cls._count > 0

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -33,6 +33,7 @@ import dimod
 
 from dimod.binary import BinaryQuadraticModel, DictBQM, Float32BQM, Float64BQM
 from dimod.binary import as_bqm
+from dimod.binary import Spin, Binary
 from dimod.testing import assert_consistent_bqm, assert_bqm_almost_equal
 
 
@@ -2020,6 +2021,73 @@ class TestShape(unittest.TestCase):
 
         self.assertEqual(BQM(dimod.SPIN).num_interactions, 0)
         self.assertEqual(BQM(0, dimod.SPIN).num_interactions, 0)
+
+
+class TestSymbolic(unittest.TestCase):
+    @parameterized.expand(BQMs.items())
+    @dimod.symbolic()
+    def test_add_number(self, name, BQM):
+        bqm = BQM('SPIN')
+        new = bqm + 1
+        self.assertIsNot(bqm, new)
+        self.assertEqual(new.offset, 1)
+        self.assertEqual(bqm.num_variables, 0)
+
+    @parameterized.expand(BQMs.items())
+    @dimod.symbolic()
+    def test_iadd_number(self, name, BQM):
+        bqm = BQM('SPIN')
+        old = bqm
+        bqm += 1
+        self.assertIs(bqm, old)
+        self.assertEqual(bqm.offset, 1)
+        self.assertEqual(bqm.num_variables, 0)
+
+    @parameterized.expand(BQMs.items())
+    @dimod.symbolic()
+    def test_radd_number(self, name, BQM):
+        bqm = BQM('SPIN')
+        new = 1 + bqm
+        self.assertIsNot(bqm, new)
+        self.assertEqual(new.offset, 1)
+        self.assertEqual(bqm.num_variables, 0)
+
+    @parameterized.expand(BQMs.items())
+    def test_exceptions(self, name, BQM):
+        bqm = BQM('SPIN')
+        with self.assertRaises(TypeError):
+            bqm + 1
+        with self.assertRaises(TypeError):
+            bqm * 1
+
+    @parameterized.expand(BQMs.items())
+    @dimod.symbolic()
+    def test_exceptions_symbolic_mode(self, name, BQM):
+        bqm = BQM('SPIN')
+        with self.assertRaises(TypeError):
+            bqm + 'a'
+        with self.assertRaises(TypeError):
+            'a' + bqm
+        with self.assertRaises(TypeError):
+            bqm += 'a'
+
+        with self.assertRaises(TypeError):
+            bqm * 'a'
+        with self.assertRaises(TypeError):
+            bqm *= 'a'
+
+    @dimod.symbolic()
+    def test_expressions_spin(self):
+        u = Spin('u')
+        v = Spin('v')
+
+        BQM = BinaryQuadraticModel
+
+        self.assertEqual(u*v, BQM({}, {'uv': 1}, 0, 'SPIN'))
+        self.assertEqual(u*u, BQM({'u': 0}, {}, 1, 'SPIN'))
+        self.assertEqual(u*(v-1), BQM({'u': -1}, {'uv': 1}, 0, 'SPIN'))
+        self.assertEqual(-u, BQM({'u': -1}, {}, 0, 'SPIN'))
+        self.assertEqual(-u*v, BQM({}, {'uv': -1}, 0, 'SPIN'))
 
 
 class TestToIsing(unittest.TestCase):

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -2025,7 +2025,6 @@ class TestShape(unittest.TestCase):
 
 class TestSymbolic(unittest.TestCase):
     @parameterized.expand(BQMs.items())
-    @dimod.symbolic()
     def test_add_number(self, name, BQM):
         bqm = BQM('SPIN')
         new = bqm + 1
@@ -2034,7 +2033,6 @@ class TestSymbolic(unittest.TestCase):
         self.assertEqual(bqm.num_variables, 0)
 
     @parameterized.expand(BQMs.items())
-    @dimod.symbolic()
     def test_iadd_number(self, name, BQM):
         bqm = BQM('SPIN')
         old = bqm
@@ -2044,7 +2042,6 @@ class TestSymbolic(unittest.TestCase):
         self.assertEqual(bqm.num_variables, 0)
 
     @parameterized.expand(BQMs.items())
-    @dimod.symbolic()
     def test_radd_number(self, name, BQM):
         bqm = BQM('SPIN')
         new = 1 + bqm
@@ -2053,15 +2050,6 @@ class TestSymbolic(unittest.TestCase):
         self.assertEqual(bqm.num_variables, 0)
 
     @parameterized.expand(BQMs.items())
-    def test_exceptions(self, name, BQM):
-        bqm = BQM('SPIN')
-        with self.assertRaises(TypeError):
-            bqm + 1
-        with self.assertRaises(TypeError):
-            bqm * 1
-
-    @parameterized.expand(BQMs.items())
-    @dimod.symbolic()
     def test_exceptions_symbolic_mode(self, name, BQM):
         bqm = BQM('SPIN')
         with self.assertRaises(TypeError):
@@ -2076,7 +2064,6 @@ class TestSymbolic(unittest.TestCase):
         with self.assertRaises(TypeError):
             bqm *= 'a'
 
-    @dimod.symbolic()
     def test_expressions_spin(self):
         u = Spin('u')
         v = Spin('v')


### PR DESCRIPTION
Add very simple operator overloading to the BQM object.

#### Alternatives Considered
Right now `__add__` etc create a new BQM object, rather than something like
```
Add = namedtuple('Add', ['lhs', 'rhs'])

class BQM:
    ...
    def __add__(self, other):
        return Add(self, other)
```

Returning a relation object like above has performance advantages (at the cost of memory), but it's a lot less flexible and a lot less self-contained. For instance, right now
```
ss = ExactSolver().sample(bqm0 + bqm1)
```
is defined without needing some sort of resolution step.

One way around this would be to make comparisons full-fledged BQM data classes (e.g. [pyBQM](https://github.com/dwavesystems/dimod/blob/be747fa4be2c898f7460f77573f82d35f634df57/dimod/binary/pybqm.py#L35) or [VartypeView](https://github.com/dwavesystems/dimod/blob/be747fa4be2c898f7460f77573f82d35f634df57/dimod/binary/vartypeview.py#L56)) and then do something like
```
class BQM:
    ...
    def __add__(self, other):
        bqm = self.__new__(type(self))
        bqm.data = AddBQM(self, other)
```

but for now I think it makes sense to keep things simple.

#### Additional Context

Performance of the multiplication operator would be improved by #833 
Closes #790 as redundant.