### PR TITLE
Backport dependence on dwave-preprocessing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
             . env/bin/activate
             pip install -r tests/requirements.txt
             pip install numpy=='<< parameters.numpy-version >>'
+            pip install 'dwave-preprocessing~=0.2.0' --no-deps
             pip install dimod --no-index -f dist/ --no-deps --force-reinstall
 
       - run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy==1.19.4
 cython==0.29.21
+dwave-preprocessing==0.2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ from distutils.command.build_ext import build_ext as _build_ext
 exec(open(os.path.join(os.path.dirname(__file__), "dimod", "package_info.py")).read())
 
 # if the numpy ranges change here, don't forget to update the circle-ci job
-install_requires = ['numpy>=1.17.3,<2.0.0']
+install_requires = ['numpy>=1.17.3,<2.0.0',
+                    'dwave-preprocessing>=0.2.0,<0.3.0',
+                    ]
 
 setup_requires = ['numpy>=1.17.3,<2.0.0']
 


### PR DESCRIPTION
This is to enable dwave-system (>1.7.0) to support both dimod 0.9 and
0.10.

Although now we have duplicated composites (available in both dimod
and dwave.preprocessing namespaces), this is necessary to resolve
unsatisfiable dependencies when dwave-system 1.7.x is installed with
dimod 0.9.x (due to dwave-preprocessing introduced as extras dependency
in dimod 0.10.0 and then removed in 0.10.5). This makes specifying dimod
as a dependency in dwave-system impossible, if we want to allow both 0.9
and 0.10.

See also #829, #894, #896, and #924.