### PR TITLE
Add support for continuous variables in QuadraticModel, Python and C++

### DIFF
--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -30,7 +30,8 @@ namespace dimod {
 enum Vartype {
     BINARY,  ///< Variables that are either 0 or 1.
     SPIN,    ///< Variables that are either -1 or 1.
-    INTEGER  ///< Variables that are integer valued.
+    INTEGER,  ///< Variables that are integer valued.
+    REAL  ///< Variables that are real valued.
 };
 
 /**
@@ -926,7 +927,8 @@ class QuadraticModel : public QuadraticModelBase<Bias, Index> {
                 base_type::linear(u) += bias;
             } else if (vartype == Vartype::SPIN) {
                 base_type::offset_ += bias;
-            } else if (vartype == Vartype::INTEGER) {
+            } else if (vartype == Vartype::INTEGER ||
+                       vartype == Vartype::REAL) {
                 base_type::add_quadratic(u, u, bias);
             } else {
                 throw std::logic_error("unknown vartype");
@@ -937,31 +939,37 @@ class QuadraticModel : public QuadraticModelBase<Bias, Index> {
     }
 
     index_type add_variable(Vartype vartype) {
-        bias_type lb;
-        bias_type ub;
         if (vartype == Vartype::BINARY) {
-            lb = 0;
-            ub = 1;
+            return this->add_variable(vartype, 0, 1);
         } else if (vartype == Vartype::SPIN) {
-            lb = -1;
-            ub = 1;
+            return this->add_variable(vartype, -1, +1);
         } else if (vartype == Vartype::INTEGER) {
-            ub = this->max_integer();
-            lb = 0;
+            return this->add_variable(vartype, 0, this->max_integer());
+        } else if (vartype == Vartype::REAL) {
+            return this->add_variable(vartype, 0, this->max_real());
         } else {
             throw std::logic_error("unknown vartype");
         }
-        return this->add_variable(vartype, lb, ub);
     }
 
     index_type add_variable(Vartype vartype, bias_type lb, bias_type ub) {
         assert(lb <= ub);
-        assert(lb >= -this->max_integer());
-        assert(ub <= this->max_integer());
+
+        assert(vartype != Vartype::BINARY || lb == 0);
+        assert(vartype != Vartype::BINARY || ub == 1);
+
+        assert(vartype != Vartype::SPIN || lb == -1);
+        assert(vartype != Vartype::SPIN || ub == +1);
+
+        assert(vartype != Vartype::INTEGER || lb >= -this->max_integer());
+        assert(vartype != Vartype::INTEGER || ub <= this->max_integer());
+
+        assert(vartype != Vartype::REAL || lb >= -this->max_real());
+        assert(vartype != Vartype::REAL || ub <= this->max_real());
 
         index_type v = this->num_variables();
 
-        varinfo_.emplace_back(vartype, lb, ub);
+        this->varinfo_.emplace_back(vartype, lb, ub);
         this->linear_biases_.resize(v + 1);
         this->adj_.resize(v + 1);
 
@@ -1011,6 +1019,8 @@ class QuadraticModel : public QuadraticModelBase<Bias, Index> {
             this->change_vartype(Vartype::BINARY, v);
             this->change_vartype(Vartype::INTEGER, v);
         } else {
+            // todo: support integer to real and vice versa, need to figure
+            // out how to handle bounds in that case though
             throw std::logic_error("invalid vartype change");
         }
     }
@@ -1022,6 +1032,11 @@ class QuadraticModel : public QuadraticModelBase<Bias, Index> {
     constexpr bias_type max_integer() {
         return ((std::int64_t)1 << (std::numeric_limits<bias_type>::digits)) -
                1;
+    }
+
+    constexpr bias_type max_real() {
+        // todo: better bound, this is too generous
+        return std::numeric_limits<bias_type>::max();
     }
 
     void set_quadratic(index_type u, index_type v, bias_type bias) {

--- a/dimod/libcpp.pxd
+++ b/dimod/libcpp.pxd
@@ -38,6 +38,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         BINARY
         SPIN
         INTEGER
+        REAL
 
     cdef cppclass cppBinaryQuadraticModel "dimod::BinaryQuadraticModel" [Bias, Index]:
         ctypedef Bias bias_type
@@ -123,6 +124,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         bias_type& linear(index_type)
         const bias_type& lower_bound(index_type)
         bias_type max_integer()
+        bias_type max_real()
         pair[const_neighborhood_iterator, const_neighborhood_iterator] neighborhood(size_type)
         size_type num_variables()
         size_type num_interactions()

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -219,6 +219,8 @@ cdef class cyQM_template(cyQMBase):
                 cpp_vartype = cppVartype.SPIN
             elif vartype_view[vi] == 2:
                 cpp_vartype = cppVartype.INTEGER
+            elif vartype_view[vi] == 3:
+                cpp_vartype = cppVartype.REAL
             else:
                 raise RuntimeError
             self.cppqm.add_variable(cpp_vartype, lb_view[vi], ub_view[vi])
@@ -252,7 +254,8 @@ cdef class cyQM_template(cyQMBase):
         cdef Py_ssize_t ui = self.variables.index(u)
         cdef Py_ssize_t vi = self.variables.index(v)
 
-        if ui == vi and self.cppqm.vartype(ui) != cppVartype.INTEGER:
+        if ui == vi and (self.cppqm.vartype(ui) == cppVartype.SPIN
+                         or self.cppqm.vartype(ui) == cppVartype.BINARY):
             raise ValueError(f"{u!r} cannot have an interaction with itself")
 
         self.cppqm.add_quadratic(ui, vi, bias)
@@ -283,9 +286,10 @@ cdef class cyQM_template(cyQMBase):
             ui = self.variables.index(u)
             vi = self.variables.index(v)
 
-            if ui == vi and self.cppqm.vartype(ui) != cppVartype.INTEGER:
+            if ui == vi and (self.cppqm.vartype(ui) == cppVartype.SPIN
+                             or self.cppqm.vartype(ui) == cppVartype.BINARY):
                 raise ValueError(f"{u!r} cannot have an interaction with itself")
-            
+
             self.cppqm.add_quadratic(ui, vi, bias)
 
     def add_variable(self, vartype, label=None, *, lower_bound=0, upper_bound=None):
@@ -302,7 +306,7 @@ cdef class cyQM_template(cyQMBase):
             vi = self.variables.index(label)
             if self.cppqm.vartype(vi) != cppvartype:
                 raise TypeError(f"variable {label!r} already exists with a different vartype")
-            if cppvartype == cppVartype.INTEGER:
+            if cppvartype == cppVartype.INTEGER or cppvartype == cppVartype.REAL:
                 if lb != self.cppqm.lower_bound(vi):
                     raise ValueError(
                         f"the specified lower bound, {lower_bound}, for "
@@ -328,6 +332,21 @@ cdef class cyQM_template(cyQMBase):
                 ub = upper_bound
                 if ub > self.cppqm.max_integer():
                     raise ValueError(f"upper_bound cannot be greater than {self.cppqm.max_integer()}")
+
+            if lb > ub:
+                raise ValueError("lower_bound must be less than or equal to upper_bound")
+
+            self.cppqm.add_variable(cppvartype, lb, ub)
+        elif cppvartype == cppVartype.REAL and (lb != 0 or upper_bound is not None):
+            if lb < -self.cppqm.max_real():
+                raise ValueError(f"lower_bound cannot be less than {-self.cppqm.max_real()}")
+
+            if upper_bound is None:
+                ub = self.cppqm.max_real()
+            else:
+                ub = upper_bound
+                if ub > self.cppqm.max_real():
+                    raise ValueError(f"upper_bound cannot be greater than {self.cppqm.max_real()}")
 
             if lb > ub:
                 raise ValueError("lower_bound must be less than or equal to upper_bound")
@@ -359,6 +378,8 @@ cdef class cyQM_template(cyQMBase):
             return cppVartype.BINARY
         elif vartype is Vartype.INTEGER:
             return cppVartype.INTEGER
+        elif vartype is Vartype.REAL:
+            return cppVartype.REAL
         else:
             raise TypeError(f"unexpected vartype {vartype!r}")
 
@@ -411,7 +432,8 @@ cdef class cyQM_template(cyQMBase):
         cdef Py_ssize_t ui = self.variables.index(u)
         cdef Py_ssize_t vi = self.variables.index(v)
 
-        if ui == vi and self.cppqm.vartype(ui) != cppVartype.INTEGER:
+        if ui == vi and (self.cppqm.vartype(ui) == cppVartype.SPIN
+                         or self.cppqm.vartype(ui) == cppVartype.BINARY):
             raise ValueError(f"{u!r} cannot have an interaction with itself")
 
         cdef bias_type bias
@@ -601,50 +623,76 @@ cdef class cyQM_template(cyQMBase):
 
     def set_lower_bound(self, v, bias_type lb):
         cdef Py_ssize_t vi = self.variables.index(v)
+        cdef cppVartype cppvartype = self.cppqm.vartype(vi)
 
-        if self.cppqm.vartype(vi) != cppVartype.INTEGER:
+        if cppvartype == cppVartype.INTEGER:
+            lb = cppround(lb)  # we round to the nearest integer
+
+            if lb < -self.cppqm.max_integer():
+                raise ValueError(
+                    f"the specified lower bound, {int(lb)}, for variable {v!r} is less than "
+                    f"{int(-self.cppqm.max_integer())}, "
+                    f"the minimum for QuadraticModel(dtype=np.{self.dtype.name}) ")
+
+            if lb > self.cppqm.upper_bound(vi):
+                raise ValueError(
+                    f"the specified lower bound, {int(lb)}, cannot be set greater than the "
+                    f"current upper bound, {int(self.cppqm.upper_bound(vi))}"
+                    )
+        elif cppvartype == cppVartype.REAL:
+            if lb < -self.cppqm.max_real():
+                raise ValueError(
+                    f"the specified lower bound, {float(lb)}, for variable {v!r} is less than "
+                    f"{float(-self.cppqm.max_real())}, "
+                    f"the minimum for QuadraticModel(dtype=np.{self.dtype.name}) ")
+
+            if lb > self.cppqm.upper_bound(vi):
+                raise ValueError(
+                    f"the specified lower bound, {float(lb)}, cannot be set greater than the "
+                    f"current upper bound, {float(self.cppqm.upper_bound(vi))}"
+                    )
+        else:
             raise ValueError(
-                "can only set the lower bound for INTEGER variables, "
+                "can only set the lower bound for INTEGER or REAL variables, "
                 f"{v!r} is a {self.vartype(v).name} variable")
-
-        lb = cppround(lb)  # we round to the nearest integer
-
-        if lb < -self.cppqm.max_integer():
-            raise ValueError(
-                f"the specified lower bound, {int(lb)}, for variable {v!r} is less than "
-                f"{int(-self.cppqm.max_integer())}, "
-                f"the minimum for QuadraticModel(dtype=np.{self.dtype.name}) ")
-
-        if lb > self.cppqm.upper_bound(vi):
-            raise ValueError(
-                f"the specified lower bound, {int(lb)}, cannot be set greater than the "
-                f"current upper bound, {int(self.cppqm.upper_bound(vi))}"
-                )
 
         cdef bias_type *b = &(self.cppqm.lower_bound(vi))
         b[0] = lb
 
     def set_upper_bound(self, v, bias_type ub):
         cdef Py_ssize_t vi = self.variables.index(v)
+        cdef cppVartype cppvartype = self.cppqm.vartype(vi)
 
-        if self.cppqm.vartype(vi) != cppVartype.INTEGER:
+        if cppvartype == cppVartype.INTEGER:
+            ub = cppround(ub)  # we round to the nearest integer
+
+            if ub > self.cppqm.max_integer():
+                raise ValueError(
+                    f"the specified upper bound, {int(ub)}, for variable {v!r} is greater than "
+                    f"{int(self.cppqm.max_integer())}, "
+                    f"the maximum for QuadraticModel(dtype=np.{self.dtype.name}) ")
+
+            if ub < self.cppqm.lower_bound(vi):
+                raise ValueError(
+                    f"the specified upper bound, {int(ub)}, cannot be set less than the "
+                    f"current lower bound, {int(self.cppqm.lower_bound(vi))}"
+                    )
+        elif cppvartype == cppVartype.REAL:
+            if ub > self.cppqm.max_real():
+                raise ValueError(
+                    f"the specified upper bound, {float(ub)}, for variable {v!r} is greater than "
+                    f"{float(self.cppqm.max_real())}, "
+                    f"the maximum for QuadraticModel(dtype=np.{self.dtype.name}) ")
+
+            if ub < self.cppqm.lower_bound(vi):
+                raise ValueError(
+                    f"the specified upper bound, {float(ub)}, cannot be set less than the "
+                    f"current lower bound, {float(self.cppqm.lower_bound(vi))}"
+                    )
+        else:
             raise ValueError(
                 "can only set the upper bound for INTEGER variables, "
                 f"{v!r} is a {self.vartype(v).name} variable")
-
-        ub = cppround(ub)  # we round to the nearest integer
-
-        if ub > self.cppqm.max_integer():
-            raise ValueError(
-                f"the specified upper bound, {int(ub)}, for variable {v!r} is greater than "
-                f"{int(self.cppqm.max_integer())}, "
-                f"the maximum for QuadraticModel(dtype=np.{self.dtype.name}) ")
-
-        if ub < self.cppqm.lower_bound(vi):
-            raise ValueError(
-                f"the specified upper bound, {int(ub)}, cannot be set less than the "
-                f"current lower bound, {int(self.cppqm.lower_bound(vi))}"
-                )
 
         cdef bias_type *b = &(self.cppqm.upper_bound(vi))
         b[0] = ub
@@ -653,9 +701,10 @@ cdef class cyQM_template(cyQMBase):
         cdef Py_ssize_t ui = self.variables.index(u)
         cdef Py_ssize_t vi = self.variables.index(v)
 
-        if ui == vi and self.cppqm.vartype(ui) != cppVartype.INTEGER:
+        if ui == vi and (self.cppqm.vartype(ui) == cppVartype.SPIN
+                         or self.cppqm.vartype(ui) == cppVartype.BINARY):
             raise ValueError(f"{u!r} cannot have an interaction with itself")
-        
+
         self.cppqm.set_quadratic(ui, vi, bias)
 
     def upper_bound(self, v):
@@ -672,5 +721,7 @@ cdef class cyQM_template(cyQMBase):
             return Vartype.SPIN
         elif cppvartype == cppVartype.INTEGER:
             return Vartype.INTEGER
+        elif cppvartype == cppVartype.REAL:
+            return Vartype.REAL
         else:
             raise RuntimeError("unexpected vartype")

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from dimod import BinaryQuadraticModel
 
 
-__all__ = ['QuadraticModel', 'QM', 'Integer', 'Integers']
+__all__ = ['QuadraticModel', 'QM', 'Integer', 'Integers', 'Real', 'Reals']
 
 
 QM_MAGIC_PREFIX = b'DIMODQM'
@@ -236,7 +236,7 @@ class QuadraticModel(QuadraticViewsMixin):
                             new.add_linear(u, ubias*vbias)
                         elif u_vartype is Vartype.SPIN:
                             new.offset += ubias * vbias
-                        elif u_vartype is Vartype.INTEGER:
+                        elif u_vartype is Vartype.INTEGER or u_vartype is Vartype.REAL:
                             new.add_quadratic(u, v, ubias*vbias)
                         else:
                             raise RuntimeError("unexpected vartype")
@@ -455,6 +455,7 @@ class QuadraticModel(QuadraticViewsMixin):
                 * :class:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
                 * :class:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
                 * :class:`.Vartype.INTEGER`, ``'INTEGER'``
+                * :class:`.Vartype.REAL`, ``'REAL'``
 
             label:
                 A label for the variable. Defaults to the length of the
@@ -463,11 +464,11 @@ class QuadraticModel(QuadraticViewsMixin):
 
             lower_bound:
                 A lower bound on the variable. Ignored when the variable is
-                not :class:`Vartype.INTEGER`.
+                not :class:`Vartype.INTEGER` or :class:`Vartype.REAL`.
 
             upper_bound:
                 An upper bound on the variable. Ignored when the variable is
-                not :class:`Vartype.INTEGER`.
+                not :class:`Vartype.INTEGER` or :class:`Vartype.REAL`.
 
         Returns:
             The variable label.
@@ -484,6 +485,7 @@ class QuadraticModel(QuadraticViewsMixin):
                 * :class:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
                 * :class:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
                 * :class:`.Vartype.INTEGER`, ``'INTEGER'``
+                * :class:`.Vartype.REAL`, ``'REAL'``
 
             variables: Iterable of variable labels.
 
@@ -506,6 +508,7 @@ class QuadraticModel(QuadraticViewsMixin):
                 * :class:`.Vartype.SPIN`, ``'SPIN'``, ``{-1, 1}``
                 * :class:`.Vartype.BINARY`, ``'BINARY'``, ``{0, 1}``
                 * :class:`.Vartype.INTEGER`, ``'INTEGER'``
+                * :class:`.Vartype.REAL`, ``'REAL'``
 
             v: Variable to change to the specified ``vartype``.
 
@@ -1223,6 +1226,50 @@ def Integers(labels: Union[int, Iterable[Variable]],
         yield from (Integer(v, dtype=dtype) for v in labels)
     else:
         yield from (Integer(dtype=dtype) for _ in range(labels))
+
+
+@unique_variable_labels
+def Real(label: Optional[Variable] = None, bias: Bias = 1,
+         dtype: Optional[DTypeLike] = None,
+         *, lower_bound: float = 0, upper_bound: Optional[float] = None) -> QuadraticModel:
+    """Return a quadratic model with a single real-valued variable.
+
+    Args:
+        label: Hashable label to identify the variable. Defaults to a
+            generated :class:`uuid.UUID` as a string.
+        bias: The bias to apply to the variable.
+        dtype: Data type for the returned quadratic model.
+        lower_bound: Keyword-only argument to specify the lower bound.
+        upper_bound: Keyword-only argument to specify the upper bound.
+
+    Returns:
+        Instance of :class:`.QuadraticModel`.
+
+    """
+    qm = QM(dtype=dtype)
+    v = qm.add_variable(Vartype.REAL, label, lower_bound=lower_bound, upper_bound=upper_bound)
+    qm.set_linear(v, bias)
+    return qm
+
+
+def Reals(labels: Union[int, Iterable[Variable]],
+          dtype: Optional[DTypeLike] = None) -> Iterator[QuadraticModel]:
+    """Yield quadratic models, each with a single real-valued variable.
+
+    Args:
+        labels: Either an iterable of variable labels or a number. If a number
+            labels are generated using :class:`uuid.UUID`.
+        dtype: Data type for the returned quadratic models.
+
+    Yields:
+        Quadratic models, each with a single real-valued variable.
+
+    """
+    if isinstance(labels, Iterable):
+        yield from (Real(v, dtype=dtype) for v in labels)
+    else:
+        yield from (Real(dtype=dtype) for _ in range(labels))
+
 
 # register fileview loader
 load.register(QM_MAGIC_PREFIX, QuadraticModel.from_file)

--- a/dimod/vartypes.py
+++ b/dimod/vartypes.py
@@ -60,7 +60,7 @@ from collections.abc import Container, Iterable
 
 __all__ = ['as_vartype',
            'Vartype', 'ExtendedVartype',
-           'SPIN', 'BINARY', 'DISCRETE', 'INTEGER',
+           'SPIN', 'BINARY', 'DISCRETE', 'INTEGER', 'REAL',
            ]
 
 
@@ -77,7 +77,17 @@ class Integers(Container):
         return self
 
 
-integers = Integers()
+class Real(Container):
+    """Container for testing real membership."""
+    def __contains__(self, item):
+        try:
+            return float(item) == item
+        except TypeError:
+            return False
+
+    def __deepcopy__(self, memo):
+        memo[id(self)] = self
+        return self
 
 
 class Vartype(enum.Enum):
@@ -85,16 +95,16 @@ class Vartype(enum.Enum):
     quadratic model.
 
     Attributes:
-        SPIN (:class:`.Vartype`): Vartype for spin-valued models; variables of
-           the model are either -1 or 1.
-        BINARY (:class:`.Vartype`): Vartype for binary models; variables of the
-           model are either 0 or 1.
+        SPIN: Vartype for spin-valued variables; variables are either -1 or 1.
+        BINARY: Vartype for binary variables; variables are either 0 or 1.
+        INTEGER: Vartype for integer-valued variables.
+        REAL: Vartype for real-valued variables.
 
     """
     SPIN = frozenset({-1, 1})
     BINARY = frozenset({0, 1})
-    INTEGER = integers
-    DISCRETE = integers  # alias for INTEGER
+    INTEGER = DISCRETE = Integers()  # DISCRETE is an alias for INTEGER
+    REAL = Real()
 
 
 # Deprecated alias
@@ -105,6 +115,7 @@ SPIN = Vartype.SPIN
 BINARY = Vartype.BINARY
 INTEGER = Vartype.INTEGER
 DISCRETE = Vartype.DISCRETE
+REAL = Vartype.REAL
 
 
 VartypeLike = typing.Union[Vartype, str, frozenset]
@@ -113,8 +124,9 @@ VartypeLike = typing.Union[Vartype, str, frozenset]
 def _vartype_miss(vartype, extended):
     if extended:
         candidates = ("Vartype.SPIN, 'SPIN', {-1, 1}, "
-                      "Vartype.BINARY, 'BINARY', {0, 1},"
-                      "Vartype.INTEGER, or 'INTEGER'")
+                      "Vartype.BINARY, 'BINARY', {0, 1}, "
+                      "Vartype.INTEGER, 'INTEGER', "
+                      "Vartype.REAL, or 'REAL'")
     else:
         candidates = ("Vartype.SPIN, 'SPIN', {-1, 1}, "
                       "Vartype.BINARY, 'BINARY', or {0, 1}")
@@ -138,13 +150,13 @@ def as_vartype(vartype: VartypeLike, extended: bool = False) -> Vartype:
             If `True`, vartype can also be:
 
             * :class:`.Vartype.INTEGER`, ``'INTEGER'``
-            * :class:`.Vartype.DISCRETE`, ``'DISCRETE'``
+            * :class:`.Vartype.REAL`, ``'REAL'``
 
 
     Returns:
         :class:`.Vartype`: Either :class:`.Vartype.SPIN` or
         :class:`.Vartype.BINARY`. If `extended` is True, can also
-        be :class:`.Vartype.INTEGER`.
+        be :class:`.Vartype.INTEGER` or :class:`.Vartype.REAL`
 
     See also:
         :func:`~dimod.decorators.vartype_argument`

--- a/releasenotes/notes/continuous-0c9da2dbefba3775.yaml
+++ b/releasenotes/notes/continuous-0c9da2dbefba3775.yaml
@@ -1,0 +1,8 @@
+---
+prelude: >
+    Add support for real-valued variables.
+features:
+  - |
+    Add C++ ``Vartype::REAL``, a new variable type for real-valued variables.
+  - |
+    Support variables with ``Vartype::REAL`` in C++ ``QuadraticModel``.

--- a/releasenotes/notes/continuous-0c9da2dbefba3775.yaml
+++ b/releasenotes/notes/continuous-0c9da2dbefba3775.yaml
@@ -6,3 +6,10 @@ features:
     Add C++ ``Vartype::REAL``, a new variable type for real-valued variables.
   - |
     Support variables with ``Vartype::REAL`` in C++ ``QuadraticModel``.
+  - |
+    Add ``Vartype.REAL``, a new variable type for real-valued variables.
+  - |
+    Add ``Real()`` and ``Reals()`` functions for creating quadratic models with
+    a single real-valued variable.
+  - |
+    Support variables with ``Vartype.REAL`` in ``QuadraticModel``.

--- a/tests/test_quadratic_model.py
+++ b/tests/test_quadratic_model.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 
 import dimod
 
-from dimod import Spin, Binary, Integer, QM, QuadraticModel
+from dimod import Spin, Binary, Integer, QM, QuadraticModel, Real, Reals
 
 
 VARTYPES = dict(BINARY=dimod.BINARY, SPIN=dimod.SPIN, INTEGER=dimod.INTEGER)
@@ -337,11 +337,13 @@ class TestFileSerialization(unittest.TestCase):
         qm.add_variable('INTEGER', 'i')
         qm.add_variable('BINARY', 'x')
         qm.add_variable('SPIN', 's')
+        qm.add_variable('REAL', 'a')
 
         qm.set_linear('i', 3)
         qm.set_quadratic('s', 'i', 2)
         qm.set_quadratic('x', 's', -2)
         qm.set_quadratic('i', 'i', 5)
+        qm.set_quadratic('i', 'a', 6)
         qm.offset = 7
 
         with tempfile.TemporaryFile() as tf:
@@ -439,6 +441,36 @@ class TestOffset(unittest.TestCase):
         self.assertEqual(qm.offset, 5)
         qm.offset -= 2
         self.assertEqual(qm.offset, 3)
+
+
+class TestReal(unittest.TestCase):
+    def test_init_no_label(self):
+        a = dimod.Real()
+        self.assertIsInstance(a.variables[0], str)
+
+    def test_multiple_labelled(self):
+        i, j, k = dimod.Reals('ijk')
+
+        self.assertEqual(i.variables[0], 'i')
+        self.assertEqual(j.variables[0], 'j')
+        self.assertEqual(k.variables[0], 'k')
+        self.assertIs(i.vartype('i'), dimod.REAL)
+        self.assertIs(j.vartype('j'), dimod.REAL)
+        self.assertIs(k.vartype('k'), dimod.REAL)
+
+    def test_multiple_unlabelled(self):
+        i, j, k = dimod.Reals(3)
+
+        self.assertNotEqual(i.variables[0], j.variables[0])
+        self.assertNotEqual(i.variables[0], k.variables[0])
+        self.assertIs(i.vartype(i.variables[0]), dimod.REAL)
+        self.assertIs(j.vartype(j.variables[0]), dimod.REAL)
+        self.assertIs(k.vartype(k.variables[0]), dimod.REAL)
+
+    def test_no_label_collision(self):
+        qm_1 = Real()
+        qm_2 = Real()
+        self.assertNotEqual(qm_1.variables[0], qm_2.variables[0])
 
 
 class TestRemoveInteraction(unittest.TestCase):
@@ -542,7 +574,7 @@ class TestSymbolic(unittest.TestCase):
         self.assertTrue(
             qm.is_equal(QM({'i': 1, 'j': -1}, {}, -5, {'i': 'INTEGER', 'j': 'INTEGER'})))
 
-    def test_expressions(self):
+    def test_expressions_integer(self):
         i = Integer('i')
         j = Integer('j')
 
@@ -558,6 +590,25 @@ class TestSymbolic(unittest.TestCase):
         self.assertTrue((-i).is_equal(QM({'i': -1}, {}, 0, {'i': 'INTEGER'})))
         self.assertTrue((1 - i).is_equal(QM({'i': -1}, {}, 1, {'i': 'INTEGER'})))
         self.assertTrue((i - 1).is_equal(QM({'i': 1}, {}, -1, {'i': 'INTEGER'})))
+        self.assertTrue(((i - j)**2).is_equal((i - j)*(i - j)))
+        self.assertTrue(((2*i + 4*i*j + 6) / 2.).is_equal(i + 2*i*j + 3))
+
+    def test_expressions_real(self):
+        i = Real('i')
+        j = Real('j')
+
+        self.assertTrue((i*j).is_equal(QM({}, {'ij': 1}, 0, {'i': 'REAL', 'j': 'REAL'})))
+        self.assertTrue((i*i).is_equal(QM({}, {'ii': 1}, 0, {'i': 'REAL'})))
+        self.assertTrue(((2*i)*(3*i)).is_equal(QM({}, {'ii': 6}, 0, {'i': 'REAL'})))
+        self.assertTrue((i + j).is_equal(QM({'i': 1, 'j': 1}, {}, 0,
+                                            {'i': 'REAL', 'j': 'REAL'})))
+        self.assertTrue((i + 2*j).is_equal(QM({'i': 1, 'j': 2}, {}, 0,
+                                              {'i': 'REAL', 'j': 'REAL'})))
+        self.assertTrue((i - 2*j).is_equal(QM({'i': 1, 'j': -2}, {}, 0,
+                                              {'i': 'REAL', 'j': 'REAL'})))
+        self.assertTrue((-i).is_equal(QM({'i': -1}, {}, 0, {'i': 'REAL'})))
+        self.assertTrue((1 - i).is_equal(QM({'i': -1}, {}, 1, {'i': 'REAL'})))
+        self.assertTrue((i - 1).is_equal(QM({'i': 1}, {}, -1, {'i': 'REAL'})))
         self.assertTrue(((i - j)**2).is_equal((i - j)*(i - j)))
         self.assertTrue(((2*i + 4*i*j + 6) / 2.).is_equal(i + 2*i*j + 3))
 

--- a/tests/test_vartypes.py
+++ b/tests/test_vartypes.py
@@ -24,3 +24,4 @@ class TestCopy(unittest.TestCase):
         self.assertIs(dimod.BINARY, deepcopy(dimod.BINARY))
         self.assertIs(dimod.INTEGER, deepcopy(dimod.INTEGER))
         self.assertIs(dimod.SPIN, deepcopy(dimod.SPIN))
+        self.assertIs(dimod.REAL, deepcopy(dimod.REAL))

--- a/testscpp/tests/test_quadratic_model.cpp
+++ b/testscpp/tests/test_quadratic_model.cpp
@@ -720,6 +720,32 @@ SCENARIO("A small quadratic model can be manipulated", "[qm]") {
             }
         }
 
+        WHEN("we add a real variable with a self-loop") {
+            auto v = qm.add_variable(Vartype::REAL);
+            qm.set_quadratic(v, v, 1.5);
+
+            THEN("it is accounted for correctly in num_interactions") {
+                CHECK(qm.num_interactions() == 1);
+            }
+            THEN("we can retrieve the quadratic bias") {
+                CHECK(qm.quadratic(v, v) == 1.5);
+            }
+
+            AND_WHEN("we add another variable with another self-loop") {
+                auto u = qm.add_variable(Vartype::REAL);
+
+                qm.add_quadratic(u, u, -2);
+
+                THEN("it is accounted for correctly in num_interactions") {
+                    CHECK(qm.num_interactions() == 2);
+                }
+                THEN("we can retrieve the quadratic bias") {
+                    CHECK(qm.quadratic(v, v) == 1.5);
+                    CHECK(qm.quadratic(u, u) == -2);
+                }
+            }
+        }
+
         WHEN("we add two integer variables with an interaction") {
           auto u = qm.add_variable(Vartype::INTEGER);
           auto v = qm.add_variable(Vartype::INTEGER);


### PR DESCRIPTION
Still need sample set support and has some TODOs. Putting this work on the [continuous](https://github.com/dwavesystems/dimod/tree/continuous) branch for now, so I don't just make an enormous patch.