### PR TITLE
Set temp upper bound on sphinx to remove doc test error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
-sphinx
+# temp upper bound to remove error from C++ docs until a patch is released
+sphinx<4.1.0
 sphinx_rtd_theme
 
 breathe


### PR DESCRIPTION
With `sphinx 4.1.1` or `4.1.0`, the following error occurs when running the doc test:

```
Exception occurred:
  File "/home/circleci/repo/env/lib/python3.7/site-packages/sphinx/util/cfamily.py", line 275, in fail
    raise self._make_multi_error(errors, '')
sphinx.util.cfamily.DefinitionError: Invalid C++ declaration: Expected identifier in nested name. [error at 5]
  class
  -----^
```

It appears to be the same problem as this: https://github.com/sphinx-doc/sphinx/issues/9433 , and should be fixed in `breathe`: https://github.com/michaeljones/breathe/pull/711 . Once a patch is released, we can probably remove this upper bound.






