### PR TITLE
Update doc string

### DIFF
--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -395,6 +395,10 @@ class ConstrainedQuadraticModel:
         Adds a special kind of one-hot constraint. These one-hot constraints
         must be disjoint, that is they must not have any overlapping variables.
 
+        Note that constraints added by :meth:`add_discrete` are guaranteed to
+        be satisfied in solutions returned by
+        :class:`~dwave.system.samplers.LeapHybridCQMSampler`.
+
         Args:
             variables: An iterable of variables.
 


### PR DESCRIPTION
This PR adds a note to the doc string of `ConstrainedQuadraticModel.add_discrete` that helps to clarify why and in what cases this method should be used instead of `ConstrainedQuadraticModel.add_constraint`.