### PR TITLE
Fix ``as_samples`` and ``parse_initial_states``

### DIFF
--- a/dimod/core/initialized.py
+++ b/dimod/core/initialized.py
@@ -50,7 +50,7 @@ class Initialized(abc.ABC):
     def parse_initial_states(self, bqm,
                              initial_states=None,
                              initial_states_generator='random',
-                             num_reads=None, seed=None):
+                             num_reads=None, seed=None, copy_always=False):
         """Parses/generates initial states for an initialized sampler.
 
         Args:
@@ -58,39 +58,43 @@ class Initialized(abc.ABC):
                 The binary quadratic model.
 
             num_reads (int, optional, default=len(initial_states) or 1):
-                Number of reads. If `num_reads` is not explicitly given, it is
-                selected to match the number of initial states given.
-                If no initial states are given, it defaults to 1.
+                Number of reads. If ``num_reads`` is not explicitly given, it is
+                selected to match the number of initial states given. If no 
+                initial states are given, it defaults to 1.
 
             initial_states (samples-like, optional, default=None):
                 One or more samples, each defining an initial state for all the
                 problem variables. Initial states are given one per read, but
-                if fewer than `num_reads` initial states are defined,
+                if fewer than ``num_reads`` initial states are defined,
                 additional values are generated as specified by
-                `initial_states_generator`. See func:`.as_samples` for a
+                ``initial_states_generator``. See func:`.as_samples` for a
                 description of "samples-like".
 
             initial_states_generator ({'none', 'tile', 'random'}, optional, default='random'):
                 Defines the expansion of `initial_states` if fewer than
-                `num_reads` are specified:
+                ``num_reads`` are specified:
 
                 * "none":
                     If the number of initial states specified is smaller than
-                    `num_reads`, raises ValueError.
+                    ``num_reads``, raises ValueError.
 
                 * "tile":
                     Reuses the specified initial states if fewer than
-                    `num_reads` or truncates if greater.
+                    ``num_reads`` or truncates if greater.
 
                 * "random":
                     Expands the specified initial states with randomly
-                    generated states if fewer than `num_reads` or truncates if
+                    generated states if fewer than ``num_reads`` or truncates if
                     greater.
 
             seed (int (32-bit unsigned integer), optional):
                 Seed to use for the PRNG. Specifying a particular seed with a
                 constant set of parameters produces identical results. If not
                 provided, a random seed is chosen.
+
+            copy_always (bool, optional, default=False):
+                If True, then ``initial_states`` is guaranteed to be copied, 
+                otherwise it is only copied if necessary.
 
         Returns:
             A named tuple with `['initial_states', 'initial_states_generator',
@@ -113,11 +117,12 @@ class Initialized(abc.ABC):
                 # check based on values, defaulting to match the current bqm
                 initial_states_vartype = infer_vartype(initial_states) or bqm.vartype
 
-            # only create a copy of the initial states if vartype mismatch
-            copy = initial_states_vartype != bqm.vartype
+            if not copy_always:
+                # only copy if there's a vartype mismatch
+                copy_always = initial_states_vartype != bqm.vartype
 
             initial_states_array, initial_states_variables = \
-                as_samples(initial_states, copy=copy)
+                as_samples(initial_states, copy=copy_always)
 
             # confirm that the variables match
             if bqm.variables ^ initial_states_variables:

--- a/dimod/core/initialized.py
+++ b/dimod/core/initialized.py
@@ -106,28 +106,31 @@ class Initialized(abc.ABC):
             initial_states_variables = list(bqm.variables)
             initial_states_vartype = bqm.vartype
         else:
-            initial_states_array, initial_states_variables = \
-                as_samples(initial_states, copy=True)
-
             # confirm that the vartype matches and/or make it match
             if isinstance(initial_states, SampleSet):
                 initial_states_vartype = initial_states.vartype
             else:
                 # check based on values, defaulting to match the current bqm
-                initial_states_vartype = infer_vartype(initial_states_array) or bqm.vartype
+                initial_states_vartype = infer_vartype(initial_states) or bqm.vartype
+
+            # only create a copy of the initial states if vartype mismatch
+            copy = initial_states_vartype != bqm.vartype
+
+            initial_states_array, initial_states_variables = \
+                as_samples(initial_states, copy=copy)
 
             # confirm that the variables match
             if bqm.variables ^ initial_states_variables:
                 raise ValueError("mismatch between variables in "
                                  "'initial_states' and 'bqm'")
 
-        # match the vartype of the initial_states to the bqm
-        if initial_states_vartype is Vartype.SPIN and bqm.vartype is Vartype.BINARY:
-            initial_states_array += 1
-            initial_states_array //= 2
-        elif initial_states_vartype is Vartype.BINARY and bqm.vartype is Vartype.SPIN:
-            initial_states_array *= 2
-            initial_states_array -= 1
+            # match the vartype of the initial_states to the bqm
+            if initial_states_vartype is Vartype.SPIN and bqm.vartype is Vartype.BINARY:
+                initial_states_array += 1
+                initial_states_array //= 2
+            elif initial_states_vartype is Vartype.BINARY and bqm.vartype is Vartype.SPIN:
+                initial_states_array *= 2
+                initial_states_array -= 1
 
         # validate num_reads and/or infer them from initial_states
         if num_reads is None:

--- a/dimod/core/initialized.py
+++ b/dimod/core/initialized.py
@@ -107,7 +107,7 @@ class Initialized(abc.ABC):
             initial_states_vartype = bqm.vartype
         else:
             initial_states_array, initial_states_variables = \
-                as_samples(initial_states)
+                as_samples(initial_states, copy=True)
 
             # confirm that the vartype matches and/or make it match
             if isinstance(initial_states, SampleSet):

--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -264,9 +264,10 @@ def as_samples(samples_like, dtype=None, copy=False, order='C'):
         # it is much faster to just do this here.
         labels = list(samples_like.variables)
         if dtype is None:
-            return samples_like.record.sample, labels
+            arr = np.copy(samples_like.record.sample) if copy else samples_like.record.sample
+            return arr, labels
         else:
-            return samples_like.record.sample.astype(dtype), labels
+            return samples_like.record.sample.astype(dtype, copy=copy), labels
 
     if isinstance(samples_like, tuple) and len(samples_like) == 2:
         samples_like, labels = samples_like
@@ -282,13 +283,13 @@ def as_samples(samples_like, dtype=None, copy=False, order='C'):
         raise TypeError('samples_like cannot be an iterator')
 
     if isinstance(samples_like, abc.Mapping):
-        return as_samples(([samples_like], labels), dtype=dtype)
+        return as_samples(([samples_like], labels), dtype=dtype, copy=copy, order=order)
 
     if (isinstance(samples_like, list) and samples_like and
             isinstance(samples_like[0], numbers.Number)):
         # this is not actually necessary but it speeds up the
         # samples_like = [1, 0, 1,...] case significantly
-        return as_samples(([samples_like], labels), dtype=dtype)
+        return as_samples(([samples_like], labels), dtype=dtype, copy=copy, order=order)
 
     if not isinstance(samples_like, np.ndarray):
         if any(isinstance(sample, abc.Mapping) for sample in samples_like):

--- a/releasenotes/notes/fix-as_samples-and-parse_initialized_states-ed9097448745a6f6.yaml
+++ b/releasenotes/notes/fix-as_samples-and-parse_initialized_states-ed9097448745a6f6.yaml
@@ -5,3 +5,7 @@ fixes:
     the ``copy`` argument is not ignored in ``as_samples`` and 
     ``Initialized.parse_initial_states`` does not modify any input data. 
     See `#861 <https://github.com/dwavesystems/dimod/issues/861>`_.
+
+features:
+  - |
+    Add ``copy_always`` parameter to ``Initialized.parse_initial_states``.

--- a/releasenotes/notes/fix-as_samples-and-parse_initialized_states-ed9097448745a6f6.yaml
+++ b/releasenotes/notes/fix-as_samples-and-parse_initialized_states-ed9097448745a6f6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix ``as_samples`` and ``Initialized.parse_initial_states`` by ensuring that 
+    the ``copy`` argument is not ignored in ``as_samples`` and 
+    ``Initialized.parse_initial_states`` does not modify any input data. 
+    See `#861 <https://github.com/dwavesystems/dimod/issues/861>`_.

--- a/tests/test_initialized.py
+++ b/tests/test_initialized.py
@@ -192,3 +192,14 @@ class TestGenerators(unittest.TestCase):
             initial_states=self.initial_states)
         self.assertEqual(len(init.initial_states), 2)
         self.assertEqual(init.num_reads, 2)
+
+    def test_mismatched_vartype(self):
+        """Input initial states are not modified when there is a mismatch between
+        the vartypes of bqm and initial_states."""
+
+        orig_sampleset = np.copy(self.initial_sampleset.record)
+        result = Initialized().parse_initial_states(
+            bqm=self.bqm.binary,
+            initial_states=self.initial_sampleset)
+
+        np.testing.assert_array_equal(orig_sampleset, self.initial_sampleset.record)

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -36,7 +36,8 @@ except ImportError:
 class Test_as_samples(unittest.TestCase):
     # tests for as_samples function
 
-    def test_copy_false(self):
+    def test_copy(self):
+        # Check case where samples_like is a tuple
         samples_like = np.ones((5, 5))
         labels = list('abcde')
         arr, lab = dimod.as_samples((samples_like, labels))
@@ -44,6 +45,25 @@ class Test_as_samples(unittest.TestCase):
         self.assertEqual(lab, list('abcde'))
         self.assertIs(labels, lab)
         self.assertTrue(np.shares_memory(arr, samples_like))
+
+        arr, lab = dimod.as_samples((samples_like, labels), copy=True)
+        self.assertFalse(np.shares_memory(arr, samples_like))
+
+        # Check case where samples_like is a dimod.SampleSet
+        sampleset = dimod.SampleSet.from_samples([{'a': -1, 'b': +1},
+                                                  {'a': +1, 'b': +1}],
+                                                  'SPIN',
+                                                  energy=[-1.0, 1.0])
+
+        arr, lab = dimod.as_samples(sampleset)
+        self.assertTrue(np.shares_memory(arr, sampleset.record.sample))
+        arr, lab = dimod.as_samples(sampleset, copy=True)
+        self.assertFalse(np.shares_memory(arr, sampleset.record.sample))
+
+        arr, lab = dimod.as_samples(sampleset, dtype=np.int8)
+        self.assertTrue(np.shares_memory(arr, sampleset.record.sample))
+        arr, lab = dimod.as_samples(sampleset, dtype=np.int8, copy=True)
+        self.assertFalse(np.shares_memory(arr, sampleset.record.sample))
 
     def test_dict_with_inconsistent_labels(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Fixes #861 and https://github.com/dwavesystems/dwave-tabu/issues/86

- Ensure that ``copy`` argument is not ignored in ``as_samples``
- Work on a copy of the input data in ``parse_initial_states`` when needed, so that input is not modified
