### PR TITLE
Raise minimum Python version to 3.7 and minimum NumPy version to 1.19.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,6 @@ jobs:
       - restore_cache: &build-linux-restore-cache
           keys:
             - pip-{{ .Environment.CIRCLE_JOB }}-{{ checksum "pyproject.toml" }}
-      - when:
-          condition:
-            equal: [3.6.8, << parameters.python-version>>]
-          steps:
-            - run: echo 'export CIBW_MANYLINUX_X86_64_IMAGE=manylinux1' >> $BASH_ENV
       - run: &build-linux-wheels
           name: build wheels
           command: |
@@ -303,17 +298,6 @@ jobs:
       - restore_cache:
           keys:
             - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode13.2.0
-      - when:
-          # see https://github.com/pyenv/pyenv/issues/1643. We use an intermediate
-          # file so we can use the --skip-existing without raising errors from curl
-          condition:
-            equal: [3.6.8, << parameters.python-version>>]
-          steps:
-            - run:
-                name: Install Python 3.6 with a patch
-                command: |
-                  curl -sSL https://github.com/python/cpython/commit/8ea6353.patch > tmp.txt
-                  pyenv install -s --patch 3.6.8 < tmp.txt
       - run:
           name: install python
           command: |
@@ -394,7 +378,7 @@ workflows:
       - build-linux: &build
           matrix:
             parameters:
-              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4, 3.10.0]
+              python-version: &python-versions [3.7.9, 3.8.9, 3.9.4, 3.10.0]
       - build-linux-aarch64: *build
       - build-sdist
       - build-osx: &build-osx
@@ -403,8 +387,6 @@ workflows:
               python-version: *python-versions
               cibw-arch: [x86_64, universal2]
             exclude:
-              - python-version: 3.6.8
-                cibw-arch: universal2
               - python-version: 3.7.9
                 cibw-arch: universal2
       - build-windows: *build
@@ -419,25 +401,17 @@ workflows:
             parameters:
               # test the lowest numpy version and the highest minor of each
               # currently deployed
-              numpy-version: [==1.17.3, ~=1.18.0, ~=1.19.0, ~=1.20.0, ~=1.21.0]
+              numpy-version: [==1.19.1, ~=1.20.0, ~=1.21.0, ~=1.22.0]
               python-version: *python-versions
             exclude:
-              - numpy-version: ==1.17.3
+              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.9
                 python-version: 3.9.4
-              - numpy-version: ==1.17.3
+              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.10
                 python-version: 3.10.0
-              - numpy-version: ~=1.18.0
-                python-version: 3.9.4
-              - numpy-version: ~=1.18.0
+              - numpy-version: ~=1.20.0  # NumPy 1.20 does not support 3.10
                 python-version: 3.10.0
-              - numpy-version: ~=1.19.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.20.0
-                python-version: 3.6.8
-              - numpy-version: ~=1.20.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.21.0
-                python-version: 3.6.8
+              - numpy-version: ~=1.22.0  # NumPy 1.22 does not support 3.7
+                python-version: 3.7.9
       - test-linux-cpp11
       - test-osx:
           name: test-osx-py<< matrix.python-version >>
@@ -445,12 +419,7 @@ workflows:
             - build-osx
           matrix:
             parameters:
-              python-version: *python-versions
-            exclude:
-              # this doesn't play nicely with the xcode version we're using.
-              # rather than mess around with https://github.com/pyenv/pyenv/issues/1740
-              # etc let's just skip until december
-              - python-version: 3.6.8            
+              python-version: *python-versions         
       - test-sdist:
           requires:
             - build-sdist

--- a/dimod/core/composite.py
+++ b/dimod/core/composite.py
@@ -57,7 +57,7 @@ Examples:
 
     >>> composed_sampler = dimod.SpinReversalTransformComposite(dimod.ExactSolver())
     >>> h = {0: -1, 1: 1}
-    >>> solutions = composed_sampler.sample_ising(h, {})
+    >>> solutions = composed_sampler.sample_ising(h, {}, num_spin_reversal_transforms=2)
     >>> len(solutions) == 8
     True
 

--- a/releasenotes/notes/drop-py-3.6-21e3bf743ccb3841.yaml
+++ b/releasenotes/notes/drop-py-3.6-21e3bf743ccb3841.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - Python 3.6 is no longer supported.
+  - NumPy 1.17 and 1.18 are no longer supported.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.19.5;python_version<"3.10"
 numpy==1.21.4;python_version>="3.10"
-cython==0.29.21
-dwave-preprocessing==0.3.0;python_version<"3.10" # until we have a 3.10 wheel for dwave-preprocessing
+cython==0.29.26
+dwave-preprocessing==0.3.2
 
 reno==3.3.0  # for changelog
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,20 @@
 [metadata]
 classifiers =
     License :: OSI Approved :: Apache Software License
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+    Programming Language :: C++
+    Programming Language :: Cython
+    Programming Language :: Python
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
 license = Apache 2.0
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -40,7 +47,7 @@ packages =
     dimod.serialization
     dimod.testing
     dimod.views
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = False
 
 [pycodestyle]

--- a/setup.py
+++ b/setup.py
@@ -83,8 +83,7 @@ setup(
         'dimod/include/',
         ],
     install_requires=[
-        # ignoring 1.21.0 and 1.21.1 due to https://github.com/dwavesystems/dimod/issues/901
-        'numpy>=1.17.3,<2.0.0,!=1.21.0,!=1.21.1', # keep synced with circle-ci, pyproject.toml
+        'numpy>=1.19.1,<2.0.0',
         'pyparsing>=2.4.7, <3.0.0',
         ],
     # we use the generic 'all' so that in the future when we remove


### PR DESCRIPTION
Python 3.6 reached EOL Dec 2021

The NumPy minimum was chosen to still support https://github.com/dwavesystems/penaltymodel/issues/134