### PR TITLE
Allow 100 character line length

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,6 @@ packages =
     dimod.views
 python_requires = >=3.6
 zip_safe = False
+
+[pycodestyle]
+max-line-length = 100


### PR DESCRIPTION
Now that we're starting to use python's typing module, 80 chars is becoming increasingly restrictive.

This commit signals that dimod support 100 characters by adding it to the `setup.cfg`. Ideally we would like to add it to the `pyproject.toml`, but right now that's not supported. See https://github.com/PyCQA/pycodestyle/issues/813