### PR TITLE
Speed up printing of large sample sets

### DIFF
--- a/dimod/serialization/format.py
+++ b/dimod/serialization/format.py
@@ -263,6 +263,16 @@ class Formatter(object):
                          width, depth, sorted_by,
                          **other):
 
+        # as a quick performance boost, we can take a subset of the variables
+        # if we know it will be too big. width is in characters, and we
+        # need at least two characters per variable, so this is already
+        # way more than we need
+        num_variables = len(sampleset.variables)  # save this for later
+        if width > 2 and num_variables > width:
+            variables = sampleset.variables[:width-1]
+            variables._append(sampleset.variables[-1])
+            sampleset = dimod.keep_variables(sampleset, variables)
+
         if len(sampleset) > 0:
             self._print_samples(sampleset, stream, width, depth, sorted_by)
         else:
@@ -283,7 +293,7 @@ class Formatter(object):
         footer = [repr(sampleset.vartype.name),
                   '{} rows'.format(len(sampleset)),
                   '{} samples'.format(sampleset.record.num_occurrences.sum()),
-                  '{} variables'.format(len(sampleset.variables))
+                  '{} variables'.format(num_variables)
                   ]
         if sum(map(len, footer)) + (len(footer) - 1)*2 > width - 2:
             # if the footer won't fit in width

--- a/releasenotes/notes/faster-print-large-sampleset-0a924afbd6ec096f.yaml
+++ b/releasenotes/notes/faster-print-large-sampleset-0a924afbd6ec096f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Speed up printing sample sets with a large number of variables.
+    See `#1068 <https://github.com/dwavesystems/dimod/issues/1068>`_.

--- a/releasenotes/notes/feature-variables-slice-0e8295cb69eda2e9.yaml
+++ b/releasenotes/notes/feature-variables-slice-0e8295cb69eda2e9.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add ability to pass a slice to ``Variables.__getitem__``. This allows
+    for syntax like ``variables[:5]`` which will return a new ``Variables``
+    object.
+    See `#1069 <https://github.com/dwavesystems/dimod/issues/1069>`_.

--- a/tests/test_serialization_format.py
+++ b/tests/test_serialization_format.py
@@ -219,3 +219,14 @@ class TestSampleSet(unittest.TestCase):
                   "['BINARY', 3 rows, 3 samples, 2 variables]")
 
         self.assertEqual(target, s)
+
+    def test_wide(self):
+        ss = dimod.SampleSet.from_samples(np.ones(1000), 'BINARY', energy=[0])
+
+        s = Formatter().format(ss)
+
+        self.assertEqual(s, ("   0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15"
+                             " 16 17 ... 999 energy num_oc.\n0  1  1  1  1  1  "
+                             "1  1  1  1  1  1  1  1  1  1  1  1  1 ...   1    "
+                             "  0       1\n['BINARY', 1 rows, 1 samples, 1000 v"
+                             "ariables]"))

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -153,6 +153,18 @@ class TestRelabel(unittest.TestCase):
         self.assertEqual(variables, [1, 0, 5, 4, 3])
 
 
+class TestSlice(unittest.TestCase):
+    def test_slice(self):
+        variables = Variables('abd')
+
+        self.assertEqual(variables[:3], 'abd')
+        self.assertEqual(variables[:1], 'a')
+        self.assertEqual(variables[:], 'abd')
+        self.assertIsInstance(variables[:2], Variables)
+        self.assertEqual(variables[1::2], 'b')
+        self.assertEqual(variables[::2], 'ad')
+
+
 @parameterized_class(
     [dict(name='list', iterable=list(range(5))),
      dict(name='string', iterable='abcde'),


### PR DESCRIPTION
Comparison:
```python
import time

import dimod
import numpy as np

sampleset = dimod.SampleSet.from_samples(np.ones((91, 500000)), vartype='BINARY', energy=np.zeros(91))

t = time.perf_counter()
dimod.serialization.format.Formatter().format(sampleset)
print(time.perf_counter() - t)
```
As an example, running this simple test locally gives `22.33913665200089` without the change and `0.007365263998508453` with.

Also add variable object slicing.

Closes https://github.com/dwavesystems/dimod/issues/1069
Closes https://github.com/dwavesystems/dimod/issues/1068