### PR TITLE
Add BQM.degrees() method

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -935,6 +935,27 @@ class BinaryQuadraticModel:
     def degree(self, v: Variable):
         return self.data.degree
 
+    def degrees(self, array: bool = False, dtype: DTypeLike = np.int
+                ) -> Union[np.ndarray, Mapping[Variable, int]]:
+        """Return the degrees of a binary quadratic model's variables.
+
+        Args:
+            array (optional, default=False):
+                If True, returns a :obj:`numpy.ndarray`; otherwise returns a dict.
+
+            dtype (optional, default=:class:`numpy.int`):
+                The data type of the returned degrees. Applies only if
+                `array==True`.
+
+        Returns:
+            Degrees of all variables.
+
+        """
+        if array:
+            return np.fromiter(map(self.degree, self.variables),
+                               count=len(self), dtype=dtype)
+        return {v: self.degree(v) for v in self.variables}
+
     @classmethod
     def empty(cls, vartype):
         """Create a new binary quadratic model with no variables and no offset.

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -817,6 +817,20 @@ class TestCoo(unittest.TestCase):
         self.assertEqual(bqm, new_bqm)
 
 
+class TestDegree(unittest.TestCase):
+    @parameterized.expand(BQM_CLSs.items())
+    def test_degrees(self, name, BQM):
+        bqm = BQM({}, {'ab': 1, 'bc': 1, 'ac': 1, 'ad': 1}, 'SPIN')
+        self.assertEqual(bqm.degrees(), {'a': 3, 'b': 2, 'c': 2, 'd': 1})
+
+    @parameterized.expand(BQM_CLSs.items())
+    def test_degrees_array(self, name, BQM):
+        bqm = BQM('SPIN')
+        bqm.add_linear_from((v, 0) for v in 'abcd')
+        bqm.add_quadratic_from({'ab': 1, 'bc': 1, 'ac': 1, 'ad': 1})
+        np.testing.assert_array_equal(bqm.degrees(array=True), [3, 2, 2, 1])
+
+
 class TestDepreaction(unittest.TestCase):
     @parameterized.expand(BQM_CLSs.items())
     def test_shapeable(self, name, BQM):


### PR DESCRIPTION
For backwards compatibility - was supported by `dimod.core.BQM`.