### PR TITLE
Drop dwave-preprocessing as a full dependency

### DIFF
--- a/releasenotes/notes/drop-preprocessing-32e36f9f665cc778.yaml
+++ b/releasenotes/notes/drop-preprocessing-32e36f9f665cc778.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    You can now install ``dwave-preprocessing`` as part of the dimod install with
+    ``pip install dimod[all]``
+upgrade:
+  - |
+    ``dwave-preprocessing`` is no longer a direct dependency. It can still be
+    installed with ``pip install dimod[all]``.

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
     install_requires=[
         # ignoring 1.21.0 and 1.21.1 due to https://github.com/dwavesystems/dimod/issues/901
         'numpy>=1.17.3,<2.0.0,!=1.21.0,!=1.21.1', # keep synced with circle-ci, pyproject.toml
-        'dwave-preprocessing>=0.3,<0.4',
         'pyparsing>=2.4.7, <3.0.0',
         ],
 )

--- a/setup.py
+++ b/setup.py
@@ -87,4 +87,8 @@ setup(
         'numpy>=1.17.3,<2.0.0,!=1.21.0,!=1.21.1', # keep synced with circle-ci, pyproject.toml
         'pyparsing>=2.4.7, <3.0.0',
         ],
+    # we use the generic 'all' so that in the future when we remove
+    # dwave-preprocessing we can leave it in as an empty list. Thereby not
+    # breaking any packages that have dimod[all] in their requirments.
+    extras_require=dict(all='dwave-preprocessing>=0.3,<0.4'),
 )


### PR DESCRIPTION
I don't love dropping it with only a patch version increment
but I don't see another way to resolve the circular dependency
issues we're having. The error message at least is pretty
explicit and all of the ocean packages that rely on it have been
updated to also use dwave-preprocessing.

Closes https://github.com/dwavesystems/dimod/issues/1021