### PR TITLE
Support a superset of variables in BQM/QM.energies

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -875,37 +875,42 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
         """
         return cls(vartype)
 
-    def energies(self, samples_like, dtype: Optional[DTypeLike] = None):
+    def energies(self, samples_like, dtype: Optional[DTypeLike] = None) -> np.ndarray:
         """Determine the energies of the given samples-like.
 
         Args:
             samples_like (samples_like):
-                Raw sample. `samples_like` is an extension of
+                Raw samples. `samples_like` is an extension of
                 NumPy's `array_like`_ structure. See :func:`.as_samples`.
 
-            dtype (data-type, optional, default=None):
+            dtype:
                 Desired NumPy data type for the energy. Matches
                 :attr:`.dtype` by default.
 
         Returns:
             Energies for the samples.
+
+        .. _`array_like`:  https://numpy.org/doc/stable/user/basics.creation.html
+
         """
         return self.data.energies(samples_like, dtype=dtype)
 
-    def energy(self, sample, dtype=None):
+    def energy(self, sample, dtype: Optional[DTypeLike] = None) -> Bias:
         """Determine the energy of the given sample.
 
         Args:
-            samples_like (samples_like):
+            sample (samples_like):
                 Raw sample. `samples_like` is an extension of
                 NumPy's `array_like`_ structure. See :func:`.as_samples`.
 
-            dtype (data-type, optional, default=None):
+            dtype:
                 Desired NumPy data type for the energy. Matches
                 :attr:`.dtype` by default.
 
         Returns:
             The energy.
+
+        .. _`array_like`:  https://numpy.org/doc/stable/user/basics.creation.html
 
         """
         energy, = self.energies(sample, dtype=dtype)

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -69,19 +69,27 @@ cdef class cyQM_template(cyQMBase):
         cdef Py_ssize_t num_samples = samples_view.shape[0]
         cdef Py_ssize_t num_variables = samples_view.shape[1]
 
-        if num_variables != self.num_variables():
-            raise ValueError("inconsistent number of variables")
         if num_variables != len(labels):
-            # an internal error to as_samples. We do this check because
-            # the boundscheck is off
+            # as_samples should never return inconsistent sizes, but we do this
+            # check because the boundscheck is off and we otherwise might get
+            # segfaults
             raise RuntimeError(
                 "as_samples returned an inconsistent samples/variables")
 
-        cdef Py_ssize_t[::1] bqm_to_sample = np.empty(num_variables, dtype=np.intp)
+        # get the indices of the QM variables. Use -1 to signal that a
+        # variable's index has not yet been set
+        cdef Py_ssize_t[::1] qm_to_sample = np.full(self.num_variables(), -1, dtype=np.intp)
         cdef Py_ssize_t si
         for si in range(num_variables):
-            v = labels[si]  # python label
-            bqm_to_sample[self.variables.index(v)] = si
+            v = labels[si]
+            if self.variables.count(v):
+                qm_to_sample[self.variables.index(v)] = si
+
+        # make sure that all of the QM variables are accounted for
+        for si in range(self.num_variables()):
+            if qm_to_sample[si] == -1:
+                raise ValueError(
+                    f"missing variable {self.variables[si]!r} in sample(s)")
 
         cdef cython.floating[::1] energies
         if cython.floating is float:
@@ -96,8 +104,8 @@ cdef class cyQM_template(cyQMBase):
             # offset
             energies[si] = self.cppqm.offset()
 
-            for ui in range(num_variables):
-                uspin = samples_view[si, bqm_to_sample[ui]]
+            for ui in range(self.num_variables()):
+                uspin = samples_view[si, qm_to_sample[ui]]
 
                 # linear
                 energies[si] += self.cppqm.linear(ui) * uspin;
@@ -106,7 +114,7 @@ cdef class cyQM_template(cyQMBase):
                 while span.first != span.second and deref(span.first).first < ui:
                     vi = deref(span.first).first
 
-                    vspin = samples_view[si, bqm_to_sample[vi]]
+                    vspin = samples_view[si, qm_to_sample[vi]]
 
                     energies[si] += uspin * vspin * deref(span.first).second
 

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -455,23 +455,41 @@ class QuadraticModel(QuadraticViewsMixin):
         return self.data.degree
 
     def energies(self, samples_like, dtype: Optional[DTypeLike] = None) -> np.ndarray:
-        """Determine the energies of the given samples."""
+        """Determine the energies of the given samples-like.
+
+        Args:
+            samples_like (samples_like):
+                Raw samples. `samples_like` is an extension of
+                NumPy's `array_like`_ structure. See :func:`.as_samples`.
+
+            dtype:
+                Desired NumPy data type for the energy. Matches
+                :attr:`.dtype` by default.
+
+        Returns:
+            Energies for the samples.
+
+        .. _`array_like`:  https://numpy.org/doc/stable/user/basics.creation.html
+
+        """
         return self.data.energies(samples_like, dtype=dtype)
 
     def energy(self, sample, dtype=None) -> Bias:
         """Determine the energy of the given sample.
 
         Args:
-            samples_like (samples_like):
+            sample (samples_like):
                 Raw sample. `samples_like` is an extension of
-                NumPy's array_like structure. See :func:`.as_samples`.
+                NumPy's `array_like`_ structure. See :func:`.as_samples`.
 
-            dtype (data-type, optional, default=None):
+            dtype:
                 Desired NumPy data type for the energy. Matches
                 :attr:`.dtype` by default.
 
         Returns:
             The energy.
+
+        .. _`array_like`:  https://numpy.org/doc/stable/user/basics.creation.html
 
         """
         energy, = self.energies(sample, dtype=dtype)

--- a/releasenotes/notes/permissive-energies-ce39fea1c68d074b.yaml
+++ b/releasenotes/notes/permissive-energies-ce39fea1c68d074b.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    ``QuadraticModel.energies``, ``QuadraticModel.energy``,
+    ``BinaryQuadraticModel.energies``, and ``BinaryQuadraticModel.energy`` now
+    all support samples containing a superset of the variables in the model.
+    Any variables not in the model are ignored when calculating the energy.
+fixes:
+  - |
+    ``BinaryQuadraticModel.energies`` now has consistent behaviour accross all
+    data types when given samples containing a superset of the variables in the
+    model. Previously binary quadratic models with ``object`` data type would
+    allow a superset of variables, while ``float64`` and ``float32`` would not.

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -1058,7 +1058,14 @@ class TestEnergies(unittest.TestCase):
             bqm.energies(samples)
 
     @parameterized.expand(BQMs.items())
-    def test_length(self, name, BQM):
+    def test_superset(self, name, BQM):
+        bqm = dimod.BQM({'a': 1}, {'ab': 1}, 1.5, 'BINARY')
+
+        self.assertEqual(bqm.energy({'a': 1, 'b': 1, 'c': 1}), 3.5)
+        self.assertEqual(bqm.energy({'a': 1, 'b': 0, 'c': 1}), 2.5)
+
+    @parameterized.expand(BQMs.items())
+    def test_subset(self, name, BQM):
         arr = np.arange(9).reshape((3, 3))
         bqm = BQM(arr, dimod.BINARY)
 

--- a/tests/test_quadratic_model.py
+++ b/tests/test_quadratic_model.py
@@ -270,6 +270,27 @@ class TestEnergies(unittest.TestCase):
             sample = {'i': -s}
             self.assertEqual(i.energy(sample), -s)
 
+    def test_superset(self):
+        a = Integer('a')
+        b = Binary('b')
+
+        qm = a + a*b + 1.5
+
+        self.assertEqual(qm.energy({'a': 1, 'b': 1, 'c': 1}), 3.5)
+        self.assertEqual(qm.energy({'a': 1, 'b': 0, 'c': 1}), 2.5)
+
+    def test_subset(self):
+        a = Integer('a')
+        b = Binary('b')
+        c = Spin('c')
+
+        qm = a + a*b + c + 1.5
+
+        samples = {'a': 1, 'c': 1}
+
+        with self.assertRaises(ValueError):
+            qm.energy(samples)
+
 
 class TestFileSerialization(unittest.TestCase):
     @parameterized.expand([(np.float32,), (np.float64,)])


### PR DESCRIPTION
Closes https://github.com/dwavesystems/dimod/issues/949

I decided not to go with the `strict` keyword argument. It occurs to me that we may want `strict` to refer to either the set of variables, the vartype, or both. For now, I am going to leave it alone and we can add that feature when it's requested (see https://github.com/dwavesystems/dimod/issues/954)