### PR TITLE
Add Spins, Binaries and Integers functions

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -22,7 +22,11 @@ import tempfile
 import warnings
 
 from numbers import Integral, Number
-from typing import Iterator, Hashable, Union, Tuple, Optional, Any, ByteString, BinaryIO, Iterable, Mapping, Callable, Sequence, MutableMapping
+from typing import (Any, BinaryIO, ByteString, Callable,
+                    Hashable, Iterable, Iterator,
+                    Mapping, MutableMapping, Optional, Sequence,
+                    Tuple, Union,
+                    )
 
 import numpy as np
 
@@ -51,7 +55,7 @@ __all__ = ['BinaryQuadraticModel',
            'Float32BQM',
            'Float64BQM',
            'as_bqm',
-           'Spin', 'Binary',
+           'Spin', 'Binary', 'Spins', 'Binaries',
            ]
 
 BQM_MAGIC_PREFIX = b'DIMODBQM'
@@ -1841,6 +1845,25 @@ def Binary(label: Optional[Variable] = None, bias: Bias = 1,
     return BQM({label: bias}, {}, 0, Vartype.BINARY, dtype=dtype)
 
 
+def Binaries(labels: Union[int, Iterable[Variable]],
+             dtype: Optional[DTypeLike] = None) -> Iterator[BinaryQuadraticModel]:
+    """Yield binary quadratic models, each with a single binary variable.
+
+    Args:
+        labels: Either an iterable of variable labels or a number. If a number
+            labels are generated using :class:`uuid.UUID`.
+        dtype: Data type for the returned binary quadratic models.
+
+    Yields:
+        Binary quadratic models, each with a single binary variable.
+
+    """
+    if isinstance(labels, Iterable):
+        yield from (Binary(v, dtype=dtype) for v in labels)
+    else:
+        yield from (Binary(dtype=dtype) for _ in range(labels))
+
+
 @unique_variable_labels
 def Spin(label: Optional[Variable] = None, bias: Bias = 1,
          dtype: Optional[DTypeLike] = None) -> BinaryQuadraticModel:
@@ -1857,6 +1880,25 @@ def Spin(label: Optional[Variable] = None, bias: Bias = 1,
 
     """
     return BQM({label: bias}, {}, 0, Vartype.SPIN, dtype=dtype)
+
+
+def Spins(labels: Union[int, Iterable[Variable]],
+          dtype: Optional[DTypeLike] = None) -> Iterator[BinaryQuadraticModel]:
+    """Yield binary quadratic models, each with a single spin variable.
+
+    Args:
+        labels: Either an iterable of variable labels or a number. If a number
+            labels are generated using :class:`uuid.UUID`.
+        dtype: Data type for the returned binary quadratic models.
+
+    Yields:
+        Binary quadratic models, each with a single spin variable.
+
+    """
+    if isinstance(labels, Iterable):
+        yield from (Spin(v, dtype=dtype) for v in labels)
+    else:
+        yield from (Spin(dtype=dtype) for _ in range(labels))
 
 
 def as_bqm(*args, cls: None = None, copy: bool = False,

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from dimod import BinaryQuadraticModel
 
 
-__all__ = ['QuadraticModel', 'QM', 'Integer']
+__all__ = ['QuadraticModel', 'QM', 'Integer', 'Integers']
 
 
 QM_MAGIC_PREFIX = b'DIMODQM'
@@ -818,12 +818,31 @@ def Integer(label: Optional[Variable] = None, bias: Bias = 1,
 
     Returns:
         Instance of :class:`.QuadraticModel`.
-    
+
     """
     qm = QM(dtype=dtype)
     v = qm.add_variable(Vartype.INTEGER, label, lower_bound=lower_bound, upper_bound=upper_bound)
     qm.set_linear(v, bias)
     return qm
+
+
+def Integers(labels: Union[int, Iterable[Variable]],
+             dtype: Optional[DTypeLike] = None) -> Iterator[QuadraticModel]:
+    """Yield quadratic models, each with a single integer variable.
+
+    Args:
+        labels: Either an iterable of variable labels or a number. If a number
+            labels are generated using :class:`uuid.UUID`.
+        dtype: Data type for the returned quadratic models.
+
+    Yields:
+        Quadratic models, each with a single integer variable.
+
+    """
+    if isinstance(labels, Iterable):
+        yield from (Integer(v, dtype=dtype) for v in labels)
+    else:
+        yield from (Integer(dtype=dtype) for _ in range(labels))
 
 # register fileview loader
 load.register(QM_MAGIC_PREFIX, QuadraticModel.from_file)

--- a/releasenotes/notes/Binaries-and-Spins-and-Integers-bfed01e0c2b5f6cd.yaml
+++ b/releasenotes/notes/Binaries-and-Spins-and-Integers-bfed01e0c2b5f6cd.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``Binaries``, ``Spins`` and ``Integers`` functions.
+    See `#918 <https://github.com/dwavesystems/dimod/issues/918>`_.

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -225,7 +225,26 @@ class TestBinary(unittest.TestCase):
     def test_init_no_label(self):
         binary_bqm = Binary()
         self.assertIsInstance(binary_bqm.variables[0], uuid.UUID)
-    
+
+    def test_multiple_labelled(self):
+        x, y, z = dimod.Binaries('abc')
+
+        self.assertEqual(x.variables[0], 'a')
+        self.assertEqual(y.variables[0], 'b')
+        self.assertEqual(z.variables[0], 'c')
+        self.assertIs(x.vartype, dimod.BINARY)
+        self.assertIs(y.vartype, dimod.BINARY)
+        self.assertIs(z.vartype, dimod.BINARY)
+
+    def test_multiple_unlabelled(self):
+        x, y, z = dimod.Binaries(3)
+
+        self.assertNotEqual(x.variables[0], y.variables[0])
+        self.assertNotEqual(x.variables[0], z.variables[0])
+        self.assertIs(x.vartype, dimod.BINARY)
+        self.assertIs(y.vartype, dimod.BINARY)
+        self.assertIs(z.vartype, dimod.BINARY)
+
     def test_no_label_collision(self):
         bqm_1 = Binary()
         bqm_2 = Binary()
@@ -2162,6 +2181,25 @@ class TestSpin(unittest.TestCase):
     def test_init_no_label(self):
         spin_bqm = Spin()
         self.assertIsInstance(spin_bqm.variables[0], uuid.UUID)
+
+    def test_multiple_labelled(self):
+        r, s, t = dimod.Spins('abc')
+
+        self.assertEqual(r.variables[0], 'a')
+        self.assertEqual(s.variables[0], 'b')
+        self.assertEqual(t.variables[0], 'c')
+        self.assertIs(s.vartype, dimod.SPIN)
+        self.assertIs(r.vartype, dimod.SPIN)
+        self.assertIs(t.vartype, dimod.SPIN)
+
+    def test_multiple_unlabelled(self):
+        r, s, t = dimod.Spins(3)
+
+        self.assertNotEqual(s.variables[0], r.variables[0])
+        self.assertNotEqual(s.variables[0], t.variables[0])
+        self.assertIs(s.vartype, dimod.SPIN)
+        self.assertIs(r.vartype, dimod.SPIN)
+        self.assertIs(t.vartype, dimod.SPIN)
 
     def test_no_label_collision(self):
         bqm_1 = Spin()

--- a/tests/test_quadratic_model.py
+++ b/tests/test_quadratic_model.py
@@ -335,6 +335,25 @@ class TestInteger(unittest.TestCase):
         integer_qm = Integer()
         self.assertIsInstance(integer_qm.variables[0], uuid.UUID)
 
+    def test_multiple_labelled(self):
+        i, j, k = dimod.Integers('ijk')
+
+        self.assertEqual(i.variables[0], 'i')
+        self.assertEqual(j.variables[0], 'j')
+        self.assertEqual(k.variables[0], 'k')
+        self.assertIs(i.vartype('i'), dimod.INTEGER)
+        self.assertIs(j.vartype('j'), dimod.INTEGER)
+        self.assertIs(k.vartype('k'), dimod.INTEGER)
+
+    def test_multiple_unlabelled(self):
+        i, j, k = dimod.Integers(3)
+
+        self.assertNotEqual(i.variables[0], j.variables[0])
+        self.assertNotEqual(i.variables[0], k.variables[0])
+        self.assertIs(i.vartype(i.variables[0]), dimod.INTEGER)
+        self.assertIs(j.vartype(j.variables[0]), dimod.INTEGER)
+        self.assertIs(k.vartype(k.variables[0]), dimod.INTEGER)
+
     def test_no_label_collision(self):
         qm_1 = Integer()
         qm_2 = Integer()


### PR DESCRIPTION
Decided to go with iterators rather than lists, as a user can always make a list from a iterator, but if for whatever reason they want to do something like
```
for x in Binaries(1000):
   ...
```
we don't need to make all 1000 of them at once.

I also stuck with capitalization, to be consistent with `Binary`, `Spin`, and `Integer`, although it's starting to get a bit weird... In a followup PR I might use lower case and deprecate the capitalized ones.

Closes https://github.com/dwavesystems/dimod/issues/918