### PR TITLE
add inner_child_properties tool

### DIFF
--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import itertools
 import os
@@ -22,14 +24,16 @@ from functools import reduce
 
 import numpy as np
 
+import dimod
 from dimod.typing import Variable
+
 
 __all__ = ['ising_energy',
            'qubo_energy',
            'ising_to_qubo',
            'qubo_to_ising',
            'child_structure_dfs',
-           'inner_child_properties',
+           'innermost_child_properties',
            'get_include',
            ]
 
@@ -450,9 +454,8 @@ def child_structure_dfs(sampler, seen=None):
 
     raise ValueError("no structured sampler found")
 
-def inner_child_properties(sampler):
-    """
-    Returns the properties of inner-most child sampler in a composite.
+def innermost_child_properties(sampler: dimod.Sampler) -> typing.Dict[str, typing.Any]:
+    """Returns the properties of the inner-most child sampler in a composite.
 
     Args:
         sampler: A dimod sampler
@@ -462,16 +465,15 @@ def inner_child_properties(sampler):
 
     Example:
     >>> sampler = EmbeddingComposite(ScaleComposite(qpu_sampler))
-    >>> inner_child_properties(sampler)["annealing_time_range]
+    >>> inner_child_properties(sampler)["annealing_time_range"]
     [0.5, 2000.0]
     """
 
-    def get_properties(properties):
-        if "child_properties" in properties:
-            return get_properties(properties["child_properties"])
-        else:
-            return properties
-    return get_properties(sampler.properties)
+    try:
+        return innermost_child_properties(sampler.child)
+    except AttributeError:
+        return sampler.properties
+
 
 def get_include():
     """Return the directory with dimod's header files."""

--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -29,6 +29,7 @@ __all__ = ['ising_energy',
            'ising_to_qubo',
            'qubo_to_ising',
            'child_structure_dfs',
+           'inner_child_properties',
            'get_include',
            ]
 
@@ -449,6 +450,28 @@ def child_structure_dfs(sampler, seen=None):
 
     raise ValueError("no structured sampler found")
 
+def inner_child_properties(sampler):
+    """
+    Returns the properties of inner-most child sampler in a composite.
+
+    Args:
+        sampler: A dimod sampler
+
+    Returns:
+        properties (dict): The properties of the inner-most sampler
+
+    Example:
+    >>> sampler = EmbeddingComposite(ScaleComposite(qpu_sampler))
+    >>> inner_child_properties(sampler)["annealing_time_range]
+    [0.5, 2000.0]
+    """
+
+    def get_properties(properties):
+        if "child_properties" in properties:
+            return get_properties(properties["child_properties"])
+        else:
+            return properties
+    return get_properties(sampler.properties)
 
 def get_include():
     """Return the directory with dimod's header files."""

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -274,6 +274,34 @@ class TestChildStructureDFS(unittest.TestCase):
         with self.assertRaises(ValueError):
             dimod.child_structure_dfs(nested)
 
+class TestInnerChildProperties(unittest.TestCase):
+        
+    class Dummy(dimod.Sampler):
+        def __init__(self, annealing_time_range):
+            self.annealing_time_range = annealing_time_range
+        @property
+        def properties(self):
+            return {"annealing_time_range": self.annealing_time_range}
+        @property
+        def parameters(self):
+            pass
+        def sample(**kwargs):
+            pass
+        sample_ising = sample_qubo = sample
+
+    def test_sampler(self):
+        # not a composed sampler
+        annealing_time_range = [1, 1000]
+        sampler = self.Dummy(annealing_time_range)
+        properties = dimod.inner_child_properties(sampler)
+        self.assertEqual(properties["annealing_time_range"], annealing_time_range)
+
+    def test_composed_sampler(self):
+        annealing_time_range = [1, 1000]
+        sampler = dimod.ClipComposite(dimod.ScaleComposite(self.Dummy(annealing_time_range)))
+        properties = dimod.inner_child_properties(sampler)
+        self.assertEqual(properties["annealing_time_range"], annealing_time_range)
+
 
 class TestAsIntegerArrays(unittest.TestCase):
     def test_empty(self):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -274,7 +274,7 @@ class TestChildStructureDFS(unittest.TestCase):
         with self.assertRaises(ValueError):
             dimod.child_structure_dfs(nested)
 
-class TestInnerChildProperties(unittest.TestCase):
+class TestInnermostChildProperties(unittest.TestCase):
         
     class Dummy(dimod.Sampler):
         def __init__(self, annealing_time_range):
@@ -293,13 +293,13 @@ class TestInnerChildProperties(unittest.TestCase):
         # not a composed sampler
         annealing_time_range = [1, 1000]
         sampler = self.Dummy(annealing_time_range)
-        properties = dimod.inner_child_properties(sampler)
+        properties = dimod.innermost_child_properties(sampler)
         self.assertEqual(properties["annealing_time_range"], annealing_time_range)
 
     def test_composed_sampler(self):
         annealing_time_range = [1, 1000]
         sampler = dimod.ClipComposite(dimod.ScaleComposite(self.Dummy(annealing_time_range)))
-        properties = dimod.inner_child_properties(sampler)
+        properties = dimod.innermost_child_properties(sampler)
         self.assertEqual(properties["annealing_time_range"], annealing_time_range)
 
 


### PR DESCRIPTION
This tool will descend and find the properties of the inner-most children sampler in a composite (or just a sampler).

Useful for extracting QPU parameters when the QPU sampler is wrapped on many composite layers.