### PR TITLE
Add quicksum function

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -56,6 +56,7 @@ __all__ = ['BinaryQuadraticModel',
            'Float64BQM',
            'as_bqm',
            'Spin', 'Binary', 'Spins', 'Binaries',
+           'quicksum',
            ]
 
 BQM_MAGIC_PREFIX = b'DIMODBQM'
@@ -1167,7 +1168,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
     def is_equal(self, other):
         if isinstance(other, Number):
-            return not self.num_variables and self.offset == other
+            return not self.num_variables and bool(self.offset == other)
         # todo: performance
         try:
             return (self.vartype == other.vartype
@@ -1978,6 +1979,30 @@ def as_bqm(*args, cls: None = None, copy: bool = False,
                         return bqm
 
     return BinaryQuadraticModel(*args, dtype=dtype)
+
+
+def quicksum(iterable: Iterable[Union[BinaryQuadraticModel, QuadraticModel, Bias]]
+             ) -> Union[BinaryQuadraticModel, QuadraticModel]:
+    r"""Sum `iterable`'s items.
+
+    This function is an alternative to the built-in :func:`sum`. It will
+    generally be faster when adding many :class:`BinaryQuadraticModel`\s and
+    :class:`QuadraticModel`\s because it creates fewer intermediate objects.
+
+    """
+    iterable = iter(iterable)
+
+    try:
+        model = next(iterable)
+    except StopIteration:
+        return QuadraticModel()
+
+    model = copy.deepcopy(model)
+
+    for obj in iterable:
+        model += obj
+
+    return model
 
 
 # register fileview loader

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -558,7 +558,7 @@ class QuadraticModel(QuadraticViewsMixin):
     def is_equal(self, other: Union['QuadraticModel', Number]) -> bool:
         """Return True if the given model has the same variables, vartypes and biases."""
         if isinstance(other, Number):
-            return not self.num_variables and self.offset == other
+            return not self.num_variables and bool(self.offset == other)
         # todo: performance
         try:
             return (self.shape == other.shape  # redundant, fast to check

--- a/docs/reference/quadratic.rst
+++ b/docs/reference/quadratic.rst
@@ -168,6 +168,16 @@ Methods
 Functions
 =========
 
+Adding models symbolically:
+
+.. currentmodule:: dimod
+
+.. autosummary::
+   :toctree: generated/
+
+   quicksum
+
+
 Generating BQMs:
 
 .. currentmodule:: dimod.generators

--- a/releasenotes/notes/add-quicksum-373672fff48775a4.yaml
+++ b/releasenotes/notes/add-quicksum-373672fff48775a4.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Add ``quicksum`` function for faster summation of ``QuadraticModel`` and
+    ``BinaryQuadraticModel``. Python's built-in ``sum`` continues to work, but
+    ``quicksum`` will generally be faster when adding many objects.
+fixes:
+  - |
+    Return ``bool`` rather than ``numpy.bool_`` from
+    ``QuadraticModel.is_equal`` and ``BinaryQuadraticModel.is_equal`` when
+    comparing empty models to numbers.

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -15,7 +15,7 @@
 import itertools
 import unittest
 
-from dimod import Binary, Integer, Spin
+from dimod import Binary, Integer, Spin, quicksum
 
 
 class TestExpressions(unittest.TestCase):
@@ -46,3 +46,27 @@ class TestExpressions(unittest.TestCase):
 
         for t0, t1 in itertools.permutations([x, i, s, 1], 2):
             qm = t0 - t1
+
+
+class QuickSum(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(quicksum([]), 0)
+
+    def test_promotion(self):
+        x = Binary('x')
+        i = Integer('i')
+        s = Spin('s')
+
+        for perm in itertools.permutations([2*x, i, s, 1]):
+            qm = quicksum(perm)
+
+            self.assertEqual(qm.linear, {'x': 2, 'i': 1, 's': 1})
+            self.assertEqual(qm.offset, 1)
+            self.assertEqual(qm.quadratic, {})
+
+    def test_copy(self):
+        x = Binary('x')
+
+        newx = quicksum([x])
+
+        self.assertIsNot(newx, x)


### PR DESCRIPTION
There is probably still more performance on the table, but this already provides a pretty nice speedup and we can encourage people to use it and improve it more later.

Testing locally,
```python
import time
import dimod

t = time.time()
sum(dimod.Binary(v) for v in range(10000))
print(time.time() - t)

t = time.time()
dimod.quicksum(dimod.Binary(v) for v in range(10000))
print(time.time() - t)
```
returns
```bash
1.0739736557006836
0.1277778148651123 
```