### PR TITLE
Fix some documentation warnings

### DIFF
--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -250,7 +250,7 @@ class ConstrainedQuadraticModel:
         Args:
             qm: Quadratic model or binary quadratic model.
 
-            sense: One of `<=', '>=', '=='.
+            sense: One of `<=`, `>=`, `==`.
 
             rhs: Right hand side of the constraint.
 
@@ -373,7 +373,7 @@ class ConstrainedQuadraticModel:
             iterable: Iterable of terms as tuples. The variables must
                 have already been added to the object.
 
-            sense: One of `<=', '>=', '=='.
+            sense: One of `<=`, `>=`, `==`.
 
             rhs: The right hand side of the constraint.
 

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -836,7 +836,7 @@ class DiscreteQuadraticModel:
 
             **Variable Data**
 
-            The first 4 bytes are exactly `"VARS"`.
+            The first 4 bytes are exactly ``"VARS"``.
 
             The next 4 bytes form a little-endian unsigned int, the length of
             the variables array ``VARIABLES_LENGTH``.

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -797,7 +797,7 @@ class DiscreteQuadraticModel:
 
             **Header**
 
-            The first 8 bytes are a magic string: exactly `"DIMODDQM"`.
+            The first 8 bytes are a magic string: exactly ``"DIMODDQM"``.
 
             The next 1 byte is an unsigned byte: the major version of the file
             format.
@@ -808,7 +808,7 @@ class DiscreteQuadraticModel:
             The next 4 bytes form a little-endian unsigned int, the length of
             the header data `HEADER_LEN`.
 
-            The next `HEADER_LEN` bytes form the header data. This is a
+            The next ``HEADER_LEN`` bytes form the header data. This is a
             json-serialized dictionary. The dictionary is exactly:
 
             .. code-block:: python
@@ -828,21 +828,21 @@ class DiscreteQuadraticModel:
             The first 4 bytes are exactly `"BIAS"`
 
             The next 4 bytes form a little-endian unsigned int, the length of
-            the DQM data `DATA_LEN`.
+            the DQM data ``DATA_LEN``.
 
-            The next `DATA_LEN` bytes are the vectors as returned by
+            The next ``DATA_LEN`` bytes are the vectors as returned by
             :meth:`DiscreteQuadraticModel.to_numpy_vectors` saved using
             :func:`numpy.save`.
 
             **Variable Data**
 
-            The first 4 bytes are exactly "VARS".
+            The first 4 bytes are exactly `"VARS"`.
 
             The next 4 bytes form a little-endian unsigned int, the length of
-            the variables array `VARIABLES_LENGTH`.
+            the variables array ``VARIABLES_LENGTH``.
 
             The next VARIABLES_LENGTH bytes are a json-serialized array. As
-            constructed by `json.dumps(list(bqm.variables)).
+            constructed by ``json.dumps(list(bqm.variables))``.
 
         .. _NPY format: https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html
 
@@ -896,7 +896,7 @@ class DiscreteQuadraticModel:
 
         Returns:
             :class:`DQMVectors`: A named tuple with fields `['case_starts',
-            'linear_biases', 'quadratic', 'labels'].
+            'linear_biases', 'quadratic', 'labels']`.
 
             - `case_starts`: A length
               :meth:`~DiscreteQuadraticModel.num_variables` array. The cases

--- a/dimod/generators/gates.py
+++ b/dimod/generators/gates.py
@@ -274,18 +274,21 @@ def multiplication_circuit(num_arg1_bits: int, num_arg2_bits: Optional[int] = No
     The generated BQM represents the binary multiplication :math:`ab=p`,
     where the args are binary variables of length ``num_arg1_bits`` and
     ``num_arg2_bits``; for example, :math:`2^ma_{num_arg1_bits} + ... + 4a_2 + 2a_1 + a0`.
-    The square below shows a graphic representation of the circuit::
-      ________________________________________________________________________________
-      |                                         and20         and10         and00    |
-      |                                           |             |             |      |
-      |                           and21         add11──and11  add01──and01    |      |
-      |                             |┌───────────┘|┌───────────┘|             |      |
-      |             and22         add12──and12  add02──and02    |             |      |
-      |               |┌───────────┘|┌───────────┘|             |             |      |
-      |             add13─────────add03           |             |             |      |
-      |  ┌───────────┘|             |             |             |             |      |
-      | p5            p4            p3            p2            p1            p0     |
-      --------------------------------------------------------------------------------
+    The square below shows a graphic representation of the circuit:
+
+    .. code-block::
+
+        ________________________________________________________________________________
+        |                                         and20         and10         and00    |
+        |                                           |             |             |      |
+        |                           and21         add11──and11  add01──and01    |      |
+        |                             |┌───────────┘|┌───────────┘|             |      |
+        |             and22         add12──and12  add02──and02    |             |      |
+        |               |┌───────────┘|┌───────────┘|             |             |      |
+        |             add13─────────add03           |             |             |      |
+        |  ┌───────────┘|             |             |             |             |      |
+        | p5            p4            p3            p2            p1            p0     |
+        --------------------------------------------------------------------------------
 
     Args:
         num_arg1_bits: Number of bits in the first argument.

--- a/docs/reference/higherorder.rst
+++ b/docs/reference/higherorder.rst
@@ -47,8 +47,6 @@ Functions
 Reducing to a Binary Quadratic Model
 ====================================
 
-.. automodule:: dimod.higherorder.utils
-
 .. autosummary::
    :toctree: generated/
 


### PR DESCRIPTION
It still throws some warnings for missing terms in glossary. But resolves all of the docstring warnings.