### PR TITLE
Use new C++ BQM in DiscreteQuadraticModel

### DIFF
--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -23,10 +23,8 @@ cimport numpy as np
 from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
 from dimod.bqm.common cimport Integral32plus, Numeric, Numeric32plus
 
-
-ctypedef np.float64_t Bias
-ctypedef np.int64_t CaseIndex
-ctypedef np.int64_t VarIndex
+ctypedef np.float64_t bias_type
+ctypedef np.int64_t index_type  # todo: int32
 
 ctypedef fused Unsigned:
     np.uint8_t
@@ -36,28 +34,28 @@ ctypedef fused Unsigned:
 
 
 cdef class cyDiscreteQuadraticModel:
-    cdef cppAdjVectorBQM[CaseIndex, Bias] bqm_
-    cdef vector[CaseIndex] case_starts_  # len(adj_) + 1
-    cdef vector[vector[VarIndex]] adj_
+    cdef cppAdjVectorBQM[index_type, bias_type] bqm_
+    cdef vector[index_type] case_starts_  # len(adj_) + 1
+    cdef vector[vector[index_type]] adj_
 
-    cdef public Bias offset
+    cdef public bias_type offset
 
     cdef readonly object dtype
     cdef readonly object case_dtype
 
     cpdef Py_ssize_t add_variable(self, Py_ssize_t) except -1
-    cpdef Bias[:] energies(self, CaseIndex[:, :])
-    cpdef Bias get_linear_case(self, VarIndex, CaseIndex) except? -45.3
+    cpdef bias_type[:] energies(self, index_type[:, :])
+    cpdef bias_type get_linear_case(self, index_type, index_type) except? -45.3
     cpdef Py_ssize_t num_cases(self, Py_ssize_t v=*) except -1
     cpdef Py_ssize_t num_case_interactions(self)
     cpdef Py_ssize_t num_variable_interactions(self) except -1
     cpdef Py_ssize_t num_variables(self)
-    cpdef Py_ssize_t set_linear(self, VarIndex v, Numeric[:] biases) except -1
-    cpdef Py_ssize_t set_linear_case(self, VarIndex, CaseIndex, Bias) except -1
+    cpdef Py_ssize_t set_linear(self, index_type v, Numeric[:] biases) except -1
+    cpdef Py_ssize_t set_linear_case(self, index_type, index_type, bias_type) except -1
     cpdef Py_ssize_t set_quadratic_case(
-        self, VarIndex, CaseIndex, VarIndex, CaseIndex, Bias) except -1
-    cpdef Bias get_quadratic_case(
-        self, VarIndex, CaseIndex, VarIndex, CaseIndex)  except? -45.3
+        self, index_type, index_type, index_type, index_type, bias_type) except -1
+    cpdef bias_type get_quadratic_case(
+        self, index_type, index_type, index_type, index_type)  except? -45.3
 
-    cdef void _into_numpy_vectors(self, Unsigned[:] starts, Bias[:] ldata,
-        Unsigned[:] irow, Unsigned[:] icol, Bias[:] qdata)
+    cdef void _into_numpy_vectors(self, Unsigned[:] starts, bias_type[:] ldata,
+        Unsigned[:] irow, Unsigned[:] icol, bias_type[:] qdata)

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -20,7 +20,8 @@ from libcpp.vector cimport vector
 
 cimport numpy as np
 
-from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
+# from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
+from dimod.libcpp cimport cppBinaryQuadraticModel
 from dimod.bqm.common cimport Integral32plus, Numeric, Numeric32plus
 
 ctypedef np.float64_t bias_type
@@ -34,7 +35,7 @@ ctypedef fused Unsigned:
 
 
 cdef class cyDiscreteQuadraticModel:
-    cdef cppAdjVectorBQM[index_type, bias_type] bqm_
+    cdef cppBinaryQuadraticModel[bias_type, index_type] cppbqm
     cdef vector[index_type] case_starts_  # len(adj_) + 1
     cdef vector[vector[index_type]] adj_
 
@@ -43,6 +44,7 @@ cdef class cyDiscreteQuadraticModel:
     cdef readonly object dtype
     cdef readonly object case_dtype
 
+    cdef void _set_linear(self, Py_ssize_t, bias_type)
     cpdef Py_ssize_t add_variable(self, Py_ssize_t) except -1
     cpdef bias_type[:] energies(self, index_type[:, :])
     cpdef bias_type get_linear_case(self, index_type, index_type) except? -45.3

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -20,12 +20,11 @@ from libcpp.vector cimport vector
 
 cimport numpy as np
 
-# from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
 from dimod.libcpp cimport cppBinaryQuadraticModel
 from dimod.bqm.common cimport Integral32plus, Numeric, Numeric32plus
 
 ctypedef np.float64_t bias_type
-ctypedef np.int32_t index_type  # todo: int32
+ctypedef np.int32_t index_type
 
 ctypedef fused Unsigned:
     np.uint8_t

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -39,12 +39,12 @@ cdef class cyDiscreteQuadraticModel:
     cdef vector[index_type] case_starts_  # len(adj_) + 1
     cdef vector[vector[index_type]] adj_
 
-    cdef public bias_type offset
-
     cdef readonly object dtype
     cdef readonly object case_dtype
 
+    cdef void _add_offset(self, bias_type offset)
     cdef void _set_linear(self, Py_ssize_t, bias_type)
+    cdef void _set_offset(self, bias_type offset)
     cpdef Py_ssize_t add_variable(self, Py_ssize_t) except -1
     cpdef bias_type[:] energies(self, index_type[:, :])
     cpdef bias_type get_linear_case(self, index_type, index_type) except? -45.3

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -24,7 +24,7 @@ from dimod.bqm.cppbqm cimport AdjVectorBQM as cppAdjVectorBQM
 from dimod.bqm.common cimport Integral32plus, Numeric, Numeric32plus
 
 ctypedef np.float64_t bias_type
-ctypedef np.int64_t index_type  # todo: int32
+ctypedef np.int32_t index_type  # todo: int32
 
 ctypedef fused Unsigned:
     np.uint8_t

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -25,6 +25,8 @@ import numpy as np
 
 from dimod.utilities import asintegerarrays, asnumericarrays
 
+BIAS_DTYPE = np.float64
+INDEX_DTYPE = np.int32
 
 # developer note: for whatever reason this is the only way we can sort a vector
 # of structs in clang. If we do it in pure cython we get segmentation faults
@@ -60,8 +62,8 @@ cdef class cyDiscreteQuadraticModel:
     def __init__(self):
         self.case_starts_.push_back(0)
 
-        self.dtype = np.float64
-        self.case_dtype = np.int64
+        self.dtype = np.dtype(BIAS_DTYPE)
+        self.case_dtype = np.dtype(INDEX_DTYPE)
 
         self.offset = 0
 

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -346,6 +346,21 @@ class QuadraticModelBase {
     }
 
     /**
+     * The neighborhood of variable `v`.
+     *
+     * @param A variable `v`.
+     * @param The neighborhood will start with the first out variable that
+     * does not compare less than `start`.
+     *
+     * @returns A pair of iterators pointing to the start and end of the
+     *     neighborhood.
+     */
+    std::pair<const_neighborhood_iterator, const_neighborhood_iterator>
+    neighborhood(index_type u, index_type start) const {
+        return std::make_pair(adj_[u].lower_bound(start), adj_[u].cend());
+    }
+
+    /**
      * Return the quadratic bias associated with `u`, `v`.
      *
      * If `u` and `v` do not have a quadratic bias, returns 0.
@@ -745,6 +760,13 @@ class BinaryQuadraticModel : public QuadraticModelBase<Bias, Index> {
                 base_type::adj_[i].sort_and_sum();
             }
         }
+    }
+
+    /// Add one (disconnected) variable to the BQM and return its index.
+    index_type add_variable() {
+        index_type vi = this->num_variables();
+        this->resize(vi + 1);
+        return vi;
     }
 
     /// Change the vartype of the binary quadratic model

--- a/dimod/libcpp.pxd
+++ b/dimod/libcpp.pxd
@@ -53,14 +53,17 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         void add_quadratic(index_type, index_type, bias_type) except +
         void add_quadratic[T](const T dense[], index_type)
         void add_quadratic[ItRow, ItCol, ItBias](ItRow, ItCol, ItBias, index_type) except +
+        index_type add_variable()
         const_quadratic_iterator cbegin_quadratic()
         const_quadratic_iterator cend_quadratic()
         void change_vartype(cppVartype)
         bint is_linear()
         bias_type& linear(index_type)
         bias_type& offset()
+        bias_type quadratic(index_type, index_type)
         bias_type quadratic_at(index_type, index_type) except +
-        pair[const_neighborhood_iterator, const_neighborhood_iterator] neighborhood(size_type)
+        pair[const_neighborhood_iterator, const_neighborhood_iterator] neighborhood(index_type)
+        pair[const_neighborhood_iterator, const_neighborhood_iterator] neighborhood(index_type, index_type)
         size_type num_variables()
         size_type num_interactions()
         size_type num_interactions(index_type)

--- a/releasenotes/notes/dqm-use-stable-c++-bqm-51c61c29d2d74263.yaml
+++ b/releasenotes/notes/dqm-use-stable-c++-bqm-51c61c29d2d74263.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Use C++ `BinaryQuadraticModel` rather than `AdjVectorBQM` as the underlying
+    object in `cyDiscreteQuadraticModel`. This means that the underlying
+    implementation is now version controlled.
+upgrade:
+  - |
+    Use C++ `BinaryQuadraticModel` rather than `AdjVectorBQM` as the underlying
+    object in `cyDiscreteQuadraticModel`. Any code that relied on the old
+    `AdjVectorBQM` implementation will need to be upgraded.


### PR DESCRIPTION
Use the new C++ BQM introduced in https://github.com/dwavesystems/dimod/pull/818 in `DiscreteQuadraticModel`.

*Additional Context*
`DQM.add_linear_equality_constraint` performance has changed. Using the following script
```
import time

import numpy as np
import dimod

num_variables = 1000
num_cases = 10
num_trials  = 5

ordered = True


rng = np.random.default_rng(42)


terms_list = [[(v, rng.choice(num_cases), 1) for v in range(num_variables)] for _ in range(10)]

if not ordered:
    for terms in terms_list:
        rng.shuffle(terms)

single = 0
additive = 0

for _ in range(num_trials):
    dqm = dimod.DQM()
    for v in range(num_variables):
        dqm.add_variable(num_cases)

    t = time.time()
    dqm.add_linear_equality_constraint(terms_list[0], 1, 1)
    single += time.time() - t

    t = time.time()
    for terms in terms_list:
        dqm.add_linear_equality_constraint(terms, 1, 1)
    additive += time.time() - t

print('single', single)
print('additive', additive)
```
to compare between this PR and https://github.com/dwavesystems/dimod/tree/06d2fd18b7bd8c12f75976675f4e7f7f32b6b512 on my system gives
* Main
    * single: ~.06
    * additive: ~5.77
* PR
    * single: ~.13
    * additive: ~4.7

So took a performance hit when adding to an empty DQM but improved performance when adding multiple constraints.