### PR TITLE
Restore BQM.to_serializable and .from_serializable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,7 +224,6 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'numpy': ('https://numpy.org/doc/stable/', None),
-                       'bson': ('https://api.mongodb.com/python/current/', None),
                        'networkx': ('https://networkx.org/documentation/stable/', None),
                        'oceandocs': ('https://docs.ocean.dwavesys.com/en/stable/', None),
                        'sysdocs_gettingstarted': ('https://docs.dwavesys.com/docs/latest/', None)}

--- a/docs/reference/quadratic.rst
+++ b/docs/reference/quadratic.rst
@@ -153,6 +153,7 @@ Methods
    ~BinaryQuadraticModel.from_ising
    ~BinaryQuadraticModel.from_numpy_vectors
    ~BinaryQuadraticModel.from_qubo
+   ~BinaryQuadraticModel.from_serializable
    ~BinaryQuadraticModel.is_almost_equal
    ~BinaryQuadraticModel.is_equal
    ~BinaryQuadraticModel.is_linear
@@ -180,6 +181,7 @@ Methods
    ~BinaryQuadraticModel.to_numpy_vectors
    ~BinaryQuadraticModel.to_polystring
    ~BinaryQuadraticModel.to_qubo
+   ~BinaryQuadraticModel.to_serializable
    ~BinaryQuadraticModel.update
 
 

--- a/releasenotes/notes/restore-to-serializable-a20e3ab59ba9348b.yaml
+++ b/releasenotes/notes/restore-to-serializable-a20e3ab59ba9348b.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Reintroduce ``BinaryQuadraticModel.to_serializable()`` and
+    ``BinaryQuadraticModel.from_serializable()`` methods that were previously
+    removed in dimod 0.10.0, see `#847 <https://github.com/dwavesystems/dimod/pull/847>`_.
+upgrade:
+  - |
+    Make ``use_bytes`` and ``bytes_type`` keyword-only arguments in
+    ``BinaryQuadraticModel.to_serializable()``.
+    Note that ``BinaryQuadraticModel.to_serializable()`` was removed in 0.10.0 but
+    restored in 0.10.12.
+  - |
+    The ``bias_dtype`` keyword-only argument in
+    ``BinaryQuadraticModel.to_serializable()`` now does nothing.
+    Note that ``BinaryQuadraticModel.to_serializable()`` was removed in 0.10.0 but
+    restored in 0.10.12.


### PR DESCRIPTION
We could also create an equivalent for quadratic models, but I am going to leave that alone for now.