### PR TITLE
set_objective from iterables

### DIFF
--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -627,7 +627,7 @@ class ConstrainedQuadraticModel:
             >>> cqm.set_objective(2*i - 0.5*i*j + 10)
 
         """
-        if not isinstance(objective, [BinaryQuadraticModel, QuadraticModel]):
+        if isinstance(objective, Iterable):
             objective = self._iterable_to_qm(objective)
         # clear out current objective, keeping only the variables
         self.objective.quadratic.clear()  # there may be a more performant way...

--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -611,7 +611,8 @@ class ConstrainedQuadraticModel:
             count += sum(lhs.degree(v) > 0 for v in lhs.variables)
         return count
 
-    def set_objective(self, objective: Union[BinaryQuadraticModel, QuadraticModel]):
+    def set_objective(self, objective: Union[BinaryQuadraticModel,
+                                             QuadraticModel, Iterable]):
         """Set the objective of the constrained quadratic model.
 
         Args:

--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -626,7 +626,7 @@ class ConstrainedQuadraticModel:
             >>> cqm.set_objective(2*i - 0.5*i*j + 10)
 
         """
-        if isinstance(objective, Iterable):
+        if not isinstance(objective, [BinaryQuadraticModel, QuadraticModel]):
             objective = self._iterable_to_qm(objective)
         # clear out current objective, keeping only the variables
         self.objective.quadratic.clear()  # there may be a more performant way...

--- a/releasenotes/notes/cqm-set-objective-from-iterables-d1dc8698cc7e42e4.yaml
+++ b/releasenotes/notes/cqm-set-objective-from-iterables-d1dc8698cc7e42e4.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ``ConstrainedQuadraticModel.set_objective`` now accepts an iterable.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -429,6 +429,19 @@ class TestSetObjective(unittest.TestCase):
         cqm.set_objective(Integer('a') * 5)
         self.assertTrue(cqm.objective.is_equal(Integer('a') * 5))
 
+    def test_terms_objective(self):
+        cqm = CQM()
+
+        a = cqm.add_variable('a', 'BINARY')
+        b = cqm.add_variable('b', 'BINARY')
+        c = cqm.add_variable('c', 'INTEGER')
+
+        cqm.set_objective([(a, b, 1), (b, 2.5,), (3,), (c, 1.5)])
+        energy = cqm.objective.energy({'a': 1, 'b': 0, 'c': 10})
+        self.assertAlmostEqual(energy, 18)
+        energy = cqm.objective.energy({'a': 1, 'b': 1, 'c': 3})
+        self.assertAlmostEqual(energy, 11)
+
 
 class TestSubstituteSelfLoops(unittest.TestCase):
     def test_typical(self):


### PR DESCRIPTION
Set objective from an iterable similar to `add_constraint` method.

CQM._iterable_to_qm(iterable) -> QuadraticModel that takes that functionality, then just use that in CQM.add_constraint_from_iterable and CQM.set_objective

Closes #919 
