### PR TITLE
Consistency Update

### DIFF
--- a/dimod/__init__.pxd
+++ b/dimod/__init__.pxd
@@ -12,4 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from dimod.bqm cimport *
+from dimod.binary cimport *
+cimport dimod.binary
+
+from dimod.quadratic cimport *
+cimport dimod.quadratic

--- a/dimod/binary/__init__.pxd
+++ b/dimod/binary/__init__.pxd
@@ -1,0 +1,16 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dimod.binary.cybqm cimport *
+cimport dimod.binary.cybqm

--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -117,7 +117,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
         self.offset = offset
 
-        vartype = self.data.vartype
+        vartype = self.vartype
 
         if isinstance(quadratic, (abc.Mapping, abc.Iterator)):
             if isinstance(quadratic, abc.Mapping):
@@ -456,7 +456,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
         One of :class:`.Vartype.SPIN` or :class:`.Vartype.BINARY`.
         """
-        return self.data.vartype
+        return self.data.vartype()
 
     @classmethod
     def shapeable(cls) -> bool:

--- a/dimod/binary/cybqm/cybqm_template.pxd.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pxd.pxi
@@ -40,6 +40,7 @@ cdef class cyBQM_template(cyBQMBase):
     cpdef Py_ssize_t add_linear_from_array(self, ConstNumeric[:] linear) except -1
     cpdef Py_ssize_t add_quadratic_from_dense(self, ConstNumeric[:, ::1] quadratic) except -1
     cpdef Py_ssize_t change_vartype(self, object) except -1
+    cdef const cppBinaryQuadraticModel[bias_type, index_type]* data(self)
     cpdef bint is_linear(self)
     cpdef Py_ssize_t num_interactions(self)
     cpdef Py_ssize_t num_variables(self)

--- a/dimod/binary/cybqm/cybqm_template.pyx.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pyx.pxi
@@ -307,6 +307,10 @@ cdef class cyBQM_template(cyBQMBase):
         else:
             raise RuntimeError("unknown vartype", vartype)
 
+    cdef const cppBinaryQuadraticModel[bias_type, index_type]* data(self):
+        """Return a pointer to the C++ BinaryQuadraticModel."""
+        return &self.cppbqm
+
     def degree(self, v):
         cdef Py_ssize_t vi = self._index(v)
         return self.cppbqm.num_interactions(vi)

--- a/dimod/binary/cybqm/cybqm_template.pyx.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pyx.pxi
@@ -54,13 +54,13 @@ cdef class cyBQM_template(cyBQMBase):
         self.variables = Variables()
 
     def __copy__(self):
-        cdef cyBQM_template new = type(self)(self.vartype)
+        cdef cyBQM_template new = type(self)(self.vartype())
         new.cppbqm = self.cppbqm
         new.variables = self.variables.copy()
         return new
 
     def __deepcopy__(self, memo):
-        cdef cyBQM_template new = type(self)(self.vartype)
+        cdef cyBQM_template new = type(self)(self.vartype())
         memo[id(self)] = new
         new.cppbqm = self.cppbqm
         new.variables = copy.deepcopy(self.variables, memo)
@@ -70,7 +70,7 @@ cdef class cyBQM_template(cyBQMBase):
         ldata, qdata, off, labels = self.to_numpy_vectors(return_labels=True)
         return (
             type(self).from_numpy_vectors,
-            (ldata, qdata, off, self.vartype, labels))
+            (ldata, qdata, off, self.vartype(), labels))
 
     @property
     def offset(self):
@@ -80,19 +80,6 @@ cdef class cyBQM_template(cyBQMBase):
     @offset.setter
     def offset(self, bias_type offset):
         self._set_offset(offset)
-
-    @property
-    def vartype(self):
-        """The model's variable type.
-
-        One of :class:`.Vartype.SPIN` or :class:`.Vartype.BINARY`.
-        """
-        if self.cppbqm.vartype() == cppVartype.BINARY:
-            return Vartype.BINARY
-        elif self.cppbqm.vartype() == cppVartype.SPIN:
-            return Vartype.SPIN
-        else:
-            raise RuntimeError("unknown vartype")
 
     cdef void _add_linear(self, Py_ssize_t vi, bias_type bias):
         # unsafe version of .add_linear
@@ -858,3 +845,15 @@ cdef class cyBQM_template(cyBQMBase):
         except TypeError:
             # if other is not a cybqm, defer back to the caller
             raise NotImplementedError from None
+
+    def vartype(self, v=None):
+        """The model's variable type.
+
+        One of :class:`.Vartype.SPIN` or :class:`.Vartype.BINARY`.
+        """
+        if self.cppbqm.vartype() == cppVartype.BINARY:
+            return Vartype.BINARY
+        elif self.cppbqm.vartype() == cppVartype.SPIN:
+            return Vartype.SPIN
+        else:
+            raise RuntimeError("unknown vartype")

--- a/dimod/binary/pybqm.py
+++ b/dimod/binary/pybqm.py
@@ -48,12 +48,8 @@ class pyBQM:
     def variables(self) -> Collection:
         return KeysView(self._adj)
 
-    @property
-    def vartype(self):
-        return self._vartype
-
     def __copy__(self):
-        new = type(self)(self.vartype)
+        new = type(self)(self._vartype)
         adj = new._adj
         for v, neighborhood in self._adj.items():
             adj[v] = neighborhood.copy()
@@ -102,11 +98,11 @@ class pyBQM:
                     self.add_quadratic(u, v, quadratic[u, v])
 
         # now handle the linear
-        if self.vartype is Vartype.SPIN:
+        if self._vartype is Vartype.SPIN:
             for v in range(num_variables):
                 # since s*s == 1
                 self.offset += quadratic[v, v]
-        elif self.vartype is Vartype.BINARY:
+        elif self._vartype is Vartype.BINARY:
             for v in range(num_variables):
                 # since x*x == x
                 self.add_linear(v, quadratic[v, v])
@@ -133,7 +129,7 @@ class pyBQM:
         vartype = as_vartype(vartype)
 
         # in place and we are already correct, so nothing to do
-        if self.vartype == vartype:
+        if self._vartype == vartype:
             return self
 
         if vartype == Vartype.BINARY:
@@ -347,3 +343,6 @@ class pyBQM:
 
     def update(self, *args, **kwargs):
         raise NotImplementedError  # defer to the caller
+
+    def vartype(self, v: Optional[Variable] = None) -> Vartype:
+        return self._vartype

--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -237,7 +237,8 @@ class ConstrainedQuadraticModel:
         return self.add_constraint_from_model(
             qm, sense, rhs=rhs, label=label, copy=False)
 
-    def add_discrete(self, variables: Collection[Variable]):
+    def add_discrete(self, variables: Collection[Variable],
+                     label: Optional[Hashable] = None) -> Hashable:
         """Add a iterable of binary variables as a disjoint one-hot constraint.
 
         Adds a special kind of one-hot constraint. These one-hot constraints
@@ -254,6 +255,9 @@ class ConstrainedQuadraticModel:
                 another discrete variable.
 
         """
+        if label is not None and label in self.constraints:
+            raise ValueError("a constraint with that label already exists")
+
         for v in variables:
             if v in self._discrete:
                 # todo: language around discrete variables?
@@ -268,7 +272,9 @@ class ConstrainedQuadraticModel:
 
         bqm = BinaryQuadraticModel('BINARY', dtype=np.float32)
         bqm.add_variables_from((v, 1) for v in variables)
-        self.discrete.add(self.add_constraint(bqm == 1))
+        label = self.add_constraint(bqm == 1, label=label)
+        self.discrete.add(label)
+        return label
 
     def add_variable(self, v: Variable, vartype: VartypeLike):
         """Add a variable to the model."""

--- a/dimod/quadratic/__init__.pxd
+++ b/dimod/quadratic/__init__.pxd
@@ -1,0 +1,16 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dimod.quadratic.cyqm cimport *
+cimport dimod.quadratic.cyqm

--- a/dimod/quadratic/cyqm/__init__.pxd
+++ b/dimod/quadratic/cyqm/__init__.pxd
@@ -1,0 +1,21 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dimod.quadratic.cyqm.cyqm_float32 cimport cyQM_float32
+from dimod.quadratic.cyqm.cyqm_float64 cimport cyQM_float64
+
+
+ctypedef fused cyQM:
+    cyQM_float32
+    cyQM_float64

--- a/dimod/quadratic/cyqm/cyqm_template.pxd.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pxd.pxi
@@ -33,6 +33,7 @@ cdef class cyQM_template(cyQMBase):
     cdef cython.floating[::1] _energies(self, object samples_like, cython.floating signal=*)
     cdef void _set_linear(self, Py_ssize_t, bias_type)
     cdef cppVartype cppvartype(self, object) except? cppVartype.SPIN
+    cdef const cppQuadraticModel[bias_type, index_type]* data(self)
     cpdef bint is_linear(self)
     cpdef void scale(self, bias_type)
     cpdef Py_ssize_t num_interactions(self)

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -313,6 +313,10 @@ cdef class cyQM_template(cyQMBase):
         else:
             raise TypeError(f"unexpected vartype {vartype!r}")
 
+    cdef const cppQuadraticModel[bias_type, index_type]* data(self):
+        """Return a pointer to the C++ QuadraticModel."""
+        return &self.cppqm
+
     def degree(self, v):
         cdef Py_ssize_t vi = self.variables.index(v)
         return self.cppqm.num_interactions(vi)

--- a/releasenotes/notes/BQM.data.vartype-method-ba96dce5716ffa4c.yaml
+++ b/releasenotes/notes/BQM.data.vartype-method-ba96dce5716ffa4c.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    ``BinaryQuadraticModel.data.vartype()`` is now accessed as a method rather
+    than as an attribute. This is consistent with
+    ``QuadraticModel.data.vartype()``.

--- a/releasenotes/notes/CQM.add_discrete-return-label-758b7756d0fc378b.yaml
+++ b/releasenotes/notes/CQM.add_discrete-return-label-758b7756d0fc378b.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add an optional ``label`` keyword argument to
+    ``ConstrainedQuadraticModel.add_discrete``. The method also now returns
+    the assigned label, whether supplied or generated. This is consistent with
+    ``ConstrainedQuadraticModel.add_constraint``.
+  

--- a/releasenotes/notes/cimport-cyBQM-and-cyQM-77968e09ebcd685d.yaml
+++ b/releasenotes/notes/cimport-cyBQM-and-cyQM-77968e09ebcd685d.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    ``cyBQM`` and ``cyQM`` fused types can now be cimported from the ``dimod``
+    namespace.
+upgrade:
+  - |
+    ``from dimod cimport cyBQM`` now is a fused type containing
+    ``cyBQM_float32`` and ``cyBQM_float64``. You can use the ``cyBQM``
+    containing ``cyAdjVectorBQM`` with ``from dimod.bqm cimport cyBQM``.

--- a/releasenotes/notes/cyBQM-and-cyQM.data-20ce921b78af8cdd.yaml
+++ b/releasenotes/notes/cyBQM-and-cyQM.data-20ce921b78af8cdd.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add ``.data()`` method to ``cyQM_template`` and ``cyBQM_template`` that
+    returns a const pointer to the underlying C++ ``QuadraticModel`` and
+    ``BinaryQuadraticModel`` respectively.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -73,6 +73,12 @@ class TestAddDiscrete(unittest.TestCase):
         cqm = CQM()
         cqm.add_discrete('abc')
 
+    def test_label(self):
+        cqm = CQM()
+        label = cqm.add_discrete('abc', label='hello')
+        self.assertEqual(label, 'hello')
+        self.assertEqual(cqm.variables, 'abc')
+
 
 class TestAdjVector(unittest.TestCase):
     # this will be deprecated in the future


### PR DESCRIPTION
A grab bag of small updates to make CQM, BQM and QM behave more consistently.

Technically the change to `.vartype()` from `.vartype` in the underlying data object is a backwards compatibility break, but it was not used in https://github.com/dwavesystems/dwave-preprocessing/pull/22 so I think it's safe to deploy in 0.10.1.