### PR TITLE
Speed up QM.add_quadratic_from

### DIFF
--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -275,6 +275,19 @@ cdef class cyQM_template(cyQMBase):
             for vi in range(length):
                 self.add_quadratic(irow[vi], icol[vi], qdata[vi])
 
+    def add_quadratic_from_iterable(self, quadratic):
+        cdef Py_ssize_t ui, vi
+        cdef bias_type bias
+
+        for u, v, bias in quadratic:
+            ui = self.variables.index(u)
+            vi = self.variables.index(v)
+
+            if ui == vi and self.cppqm.vartype(ui) != cppVartype.INTEGER:
+                raise ValueError(f"{u!r} cannot have an interaction with itself")
+            
+            self.cppqm.add_quadratic(ui, vi, bias)
+
     def add_variable(self, vartype, label=None, *, lower_bound=0, upper_bound=None):
         # as_vartype will raise for unsupported vartypes
         vartype = as_vartype(vartype, extended=True)

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -418,14 +418,12 @@ class QuadraticModel(QuadraticViewsMixin):
                 If the interaction already exists, the bias is added.
 
         """
-        add_quadratic = self.data.add_quadratic
-
         if isinstance(quadratic, Mapping):
-            for (u, v), bias in quadratic.items():
-                add_quadratic(u, v, bias)
+            self.data.add_quadratic_from_iterable(
+                (u, v, bias) for (u, v), bias in quadratic.items())
         else:
-            for u, v, bias in quadratic:
-                add_quadratic(u, v, bias)
+            self.data.add_quadratic_from_iterable(quadratic)
+
 
     @forwarding_method
     def add_variable(self, vartype: VartypeLike,


### PR DESCRIPTION
Provides about a 25% speedup at all sizes in my local testing. Test script:
```python
import itertools
import time

import dimod


num_variables = 2500

qm = dimod.QuadraticModel()
qm.add_variables_from('BINARY', range(num_variables))
qm.add_variable('BINARY', 'a')

t = time.time()
for u, v in itertools.combinations(qm.variables, 2):
    qm.add_quadratic(u, v, 1)
print(time.time() - t)

qm = dimod.QuadraticModel()
qm.add_variables_from('BINARY', range(num_variables))
qm.add_variable('BINARY', 'a')

t = time.time()
qm.add_quadratic_from((u, v, 1) for u, v in itertools.combinations(qm.variables, 2))
print(time.time() - t)
```
Output:
```bash
1.094804286956787
0.8172729015350342
```