### PR TITLE
Speed up QM.add_variables_from() and QM.add_linear_from()

### DIFF
--- a/benchmarks/qm.py
+++ b/benchmarks/qm.py
@@ -1,0 +1,39 @@
+# Copyright 2021 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import dimod
+
+
+class TimeAddLinearFrom:
+    params = ([str, int], [dict, list])
+
+    def setUp(self, type_, container):
+        self.qm = qm = dimod.QuadraticModel()
+        qm.add_variables_from('BINARY', map(type_, range(5000)))
+
+        self.iterator = container((type_(v), 1) for v in range(5000))
+
+    def time_add_linear_from(self, *args):
+        self.qm.add_linear_from(self.iterator)
+
+
+class TimeAddVariablesFrom:
+    params = [str, int]
+
+    def setUp(self, type_):
+        self.qm = dimod.QuadraticModel()
+        self.variables = list(map(type_, range(5000)))
+
+    def time_add_variables_from(self, *args):
+        self.qm.add_variables_from('BINARY', self.variables)

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,3 +1,2 @@
-# we want the --strict flag which is not yet released as of October 2021
-git+https://github.com/airspeed-velocity/asv.git@7c938cf679d2e043829259f9f1061cf2564f7332
+asv==0.5.1
 virtualenv==16.7.12

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -226,8 +226,8 @@ cdef class cyQM_template(cyQMBase):
             self.cppqm.add_quadratic(ui, vi, bias)
 
     def add_variable(self, vartype, label=None, *, lower_bound=None, upper_bound=None):
-        # as_vartype will raise for unsupported vartypes
-        vartype = as_vartype(vartype, extended=True)
+        if not isinstance(vartype, Vartype):  # redundant, but provides a bit of a speedup
+            vartype = as_vartype(vartype, extended=True)
         cdef cppVartype cppvartype = self.cppvartype(vartype)
 
         cdef bias_type lb

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -423,7 +423,7 @@ class QuadraticModel(QuadraticViewsMixin):
         Raises:
             ValueError: If a specified variable is not in the model.
         """
-        add_linear = self.add_linear
+        add_linear = self.data.add_linear
 
         if isinstance(linear, Mapping):
             for v, bias in linear.items():
@@ -523,8 +523,9 @@ class QuadraticModel(QuadraticViewsMixin):
 
         """
         vartype = as_vartype(vartype, extended=True)
+        add_variable = self.data.add_variable
         for v in variables:
-            self.add_variable(vartype, v)
+            add_variable(vartype, v)
 
     def add_variables_from_model(self,
                                  model: Union[BinaryQuadraticModel,


### PR DESCRIPTION
Some minor speedups for `QM.add_variables_from()` and `QM.add_linear_from()`

```bash
Commit: c9fb8c3f <main>

qm.TimeAddLinearFrom.time_add_linear_from [desktop/virtualenv-py3.8]
  ok
  ======== ============= =============
  --                  param2          
  -------- ---------------------------
   param1       dict          list    
  ======== ============= =============
    str     1.07±0.05ms   1.10±0.05ms 
    int       332±80μs      295±2μs   
  ======== ============= =============
  started: 2022-04-05 11:00:31, duration: 1.82s

qm.TimeAddVariablesFrom.time_add_variables_from_str [desktop/virtualenv-py3.8]
  ok
  ======== =============
   param1               
  -------- -------------
    str     2.79±0.04ms 
    int     1.36±0.01ms 
  ======== =============
  started: 2022-04-05 11:00:32, duration: 808ms

```

```bash
Commit: d77a246a <feature/speedup-qm-linear-methods>

qm.TimeAddLinearFrom.time_add_linear_from [desktop/virtualenv-py3.8]
  ok
  ======== ============= ===========
  --                 param2         
  -------- -------------------------
   param1       dict         list   
  ======== ============= ===========
    str     1.02±0.01ms   1000±30μs 
    int       305±20μs     271±5μs  
  ======== ============= ===========
  started: 2022-04-05 11:00:03, duration: 1.67s

qm.TimeAddVariablesFrom.time_add_variables_from_str [desktop/virtualenv-py3.8]
  ok
  ======== =============
   param1               
  -------- -------------
    str     1.95±0.01ms 
    int       606±6μs   
  ======== =============
  started: 2022-04-05 11:00:04, duration: 809ms

```