### PR TITLE
Don't require dwave-preprocessing to be installed to import dimod

### DIFF
--- a/dimod/reference/composites/_preprocessing.py
+++ b/dimod/reference/composites/_preprocessing.py
@@ -16,11 +16,25 @@
 
 import warnings
 
-__all__ = ['DeprecatedToPreprocessing']
+__all__ = ['NotFound', 'DeprecatedToPreprocessing']
+
+
+class NotFound:
+    pass
 
 
 class DeprecatedToPreprocessing:
     def __init__(self, *args, **kwargs):
+        if isinstance(self, NotFound):
+            # we recommend --no-deps because its dependencies are the same as
+            # dimods and it would be a circular install otherwise
+            raise TypeError(
+                f"{type(self).__name__!r} has been moved to dwave-preprocessing. "
+                "You must install dwave-preprocessing in order to use it. "
+                "You can do so with "
+                "'pip install \"dwave-preprocessing<0.4\" --no-deps'.",
+                )
+
         # otherwise warn about it's new location but let it proceed
         warnings.warn(
             f"{type(self).__name__!s} has been moved to dwave-preprocessing "

--- a/dimod/reference/composites/clipcomposite.py
+++ b/dimod/reference/composites/clipcomposite.py
@@ -18,7 +18,10 @@ and upper bounds is not given it does nothing.
 
 """
 
-from dwave.preprocessing import ClipComposite as _ClipComposite
+try:
+    from dwave.preprocessing import ClipComposite as _ClipComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as _ClipComposite
 
 from dimod.reference.composites._preprocessing import DeprecatedToPreprocessing
 

--- a/dimod/reference/composites/connectedcomponent.py
+++ b/dimod/reference/composites/connectedcomponent.py
@@ -18,7 +18,10 @@ connected components of the binary
 quadratic model graph before sending to its child sampler.
 """
 
-from dwave.preprocessing import ConnectedComponentsComposite as _ConnectedComponentsComposite
+try:
+    from dwave.preprocessing import ConnectedComponentsComposite as _ConnectedComponentsComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as _ConnectedComponentsComposite
 
 from dimod.reference.composites._preprocessing import DeprecatedToPreprocessing
 

--- a/dimod/reference/composites/fixedvariable.py
+++ b/dimod/reference/composites/fixedvariable.py
@@ -18,7 +18,12 @@ quadratic model before sending to its child sampler.
 """
 import warnings
 
-from dwave.preprocessing import FixVariablesComposite
+try:
+    from dwave.preprocessing import FixVariablesComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as FixVariablesComposite
+
+from dimod.reference.composites._preprocessing import NotFound
 
 __all__ = ['FixedVariableComposite']
 
@@ -44,6 +49,16 @@ class FixedVariableComposite(FixVariablesComposite):
 
     """
     def __init__(self, child):
+        if isinstance(self, NotFound):
+            # we recommend --no-deps because its dependencies are the same as
+            # dimods and it would be a circular install otherwise
+            raise TypeError(
+                f"{type(self).__name__!r} has been moved to dwave-preprocessing. "
+                "You must install dwave-preprocessing in order to use it. "
+                "You can do so with "
+                "'pip install \"dwave-preprocessing<0.4\" --no-deps'.",
+                )
+
         # otherwise warn about it's new location but let it proceed
         warnings.warn(
             f"{type(self).__name__!s} has been deprecated and will be removed from dimod 0.11.0. "

--- a/dimod/reference/composites/roofduality.py
+++ b/dimod/reference/composites/roofduality.py
@@ -25,7 +25,12 @@ sampler.
 """
 import warnings
 
-from dwave.preprocessing import FixVariablesComposite
+try:
+    from dwave.preprocessing import FixVariablesComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as FixVariablesComposite
+
+from dimod.reference.composites._preprocessing import NotFound
 
 __all__ = ['RoofDualityComposite']
 
@@ -44,6 +49,16 @@ class RoofDualityComposite(FixVariablesComposite):
 
     """
     def __init__(self, child):
+        if isinstance(self, NotFound):
+            # we recommend --no-deps because its dependencies are the same as
+            # dimods and it would be a circular install otherwise
+            raise TypeError(
+                f"{type(self).__name__!r} has been moved to dwave-preprocessing. "
+                "You must install dwave-preprocessing in order to use it. "
+                "You can do so with "
+                "'pip install \"dwave-preprocessing<0.4\" --no-deps'.",
+                )
+
         # otherwise warn about it's new location but let it proceed
         warnings.warn(
             f"{type(self).__name__!s} has been deprecated and will be removed from dimod 0.11.0. "

--- a/dimod/reference/composites/scalecomposite.py
+++ b/dimod/reference/composites/scalecomposite.py
@@ -18,7 +18,10 @@ not specified, calculates it based on quadratic and bias ranges.
 
 """
 
-from dwave.preprocessing import ScaleComposite as _ScaleComposite
+try:
+    from dwave.preprocessing import ScaleComposite as _ScaleComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as _ScaleComposite
 
 from dimod.reference.composites._preprocessing import DeprecatedToPreprocessing
 

--- a/dimod/reference/composites/spin_transform.py
+++ b/dimod/reference/composites/spin_transform.py
@@ -22,7 +22,10 @@ the transform simply amounts to reinterpreting spin up as spin down, and visa-ve
 a particular spin.
 """
 
-from dwave.preprocessing import SpinReversalTransformComposite as _SpinReversalTransformComposite
+try:
+    from dwave.preprocessing import SpinReversalTransformComposite as _SpinReversalTransformComposite
+except ImportError:
+    from dimod.reference.composites._preprocessing import NotFound as _SpinReversalTransformComposite
 
 from dimod.reference.composites._preprocessing import DeprecatedToPreprocessing
 


### PR DESCRIPTION
Tested locally the `dwave-preprocessing` install. Credit to @hhtong for the nice commit history that made this very simple.

Closes https://github.com/dwavesystems/dimod/issues/989