### PR TITLE
Update structure composite docs

### DIFF
--- a/dimod/reference/composites/structure.py
+++ b/dimod/reference/composites/structure.py
@@ -24,8 +24,8 @@ from dimod.decorators import bqm_structured
 class StructureComposite(Sampler, Composite, Structured):
     """Creates a structured composed sampler from an unstructured sampler.
 
-    Useful for simulation purposes, for example testing a proposed chip's graph structure
-    with the :class:`Simulated Annealing Sampler <neal.SimulatedAnnealingSampler>`.
+    Useful for simulation; for example testing a QPU's working graph
+    with the :class:`~neal.sampler.SimulatedAnnealingSampler` class.
 
     Args:
         Sampler (:obj:`~dimod.Sampler`):

--- a/docs/reference/sampler_composites/composites.rst
+++ b/docs/reference/sampler_composites/composites.rst
@@ -17,7 +17,7 @@ additional :std:doc:`composites for D-Wave systems <oceandocs:docs_system/refere
 such as those used for :term:`minor-embedding`.
 
 Structure Composite
---------------------
+-------------------
 
 .. automodule:: dimod.reference.composites.structure
 


### PR DESCRIPTION
Small changes to documentation for `StructureComposite`:
- adds context on intended usage of class to docstring
- align section heading for `StructureComposite` in docs to match class name