### PR TITLE
Add offset to dqm

### DIFF
--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -40,7 +40,7 @@ cdef class cyDiscreteQuadraticModel:
     cdef vector[CaseIndex] case_starts_  # len(adj_) + 1
     cdef vector[vector[VarIndex]] adj_
 
-    cdef Bias offset_
+    cdef public Bias offset
 
     cdef readonly object dtype
     cdef readonly object case_dtype

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -40,6 +40,8 @@ cdef class cyDiscreteQuadraticModel:
     cdef vector[CaseIndex] case_starts_  # len(adj_) + 1
     cdef vector[vector[VarIndex]] adj_
 
+    cdef Bias offset_
+
     cdef readonly object dtype
     cdef readonly object case_dtype
 

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -18,7 +18,6 @@ cimport cython
 
 from cython.operator cimport preincrement as inc, dereference as deref
 from cython.operator cimport preincrement as preinc  # for when it matters
-from libcpp cimport bool
 from libcpp.algorithm cimport lower_bound, sort, unique
 from libcpp.unordered_set cimport unordered_set
 
@@ -687,7 +686,7 @@ cdef class cyDiscreteQuadraticModel:
                 qi += 1
         
 
-    def to_numpy_vectors(self, bool return_offset=False):
+    def to_numpy_vectors(self, bint return_offset=False):
         
         cdef Py_ssize_t num_variables = self.num_variables()
         cdef Py_ssize_t num_cases = self.num_cases()

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -74,7 +74,7 @@ cdef class cyDiscreteQuadraticModel:
     def add_linear_equality_constraint(self, object terms,
                                        Bias lagrange_multiplier, Bias constant):
         # adjust energy offset
-        self.offset_ += lagrange_multiplier * constant * constant
+        self.offset += lagrange_multiplier * constant * constant
 
         # resolve the terms from a python object into a C++ object
         cdef vector[LinearTerm] cppterms
@@ -223,7 +223,7 @@ cdef class cyDiscreteQuadraticModel:
         dqm.bqm_ = self.bqm_
         dqm.case_starts_ = self.case_starts_
         dqm.adj_ = self.adj_
-        dqm.offset_ = self.offset_
+        dqm.offset = self.offset
 
         return dqm
 
@@ -242,7 +242,7 @@ cdef class cyDiscreteQuadraticModel:
         cdef Py_ssize_t num_samples = samples.shape[0]
         cdef VarIndex num_variables = samples.shape[1]
 
-        cdef Bias[:] energies = np.full(num_samples, self.offset_, dtype=self.dtype)
+        cdef Bias[:] energies = np.full(num_samples, self.offset, dtype=self.dtype)
 
         cdef Py_ssize_t si, vi
         cdef CaseIndex cu, case_u, cv, case_v
@@ -382,7 +382,7 @@ cdef class cyDiscreteQuadraticModel:
                     raise ValueError("A variable has a self-loop")
 
         # add provided offset to dqm
-        dqm.offset_ = offset
+        dqm.offset = offset
 
         return dqm
 
@@ -716,6 +716,6 @@ cdef class cyDiscreteQuadraticModel:
             self._into_numpy_vectors[np.uint64_t](starts, ldata, irow, icol, qdata)
 
         if return_offset:
-            return starts, ldata, (irow, icol, qdata), self.offset_
+            return starts, ldata, (irow, icol, qdata), self.offset
 
         return starts, ldata, (irow, icol, qdata)

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -63,9 +63,19 @@ cdef class cyDiscreteQuadraticModel:
         self.dtype = np.float64
         self.case_dtype = np.int64
 
+        self.offset_ = 0
+
     @property
     def adj(self):
         return self.adj_
+
+    @property
+    def offset(self):
+        return self.offset_
+
+    @offset.setter
+    def offset(self, Bias offset):
+        self.offset_ = offset
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -219,6 +229,7 @@ cdef class cyDiscreteQuadraticModel:
         dqm.bqm_ = self.bqm_
         dqm.case_starts_ = self.case_starts_
         dqm.adj_ = self.adj_
+        dqm.offset_ = self.offset_
 
         return dqm
 

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -64,19 +64,11 @@ cdef class cyDiscreteQuadraticModel:
         self.dtype = np.float64
         self.case_dtype = np.int64
 
-        self.offset_ = 0
+        self.offset = 0
 
     @property
     def adj(self):
         return self.adj_
-
-    @property
-    def offset(self):
-        return self.offset_
-
-    @offset.setter
-    def offset(self, Bias offset):
-        self.offset_ = offset
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -293,7 +293,8 @@ cdef class cyDiscreteQuadraticModel:
                             Numeric32plus[::1] linear_biases,
                             Integral32plus[::1] irow,
                             Integral32plus[::1] icol,
-                            Numeric32plus[::1] quadratic_biases):
+                            Numeric32plus[::1] quadratic_biases,
+                            Bias offset):
         """Equivalent of from_numpy_vectors with fused types."""
 
         # some input checking
@@ -389,10 +390,13 @@ cdef class cyDiscreteQuadraticModel:
                 if deref(span2.first).first < dqm.case_starts_[v+1]:
                     raise ValueError("A variable has a self-loop")
 
+        # add provided offset to dqm
+        dqm.offset_ = offset
+
         return dqm
 
     @classmethod
-    def from_numpy_vectors(cls, case_starts, linear_biases, quadratic):
+    def from_numpy_vectors(cls, case_starts, linear_biases, quadratic, offset = 0):
 
         cdef cyDiscreteQuadraticModel obj = cls()
 
@@ -412,7 +416,7 @@ cdef class cyDiscreteQuadraticModel:
         ldata, qdata = asnumericarrays(
             linear_biases, quadratic_biases, min_itemsize=4, requirements='C')
 
-        return cls._from_numpy_vectors(case_starts, ldata, irow, icol, qdata)
+        return cls._from_numpy_vectors(case_starts, ldata, irow, icol, qdata, offset)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -722,5 +726,5 @@ cdef class cyDiscreteQuadraticModel:
 
         if return_offset:
             return starts, ldata, (irow, icol, qdata), self.offset_
-            
+
         return starts, ldata, (irow, icol, qdata)

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -43,10 +43,9 @@ VERSION = bytes([1, 0])  # version 1.0
 
 # todo: update BinaryQuadraticModel.to_numpy_vectors to also use namedtuple
 DQMVectors = namedtuple(
-    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels'])
-
-DQMVectorsWithOffset = namedtuple(
-    'DQMVectorsWithOffset', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
+    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'],
+    defaults=(0,)
+)
 
 QuadraticVectors = namedtuple(
     'QuadraticVectors', ['row_indices', 'col_indices', 'biases'])
@@ -344,7 +343,7 @@ class DiscreteQuadraticModel:
 
     @classmethod
     def from_numpy_vectors(cls, case_starts, linear_biases, quadratic,
-                           labels=None):
+                           offset=0, labels=None):
         """Construct a DQM from five numpy vectors.
 
         Args:
@@ -372,6 +371,9 @@ class DiscreteQuadraticModel:
                   the case interactions were defined in a sparse matrix, these
                   would be the values.
 
+            offset (float):
+                Energy offset of the DQM.
+
             labels (list, optional):
                 The variable labels. Defaults to index-labeled.
 
@@ -392,7 +394,7 @@ class DiscreteQuadraticModel:
         obj = cls()
 
         obj._cydqm = cyDiscreteQuadraticModel.from_numpy_vectors(
-            case_starts, linear_biases, quadratic)
+            case_starts, linear_biases, quadratic, offset)
 
         if labels is not None:
             if len(labels) != obj._cydqm.num_variables():
@@ -820,7 +822,7 @@ class DiscreteQuadraticModel:
 
         case_starts, linear_biases, quadratic, offset = self._cydqm.to_numpy_vectors(return_offset)
 
-        return DQMVectorsWithOffset(
+        return DQMVectors(
             case_starts, linear_biases, QuadraticVectors(*quadratic), self.variables, offset
         )
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 from operator import eq
 
 import numpy as np
+from numpy.core.shape_base import stack
 
 from dimod.discrete.cydiscrete_quadratic_model import cyDiscreteQuadraticModel
 from dimod.sampleset import as_samples
@@ -42,10 +43,11 @@ VERSION = bytes([1, 1])  # version 1.1
 
 
 # todo: update BinaryQuadraticModel.to_numpy_vectors to also use namedtuple
+LegacyDQMVectors = namedtuple(
+    'LegacyDQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels'])
+
 DQMVectors = namedtuple(
     'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
-
-DQMVectors.__new__.__defaults__ = (0,)
 
 QuadraticVectors = namedtuple(
     'QuadraticVectors', ['row_indices', 'col_indices', 'biases'])
@@ -814,13 +816,17 @@ class DiscreteQuadraticModel:
 
         """
         if not return_offset:
+            warnings.warn(
+                "`return_offset` will default to `True` in the future.", DeprecationWarning,
+                stacklevel=2
+            )
+            
             case_starts, linear_biases, quadratic = self._cydqm.to_numpy_vectors()
 
-            return DQMVectors(case_starts,
-                            linear_biases,
-                            QuadraticVectors(*quadratic),
-                            self.variables,
-                            )
+            return LegacyDQMVectors(case_starts,
+                                    linear_biases,
+                                    QuadraticVectors(*quadratic),
+                                    self.variables)
 
         case_starts, linear_biases, quadratic, offset = self._cydqm.to_numpy_vectors(return_offset)
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -43,9 +43,9 @@ VERSION = bytes([1, 1])  # version 1.1
 
 # todo: update BinaryQuadraticModel.to_numpy_vectors to also use namedtuple
 DQMVectors = namedtuple(
-    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'],
-    defaults=(0,)
-)
+    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
+
+DQMVectors.__new__.__defaults__ = (0,)
 
 QuadraticVectors = namedtuple(
     'QuadraticVectors', ['row_indices', 'col_indices', 'biases'])

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -291,18 +291,13 @@ class DiscreteQuadraticModel:
 
         data = np.load(file_like)
 
-        try:
-            offset = data['offset']
-        except KeyError:
-            offset = 0
-
         obj = cls.from_numpy_vectors(data['case_starts'],
                                      data['linear_biases'],
                                      (data['quadratic_row_indices'],
                                       data['quadratic_col_indices'],
                                       data['quadratic_biases'],
                                       ),
-                                     offset=offset,
+                                     offset=data.get('offset', 0),
                                      )
 
         # move to the end of the data section

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -46,7 +46,7 @@ DQMVectors = namedtuple(
     'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels'])
 
 DQMVectorsWithOffset = namedtuple(
-    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
+    'DQMVectorsWithOffset', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
 
 QuadraticVectors = namedtuple(
     'QuadraticVectors', ['row_indices', 'col_indices', 'biases'])

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -182,6 +182,15 @@ class DiscreteQuadraticModel:
         self._adj = adj = VariableAdjacency(self)
         return adj
 
+    @property
+    def offset(self):
+        return self._cydqm.offset
+
+    @offset.setter
+    def offset(self, offset: float):
+        self._cydqm.offset = offset
+
+
     def add_linear_equality_constraint(self, terms: LinearTriplets,
                                        lagrange_multiplier: float,
                                        constant: float):

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -344,7 +344,7 @@ class DiscreteQuadraticModel:
 
     @classmethod
     def from_numpy_vectors(cls, case_starts, linear_biases, quadratic,
-                           offset=0, labels=None):
+                           labels=None, offset=0):
         """Construct a DQM from five numpy vectors.
 
         Args:
@@ -372,11 +372,11 @@ class DiscreteQuadraticModel:
                   the case interactions were defined in a sparse matrix, these
                   would be the values.
 
-            offset (float):
-                Energy offset of the DQM.
-
             labels (list, optional):
                 The variable labels. Defaults to index-labeled.
+
+            offset (float):
+                Energy offset of the DQM.
 
         Example:
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -44,6 +44,10 @@ VERSION = bytes([1, 0])  # version 1.0
 # todo: update BinaryQuadraticModel.to_numpy_vectors to also use namedtuple
 DQMVectors = namedtuple(
     'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels'])
+
+DQMVectorsWithOffset = namedtuple(
+    'DQMVectors', ['case_starts', 'linear_biases', 'quadratic', 'labels', 'offset'])
+
 QuadraticVectors = namedtuple(
     'QuadraticVectors', ['row_indices', 'col_indices', 'biases'])
 
@@ -758,8 +762,11 @@ class DiscreteQuadraticModel:
 
         return file
 
-    def to_numpy_vectors(self):
+    def to_numpy_vectors(self, return_offset: bool = False):
         """Convert the DQM to five numpy vectors and the labels.
+
+        Args:
+            return_offset: Boolean flag to optionally return energy offset value.
 
         Returns:
             :class:`DQMVectors`: A named tuple with fields `['case_starts',
@@ -802,13 +809,20 @@ class DiscreteQuadraticModel:
             :meth:`~DiscreteQuadraticModel.from_numpy_vectors`
 
         """
-        case_starts, linear_biases, quadratic = self._cydqm.to_numpy_vectors()
+        if not return_offset:
+            case_starts, linear_biases, quadratic = self._cydqm.to_numpy_vectors()
 
-        return DQMVectors(case_starts,
-                          linear_biases,
-                          QuadraticVectors(*quadratic),
-                          self.variables,
-                          )
+            return DQMVectors(case_starts,
+                            linear_biases,
+                            QuadraticVectors(*quadratic),
+                            self.variables,
+                            )
+
+        case_starts, linear_biases, quadratic, offset = self._cydqm.to_numpy_vectors(return_offset)
+
+        return DQMVectorsWithOffset(
+            case_starts, linear_biases, QuadraticVectors(*quadratic), self.variables, offset
+        )
 
 
 DQM = DiscreteQuadraticModel  # alias

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -664,7 +664,8 @@ class TestNumpyVectors(unittest.TestCase):
 
     def test_empty_functional(self):
         dqm = dimod.DQM()
-        new = dimod.DQM.from_numpy_vectors(*dqm.to_numpy_vectors())
+        with self.assertWarns(DeprecationWarning):
+            new = dimod.DQM.from_numpy_vectors(*dqm.to_numpy_vectors())
         self.assertEqual(new.num_variables(), 0)
 
     def test_exceptions(self):
@@ -741,7 +742,8 @@ class TestNumpyVectors(unittest.TestCase):
         dqm.set_linear_case(0, 3, 1.5)
         dqm.set_quadratic(0, 1, {(0, 1): 1.5, (3, 4): 1})
 
-        new = dimod.DQM.from_numpy_vectors(*dqm.to_numpy_vectors())
+        with self.assertWarns(DeprecationWarning):
+            new = dimod.DQM.from_numpy_vectors(*dqm.to_numpy_vectors())
 
         self.assertEqual(new.num_variables(), dqm.num_variables())
         self.assertEqual(new.num_cases(), dqm.num_cases())
@@ -760,11 +762,13 @@ class TestNumpyVectors(unittest.TestCase):
         dqm.set_linear_case(0, 3, 1.5)
         dqm.set_quadratic(0, 'b', {(0, 1): 1.5, (3, 4): 1})
 
-        vectors = dqm.to_numpy_vectors()
+        with self.assertWarns(DeprecationWarning):
+            vectors = dqm.to_numpy_vectors()
 
-        new = dimod.DQM.from_numpy_vectors(*vectors)
+            new = dimod.DQM.from_numpy_vectors(*vectors)
 
-        new_vectors = new.to_numpy_vectors()
+            new_vectors = new.to_numpy_vectors()
+
         np.testing.assert_array_equal(vectors[0], new_vectors[0])
         np.testing.assert_array_equal(vectors[1], new_vectors[1])
         np.testing.assert_array_equal(vectors[2][0], new_vectors[2][0])
@@ -790,11 +794,13 @@ class TestNumpyVectors(unittest.TestCase):
 
         dqm = gnp_random_dqm(5, [4, 5, 2, 1, 10], .5, .5, seed=17)
 
-        vectors = dqm.to_numpy_vectors()
+        with self.assertWarns(DeprecationWarning):
+            vectors = dqm.to_numpy_vectors()
 
         new = dimod.DQM.from_numpy_vectors(*vectors)
 
-        new_vectors = new.to_numpy_vectors()
+        with self.assertWarns(DeprecationWarning):
+            new_vectors = new.to_numpy_vectors()
         np.testing.assert_array_equal(vectors[0], new_vectors[0])
         np.testing.assert_array_equal(vectors[1], new_vectors[1])
         np.testing.assert_array_equal(vectors[2][0], new_vectors[2][0])
@@ -820,10 +826,11 @@ class TestNumpyVectors(unittest.TestCase):
 
         dqm = gnp_random_dqm(5, [4, 5, 2, 1, 10], .5, .5, seed=17)
 
-        vectors = dqm.to_numpy_vectors()
+        with self.assertWarns(DeprecationWarning):
+            vectors = dqm.to_numpy_vectors()
 
         # suffle the quadratic vectors so they are not ordered anymore
-        starts, ldata, (irow, icol, qdata), labels, offset = vectors
+        starts, ldata, (irow, icol, qdata), labels = vectors
 
         shuffled = (starts, ldata,
                     (np.array(np.flip(icol), copy=True),

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -95,6 +95,7 @@ class TestConstruction(unittest.TestCase):
         self.assertEqual(dqm.variables, [])
         self.assertEqual(dqm.adj, {})
         self.assertEqual(dqm.num_cases(), 0)
+        self.assertEqual(dqm.offset, 0)
 
     def test_one_variable(self):
         dqm = dimod.DQM()
@@ -107,6 +108,18 @@ class TestConstruction(unittest.TestCase):
         self.assertEqual(dqm.adj, {0: set()})
         self.assertEqual(dqm.num_cases(), 10)
         self.assertEqual(dqm.num_cases(0), 10)
+
+    def test_offset(self):
+        dqm = dimod.DQM()
+        dqm.add_variable(2)
+        dqm.set_linear(0, [1,1])
+        initial_energy = dqm.energy([0])
+
+        dqm.offset = 10
+        self.assertEqual(dqm.offset, 10)
+        self.assertEqual(
+            dqm.energy([0]), initial_energy + dqm.offset
+        )
 
     def test_one_labelled(self):
         dqm = dimod.DQM()

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -826,7 +826,7 @@ class TestNumpyVectors(unittest.TestCase):
         vectors = dqm.to_numpy_vectors()
 
         # suffle the quadratic vectors so they are not ordered anymore
-        starts, ldata, (irow, icol, qdata), labels = vectors
+        starts, ldata, (irow, icol, qdata), labels, offset = vectors
 
         shuffled = (starts, ldata,
                     (np.array(np.flip(icol), copy=True),

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -521,7 +521,7 @@ class TestConstraint(unittest.TestCase):
             for v, cv, bias in expression:
                 if expression_dict[v][0] == state[v]:
                     s += bias
-            self.assertAlmostEqual(dqm.energy(state) + constant ** 2, s ** 2)
+            self.assertAlmostEqual(dqm.energy(state), s ** 2)
 
     def test_random_constraint(self):
         num_variables = 4
@@ -541,13 +541,12 @@ class TestConstraint(unittest.TestCase):
         expression_dict = {v: (c, b) for v, c, b in expression}
         for case_values in itertools.product(*(range(c) for c in cases)):
             state = {x[i]: case_values[i] for i in x}
-            energy = dqm.energy(state) + lagrange_multiplier * constant ** 2
             s = constant
             for v, cv, bias in expression:
                 if expression_dict[v][0] == state[v]:
                     s += bias
 
-            self.assertAlmostEqual(energy, lagrange_multiplier * s ** 2 + dqm_0.energy(state))
+            self.assertAlmostEqual(dqm.energy(state), lagrange_multiplier * s ** 2 + dqm_0.energy(state))
 
     def test_unknown_variable(self):
         dqm = dimod.DQM()
@@ -598,7 +597,6 @@ class TestConstraint(unittest.TestCase):
 
         for case_values in itertools.product(*(range(c) for c in cases)):
             state = {i: case_values[i] for i in range(num_variables)}
-            energy = dqm.energy(state) + lagrange_multiplier * constant ** 2
             s = constant
             for v, cv, bias in expression1:
                 if expression_dict1[v][0] == state[v]:
@@ -606,7 +604,7 @@ class TestConstraint(unittest.TestCase):
             for v, cv, bias in expression2:
                 if expression_dict2[v][0] == state[v]:
                     s += bias
-            self.assertEqual(energy, lagrange_multiplier * s ** 2)
+            self.assertEqual(dqm.energy(state), lagrange_multiplier * s ** 2)
 
     def test_self_loop_repeat2(self):
         num_variables = 4
@@ -630,7 +628,6 @@ class TestConstraint(unittest.TestCase):
 
         for case_values in itertools.product(*(range(c) for c in cases)):
             state = {i: case_values[i] for i in range(num_variables)}
-            energy = dqm.energy(state) + lagrange_multiplier * constant ** 2
             s = constant
             for v, cv, bias in expression1:
                 if expression_dict1[v][0] == state[v]:
@@ -638,7 +635,7 @@ class TestConstraint(unittest.TestCase):
             for v, cv, bias in expression2:
                 if expression_dict2[v][0] == state[v]:
                     s += bias
-            self.assertEqual(energy, lagrange_multiplier * s ** 2)
+            self.assertEqual(dqm.energy(state), lagrange_multiplier * s ** 2)
 
     def test_self_loop3(self):
 


### PR DESCRIPTION
Note: Publishing before it's ready to merge to get eyes on it.

Implement offset in DQM object via underlying `cyDiscreteQuadraticModel` object.
Update methods in backwards compatibility safe way.
Add new tests and update existing tests to reflect offset.

Closes https://github.com/dwavesystems/dimod/issues/744