### PR TITLE
Add BinaryQuadraticModel.maximum_energy_delta() method

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -1111,6 +1111,37 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
         energy, = energies
         return energy
 
+    def maximum_energy_delta(self) -> Bias:
+        """Compute a conservative bound on the maximum change in energy that can
+        result from flipping a single variable in a binary quadratic model.
+
+        The bound is useful as a starting point for determining the values of
+        `penalty parameters`_ in a `penalty model`_.
+
+        Returns:
+            Bound on change in energy.
+
+        Examples:
+            >>> Q = {(0, 0): -1, (0, 1): 1, (1, 2): -4.5}
+            >>> bqm = dimod.BinaryQuadraticModel.from_qubo(Q)
+            >>> bqm.maximum_energy_delta()
+            5.5
+
+        .. _`penalty parameters`: https://en.wikipedia.org/wiki/Penalty_method
+        .. _`penalty model`: https://docs.ocean.dwavesys.com/en/stable/concepts/index.html#term-Penalty-model
+
+        """
+        if self.vartype is Vartype.SPIN:
+            scale = 2
+        elif self.vartype is Vartype.BINARY:
+            scale = 1
+        else:
+            raise RuntimeError("unexpected vartype")
+
+        return max(abs(self.get_linear(v))
+                   + sum(abs(bias) for u, bias in self.iter_neighborhood(v))
+                   for v in self.variables) * scale
+
     def flip_variable(self, v: Variable):
         """Flip the specified variable in a binary quadratic model."""
         if self.vartype is Vartype.SPIN:

--- a/docs/reference/quadratic.rst
+++ b/docs/reference/quadratic.rst
@@ -173,6 +173,7 @@ Methods
    ~BinaryQuadraticModel.iter_neighborhood
    ~BinaryQuadraticModel.get_linear
    ~BinaryQuadraticModel.get_quadratic
+   ~BinaryQuadraticModel.maximum_energy_delta
    ~BinaryQuadraticModel.normalize
    ~BinaryQuadraticModel.reduce_linear
    ~BinaryQuadraticModel.reduce_neighborhood


### PR DESCRIPTION
### Summary

Add a method to `BinaryQuadraticModel` that may be generally useful for constructing penalty models.

### Background

This method is defined as a function in the [Mutual Information Feature Selection example](https://github.com/dwave-examples/mutual-information-feature-selection/) ([here](https://github.com/dwave-examples/mutual-information-feature-selection/blob/master/titanic.py#L90)).

### Alternatives considered

Defining `maximum_energy_delta` as a free function elsewhere in `dimod` (e.g. in `utilities.py` and in `generators/constraints.py`) was considered.  It seemed out of place elsewhere, and on the other hand, a natural fit in `BinaryQuadraticModel`, despite its specialized nature.

Adding `maximum_energy_delta` to another class (e.g. `QuadraticModel`) was also considered.  There may be some value in extending this functionality to that class in the future (i.e. supporting integer variables in the calculation).  But there is less utility in doing this, because problems with integer variables are naturally modeled using `ConstrainedQuadraticModel`.  And a penalty model is not needed in that case as constraints can be represented natively.