### PR TITLE
Add `scale` method to `QuadraticModelBase`, with test

### DIFF
--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -613,8 +613,7 @@ class QuadraticModelBase {
     }
 
     /// Scale offset, linear biases, and interactions by a factor
-    void scale(double scale_factor, int ignored_variables = NULL,
-               int ignored_interactions = NULL) {
+    void scale(double scale_factor) {
         // adjust offset
         offset() *= scale_factor;
 

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -618,11 +618,11 @@ class QuadraticModelBase {
         offset() *= scale_factor;
 
         // adjust linear biases and quadratic interactions
-        for (size_type ui = 0; ui < num_variables(); ui++) {
-            linear_biases_[ui] *= scale_factor;
+        for (size_type u = 0; u < num_variables(); u++) {
+            linear_biases_[u] *= scale_factor;
 
-            auto begin = adj_[ui].begin();
-            auto end = adj_[ui].end();
+            auto begin = adj_[u].begin();
+            auto end = adj_[u].end();
             for (auto nit = begin; nit != end; ++nit) {
                 (*nit).second *= scale_factor;
             }

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -612,6 +612,24 @@ class QuadraticModelBase {
         }
     }
 
+    /// Scale offset, linear biases, and interactions by a factor
+    void scale(double scale_factor, int ignored_variables = NULL,
+               int ignored_interactions = NULL) {
+        // adjust offset
+        offset() *= scale_factor;
+
+        // adjust linear biases and quadratic interactions
+        for (size_type ui = 0; ui < num_variables(); ui++) {
+            linear_biases_[ui] *= scale_factor;
+
+            auto begin = adj_[ui].begin();
+            auto end = adj_[ui].end();
+            for (auto nit = begin; nit != end; ++nit) {
+                (*nit).second *= scale_factor;
+            }
+        }
+    }
+
  protected:
     std::vector<bias_type> linear_biases_;
     std::vector<Neighborhood<bias_type, index_type>> adj_;

--- a/releasenotes/notes/quadratic_model_scale_method-52f5a73ec045801c.yaml
+++ b/releasenotes/notes/quadratic_model_scale_method-52f5a73ec045801c.yaml
@@ -1,6 +1,5 @@
 ---
 features:
   - |
-    Add new `scale` method to `QuadraticModelBase`. Eventually to be ported to python
-    layer for performance reasons. Scales offset, linear biases, and quadratic interactions
+    Add `QuadraticModelBase::scale` method. Scales offset, linear biases, and quadratic biases
     by a provided scale factor.

--- a/releasenotes/notes/quadratic_model_scale_method-52f5a73ec045801c.yaml
+++ b/releasenotes/notes/quadratic_model_scale_method-52f5a73ec045801c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add new `scale` method to `QuadraticModelBase`. Eventually to be ported to python
+    layer for performance reasons. Scales offset, linear biases, and quadratic interactions
+    by a provided scale factor.

--- a/testscpp/tests/test_quadratic_model.cpp
+++ b/testscpp/tests/test_quadratic_model.cpp
@@ -38,6 +38,31 @@ TEMPLATE_TEST_CASE_SIG("Scenario: BinaryQuadraticModel tests", "[qmbase][bqm]",
             }
         }
 
+        AND_GIVEN("a scale factor for biases and offset") {
+            double scale_factor = 5.5;
+
+            WHEN("we call scale on a filled BQM") {
+                bqm.offset() = 2;
+                bqm.resize(3);
+                bqm.linear(0) = 1;
+                bqm.linear(1) = 2;
+                bqm.linear(2) = 3;
+                bqm.set_quadratic(0,1,1);
+                bqm.set_quadratic(1,2,2);
+
+                bqm.scale(scale_factor);
+
+                THEN("all biases, interaction, and offset are scaled") {
+                    REQUIRE(bqm.offset() == 11.0);
+                    REQUIRE(bqm.linear(0) == 5.5);
+                    REQUIRE(bqm.linear(1) == 11.0);
+                    REQUIRE(bqm.linear(2) == 16.5);
+                    REQUIRE(bqm.quadratic(0,1) == 5.5);
+                    REQUIRE(bqm.quadratic(1,2) == 11.0);
+                }
+            }
+        }
+
         AND_GIVEN("some COO-formatted arrays") {
             int irow[4] = {0, 2, 0, 1};
             int icol[4] = {0, 2, 1, 2};


### PR DESCRIPTION
Implement `scale` method in `QuadraticModelBase`.
Adjust offset, linear biases, and interactions by a scale factor.
Add test to reflect addition.

Closes #833  