### PR TITLE
Make use of QuadraticModelBase::scale in dimod.binary.BQM

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -1225,8 +1225,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
     def scale(self, scalar, ignored_variables=None, ignored_interactions=None,
               ignore_offset=False):
-        """Multiply all the biases by the specified scalar. Default to C++
-        implementation with default args, otherwise fallback on Python.
+        """Multiply all the biases by the specified scalar. 
 
         Args:
             scalar (number):
@@ -1244,14 +1243,14 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
                 If True, the offset is not scaled.
 
         """
-        if (
-            ignored_variables, ignored_interactions, ignore_offset
-        ) == (None, None, False) and isinstance(
-            self.data, (cyBQM_float32, cyBQM_float64)
-        ):
-            self.data.scale(scalar)
-            return
-        
+        if ignored_variables is None and ignored_interactions is None \
+            and ignore_offset is False:
+            try:
+                self.data.scale(scalar)
+                return
+            except AttributeError:
+                pass
+
         if ignored_variables is None:
             ignored_variables = set()
         elif not isinstance(ignored_variables, abc.Container):

--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -1225,7 +1225,8 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
     def scale(self, scalar, ignored_variables=None, ignored_interactions=None,
               ignore_offset=False):
-        """Multiply all the biases by the specified scalar.
+        """Multiply all the biases by the specified scalar. Default to C++
+        implementation with default args, otherwise fallback on Python.
 
         Args:
             scalar (number):
@@ -1243,8 +1244,12 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
                 If True, the offset is not scaled.
 
         """
-        # this could be cythonized for performance
-
+        if (
+            ignored_variables, ignored_interactions, ignore_offset
+        ) == (None, None, False):
+            self.data.scale(scalar)
+            return
+        
         if ignored_variables is None:
             ignored_variables = set()
         elif not isinstance(ignored_variables, abc.Container):

--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -1246,7 +1246,9 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
         """
         if (
             ignored_variables, ignored_interactions, ignore_offset
-        ) == (None, None, False):
+        ) == (None, None, False) and isinstance(
+            self.data, (cyBQM_float32, cyBQM_float64)
+        ):
             self.data.scale(scalar)
             return
         

--- a/dimod/binary/cybqm/cybqm_template.pxd.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pxd.pxi
@@ -72,7 +72,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         size_type num_interactions(index_type)
         bint remove_interaction(index_type, index_type) except +
         void resize(index_type)
-        void scale(cython.double)
+        void scale(bias_type)
         void set_quadratic(index_type, index_type, bias_type) except +
         cppVartype& vartype()
 
@@ -101,4 +101,4 @@ cdef class cyBQM_template(cyBQMBase):
     cpdef Py_ssize_t num_interactions(self)
     cpdef Py_ssize_t num_variables(self)
     cpdef Py_ssize_t resize(self, Py_ssize_t) except -1
-    cpdef void scale(self, cython.double)
+    cpdef void scale(self, bias_type)

--- a/dimod/binary/cybqm/cybqm_template.pxd.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pxd.pxi
@@ -72,6 +72,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         size_type num_interactions(index_type)
         bint remove_interaction(index_type, index_type) except +
         void resize(index_type)
+        void scale(cython.double)
         void set_quadratic(index_type, index_type, bias_type) except +
         cppVartype& vartype()
 
@@ -100,3 +101,4 @@ cdef class cyBQM_template(cyBQMBase):
     cpdef Py_ssize_t num_interactions(self)
     cpdef Py_ssize_t num_variables(self)
     cpdef Py_ssize_t resize(self, Py_ssize_t) except -1
+    cpdef void scale(self, cython.double)

--- a/dimod/binary/cybqm/cybqm_template.pyx.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pyx.pxi
@@ -736,7 +736,7 @@ cdef class cyBQM_template(cyBQMBase):
         while self.variables.size() > n:
             self.variables._pop()
 
-    cpdef void scale(self, cython.double scalar):
+    cpdef void scale(self, bias_type scalar):
         self.cppbqm.scale(scalar)
 
     def set_linear(self, v, bias_type bias):

--- a/dimod/binary/cybqm/cybqm_template.pyx.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pyx.pxi
@@ -736,6 +736,9 @@ cdef class cyBQM_template(cyBQMBase):
         while self.variables.size() > n:
             self.variables._pop()
 
+    cpdef void scale(self, cython.double scalar):
+        self.cppbqm.scale(scalar)
+
     def set_linear(self, v, bias_type bias):
         cdef Py_ssize_t vi = self._index(v, permissive=True)
         self._set_linear(vi, bias)


### PR DESCRIPTION
Port `QuadraticModelBase::scale` to Python layer of BQM.
Benchmark done using `dimod.generators.random.gnm_random_bqm`, fixed with 100,000 variables and 1,000,000 interactions. Comparison done with `cls = AdjVectorBQM` and `cls = dimod.binary.BinaryQuadraticModel` respectively:

`1.4 s ± 7.43 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)` (`AdjVectorBQM` scale method pure python)

`102 ms ± 651 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)` (`BinaryQuadraticModel` defaulting to C++ code)