### PR TITLE
Update outdated link 

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -568,7 +568,7 @@ class SampleSet(abc.Iterable, abc.Sized):
             >>> sampleset.variables
             Variables(['a', 'b', 'c'])
 
-        .. _array_like:  https://numpy.org/doc/stable/user/basics.creation.html#converting-python-array-like-objects-to-numpy-arrays
+        .. _array_like:  https://numpy.org/doc/stable/user/basics.creation.html
         """
         if aggregate_samples:
             return cls.from_samples(samples_like, vartype, energy,


### PR DESCRIPTION
Will cause a linkcheck failure on the SDK: 
```
docs_dimod/reference/generated/dimod.SampleSet.from_samples.rst:2: [broken] https://numpy.org/doc/stable/user/basics.creation.html#converting-python-array-like-objects-to-numpy-arrays: Anchor 'converting-python-array-like-objects-to-numpy-arrays' not found
```
An alternative (for several places where `.. _array_like:` is defined) for consideration is 
`https://github.com/numpy/numpy/blob/main/numpy/typing/_array_like.py`
(see https://github.com/numpy/numpy/blob/dc7dafe70a53d6c122091516f34058bd0a6d89e1/numpy/typing/_array_like.py#L60)