### PR TITLE
fix BinaryPolynomial.__eq__ when args contain different terms

### DIFF
--- a/dimod/higherorder/polynomial.py
+++ b/dimod/higherorder/polynomial.py
@@ -134,11 +134,11 @@ class BinaryPolynomial(abc.MutableMapping):
         return (
             self.vartype == other.vartype
             and all(
-                (not bias or other_terms.get(term) == bias)
+                (not bias or other_terms.get(term, 0.) == bias)
                 for term, bias in self.items()
             )
             and all(
-                (not bias or self_terms.get(term) == bias)
+                (not bias or self_terms.get(term, 0.) == bias)
                 for term, bias in other.items()
             )
         )

--- a/dimod/higherorder/polynomial.py
+++ b/dimod/higherorder/polynomial.py
@@ -134,11 +134,11 @@ class BinaryPolynomial(abc.MutableMapping):
         return (
             self.vartype == other.vartype
             and all(
-                (not bias or other_terms[term] == bias)
+                (not bias or other_terms.get(term) == bias)
                 for term, bias in self.items()
             )
             and all(
-                (not bias or self_terms[term] == bias)
+                (not bias or self_terms.get(term) == bias)
                 for term, bias in other.items()
             )
         )

--- a/tests/test_higherorder_polynomial.py
+++ b/tests/test_higherorder_polynomial.py
@@ -70,6 +70,11 @@ class Test__eq__(unittest.TestCase):
         self.assertEqual(BinaryPolynomial(polydict, 'SPIN'), polydict)
         self.assertNotEqual(BinaryPolynomial(polydict, 'SPIN'), 1)
 
+    def test_different_terms(self):
+        poly1 = BinaryPolynomial({'a': 1, 'b': 1}, 'BINARY')
+        poly2 = BinaryPolynomial({'ab': -1, 'a': 1, 'b': 1}, 'BINARY')
+        self.assertNotEqual(poly1, poly2)
+
 
 class Test__len__(unittest.TestCase):
     def test_single_term(self):


### PR DESCRIPTION
Just noticed this. It was in the original version too, but it stands out more in the new version