### PR TITLE
Add `cqm_to_bqm` function

### DIFF
--- a/docs/reference/constrained.rst
+++ b/docs/reference/constrained.rst
@@ -60,3 +60,12 @@ Generating constrained quadratic models:
    :toctree: generated/
 
    bin_packing
+
+Generating constrained quadratic models to other model types:
+
+.. currentmodule:: dimod
+
+.. autosummary::
+   :toctree: generated/
+
+   cqm_to_bqm

--- a/releasenotes/notes/cqm-to-bqm-d369043cc341c5a3.yaml
+++ b/releasenotes/notes/cqm-to-bqm-d369043cc341c5a3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``cqm_to_bqm`` function.


### PR DESCRIPTION
*Example usage*

Start with a constrained quadratic model
```python
>>> num_widget_a = dimod.Integer('num_widget_a', upper_bound=7)
>>> num_widget_b = dimod.Integer('num_widget_b', upper_bound=3)
>>> cqm = dimod.ConstrainedQuadraticModel()
>>> cqm.set_objective(-3 * num_widget_a - 4 * num_widget_b)
>>> cqm.add_constraint(num_widget_a + num_widget_b <= 5, label='total widgets')
'total widgets'
```
Convert it to a binary quadratic model and solve it using `dimod.ExactSolver`.
```python
>>> bqm, invert = dimod.cqm_to_bqm(cqm)
>>> sampleset = dimod.ExactSolver().sample(bqm)
```
Interpret the answer in the original variable classes
```python
>>> invert(sampleset.first.sample)
{'num_widget_a': 2, 'num_widget_b': 3}
```