### PR TITLE
Fix/add empty bqm

### DIFF
--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -577,6 +577,10 @@ class BinaryQuadraticModel : public QuadraticModelBase<Bias, Index> {
     template <class B, class I, class T>
     void add_bqm(const BinaryQuadraticModel<B, I>& bqm,
                  const std::vector<T>& mapping) {
+        if (bqm.num_variables() == 0)
+            // nothing to do, other BQM is empty
+            return;
+
         if (bqm.vartype() != this->vartype()) {
             // we could do this without the copy, but for now let's just do
             // it simply

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -577,10 +577,6 @@ class BinaryQuadraticModel : public QuadraticModelBase<Bias, Index> {
     template <class B, class I, class T>
     void add_bqm(const BinaryQuadraticModel<B, I>& bqm,
                  const std::vector<T>& mapping) {
-        if (bqm.num_variables() == 0)
-            // nothing to do, other BQM is empty
-            return;
-
         if (bqm.vartype() != this->vartype()) {
             // we could do this without the copy, but for now let's just do
             // it simply
@@ -590,6 +586,13 @@ class BinaryQuadraticModel : public QuadraticModelBase<Bias, Index> {
             return;
         }
 
+        // offset
+        this->offset() += bqm.offset();
+
+        if (bqm.num_variables() == 0)
+            // nothing else to do, other BQM is empty
+            return;
+
         // make sure we're big enough
         T max_v = *std::max_element(mapping.begin(),
                                     mapping.begin() + bqm.num_variables());
@@ -598,9 +601,6 @@ class BinaryQuadraticModel : public QuadraticModelBase<Bias, Index> {
         } else if ((size_type)max_v >= this->num_variables()) {
             this->resize(max_v + 1);
         }
-
-        // offset
-        this->offset() += bqm.offset();
 
         // linear
         for (size_type v = 0; v < bqm.num_variables(); ++v) {

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -3178,18 +3178,22 @@ class TestConstraint(unittest.TestCase):
 
 
 class TestAddBQM(unittest.TestCase):
-    @parameterized.expand(itertools.product(BQMs.items(), BQMs.items()))
-    def test_add_empty_bqm(self, BQM_info0, BQM_info1):
-        name0, BQM0 = BQM_info0
-        name1, BQM1 = BQM_info1
-
+    @parameterized.expand(itertools.product(BQMs.values(), repeat=2))
+    def test_add_empty_bqm(self, BQM0, BQM1):
         for vtype0, vtype1 in itertools.product(*[("BINARY", "SPIN")]*2):
             empty = BQM0(vtype0)
             self.assertEqual(empty, empty + BQM1(vtype1))
             self.assertEqual(empty.change_vartype(vtype1),
                              BQM1(vtype1) + empty)
 
+            empty_offset = BQM0(vtype0)
+            empty_offset.offset = 3
+            self.assertEqual(empty_offset, empty_offset + BQM1(vtype1))
+            self.assertEqual(empty_offset.change_vartype(vtype1),
+                             BQM1(vtype1) + empty_offset)
+
             nonempty = BQM0([[1]], vtype0)
+            nonempty.offset = 3
             self.assertEqual(nonempty, nonempty + BQM1(vtype1))
             self.assertEqual(nonempty.change_vartype(vtype1),
                              BQM1(vtype1) + nonempty)

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -3175,3 +3175,21 @@ class TestConstraint(unittest.TestCase):
 
             self.assertAlmostEqual(bqm.energy(sample),
                                    sum(sample[v]*b for v, b in terms)**2)
+
+
+class TestAddBQM(unittest.TestCase):
+    @parameterized.expand(itertools.product(BQMs.items(), BQMs.items()))
+    def test_add_empty_bqm(self, BQM_info0, BQM_info1):
+        name0, BQM0 = BQM_info0
+        name1, BQM1 = BQM_info1
+
+        for vtype0, vtype1 in itertools.product(*[("BINARY", "SPIN")]*2):
+            empty = BQM0(vtype0)
+            self.assertEqual(empty, empty + BQM1(vtype1))
+            self.assertEqual(empty.change_vartype(vtype1),
+                             BQM1(vtype1) + empty)
+
+            nonempty = BQM0([[1]], vtype0)
+            self.assertEqual(nonempty, nonempty + BQM1(vtype1))
+            self.assertEqual(nonempty.change_vartype(vtype1),
+                             BQM1(vtype1) + nonempty)


### PR DESCRIPTION
Adding an empty BQM to another is causing a segfault.

```
In [1]: dimod.BQM.empty(dimod.BINARY) + dimod.BQM.empty(dimod.BINARY)
[1]    30444 segmentation fault (core dumped)  ipython
```

Seems to be caused by trying to use `std::max_element` on an empty vector https://github.com/dwavesystems/dimod/blob/c39677b4a743574dc795bc140dce703abd61087b/dimod/include/dimod/quadratic_model.h#L590