### PR TITLE
expose innermost_child sampler

### DIFF
--- a/dimod/core/composite.py
+++ b/dimod/core/composite.py
@@ -45,6 +45,8 @@ Examples:
     For more examples, see the source code for the composed
     documented in :ref:`quadratic_composites`.
 """
+from __future__ import annotations
+
 import abc
 
 from dimod.core.sampler import Sampler
@@ -75,10 +77,14 @@ class Composite(abc.ABC):
             raise RuntimeError("A Composite must have at least one child Sampler")
 
 
+
 class ComposedSampler(Sampler, Composite):
     """Abstract base class for dimod composed samplers.
 
     Inherits from :class:`.Sampler` and :class:`.Composite`.
 
     """
-    pass
+
+    def innermost_child(self) -> Sampler:
+        """Returns the inner-most child sampler"""
+        return self.child.innermost_child()    

--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -105,6 +105,7 @@ non-empty dicts.
             return self._parameters
 
 """
+from __future__ import annotations
 
 import abc
 import typing
@@ -317,3 +318,6 @@ class Sampler(metaclass=SamplerABCMeta):
             kwargs.pop(kw)
 
         return kwargs
+    
+    def innermost_child(self) -> Sampler:
+            return self

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -39,3 +39,34 @@ class TestCompositeClass(unittest.TestCase):
         sampler = Dummy()
         with self.assertRaises(RuntimeError):
             sampler.child
+
+
+class TestInnermostChildProperties(unittest.TestCase):
+
+    class Dummy(dimod.Sampler):
+        def __init__(self, annealing_time_range):
+            self.annealing_time_range = annealing_time_range
+        @property
+        def properties(self):
+            return {"annealing_time_range": self.annealing_time_range}
+        @property
+        def parameters(self):
+            pass
+        def sample(**kwargs):
+            pass
+        sample_ising = sample_qubo = sample
+
+    def test_sampler(self):
+        # not a composed sampler
+        annealing_time_range = [1, 1000]
+        sampler = self.Dummy(annealing_time_range)
+        innermost_child = sampler.innermost_child()
+        self.assertEqual(innermost_child.properties["annealing_time_range"], annealing_time_range)
+
+    def test_composed_sampler(self):
+        annealing_time_range = [1, 1000]
+        sampler = dimod.ClipComposite(dimod.ScaleComposite(self.Dummy(annealing_time_range)))
+        innermost_child = sampler.innermost_child()
+        print(innermost_child.properties)
+        self.assertEqual(innermost_child.properties["annealing_time_range"], annealing_time_range)
+

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -362,3 +362,20 @@ class TestSamplerClass(unittest.TestCase):
 
         # Check that known kwargs are kept and unknown kwargs are removed
         self.assertDictEqual(kwargs, {'a': 1})
+
+    def test_innermost_child(self):
+        class Dummy(dimod.Sampler):
+            def sample(self, **kwargs):
+                kwargs = self.remove_unknown_kwargs(**kwargs)
+                return kwargs
+
+            @property
+            def parameters(self):
+                return {'a':[]}
+
+            @property
+            def properties(self):
+                return {'b':[]}
+
+        sampler = Dummy()
+        self.assertDictEqual(sampler.innermost_child().properties, {'b':[]})


### PR DESCRIPTION
Allow composite samplers to expose the innermost child sampler, this can be used to gather properties. For example, one can get QPU properties from a composite made of several layers