### PR TITLE
Drop support for NumPy 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,14 +416,10 @@ workflows:
             parameters:
               # test the lowest numpy version and the highest minor of each
               # currently deployed
-              numpy-version: [==1.19.1, ~=1.20.0, ~=1.21.0, ~=1.22.0]
+              numpy-version: [==1.20.0, ~=1.21.0, ~=1.22.0]
               python-version: *python-versions
             exclude:
-              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.9
-                python-version: 3.9.4
-              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.10
-                python-version: 3.10.0
-              - numpy-version: ~=1.20.0  # NumPy 1.20 does not support 3.10
+              - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
                 python-version: 3.10.0
               - numpy-version: ~=1.22.0  # NumPy 1.22 does not support 3.7
                 python-version: 3.7.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ requires = [
     "setuptools>=46.4.0",
     "wheel",
     "Cython>=0.29.21,<3.0",
-    'numpy==1.19.5;python_version<"3.10"',
-    'numpy==1.21.4;python_version>="3.10"',
+    'numpy~=1.21.0',
 ]
 build-backend = "setuptools.build_meta"
 

--- a/releasenotes/notes/drop-numpy1.19-e71bb3b051194bdb.yaml
+++ b/releasenotes/notes/drop-numpy1.19-e71bb3b051194bdb.yaml
@@ -1,0 +1,3 @@
+---
+upgrade:
+  - Drop support for Numpy 1.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-numpy==1.19.5;python_version<"3.10"
-numpy==1.21.4;python_version>="3.10"
+numpy==1.21.6
 cython==0.29.28
 
 reno==3.3.0  # for changelog

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'dimod/include/',
         ],
     install_requires=[
-        'numpy>=1.19.1,<2.0.0',
+        'numpy>=1.20.0,<2.0.0',
         'pyparsing>=2.4.7, <3.0.0',
         ],
     # we use the generic 'all' so that in the future we can add or remove

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -1132,7 +1132,7 @@ class TestEnergies(unittest.TestCase):
                 arr = np.array([5, 2.5], dtype=dtype)
                 self.assertEqual(bqm.energy((arr, 'xy')), -40)
 
-        for dtype in [np.complex]:
+        for dtype in [complex]:
             with self.subTest(dtype):
                 arr = np.array([5, 2], dtype=dtype)
                 with self.assertRaises(ValueError):
@@ -2611,7 +2611,7 @@ class TestToFromSerializable(unittest.TestCase):
         self.assertEqual(bqm, new)
 
     def test_variable_labels(self):
-        h = {0: 0, 1: 1, np.int64(2): 2, np.float(3): 3,
+        h = {0: 0, 1: 1, np.int64(2): 2, np.float64(3): 3,
              fractions.Fraction(4, 1): 4, fractions.Fraction(5, 2): 5,
              '6': 6}
         J = {}

--- a/tests/test_quadratic_model.py
+++ b/tests/test_quadratic_model.py
@@ -440,7 +440,7 @@ class TestEnergies(unittest.TestCase):
                 arr = np.array([5, 2.5], dtype=dtype)
                 self.assertEqual(qm.energy((arr, 'ij')), -40)
 
-        for dtype in [np.complex]:
+        for dtype in [complex]:
             with self.subTest(dtype):
                 arr = np.array([5, 2], dtype=dtype)
                 with self.assertRaises(ValueError):


### PR DESCRIPTION
This allows us to build all version of dimod with the same NumPy version which simplifies thing.