### PR TITLE
Update brew in CI OSX for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: dist
+      - when:
+          condition:
+            equal: [3.10.0, << parameters.python-version>>]
+          steps:
+            - run: brew update
       - run:
           name: install pyenv
           command: |


### PR DESCRIPTION
Not sure why this wasn't failing on the PR before, but it was failing on main so...