### PR TITLE
Speed up iteration over Variables objects

### DIFF
--- a/benchmarks/variables.py
+++ b/benchmarks/variables.py
@@ -12,15 +12,32 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import dimod
+from dimod.variables import Variables
+
+
+class TimeConstuction:
+    num_variables = 1000
+
+    iterables = dict(range=range(num_variables),
+                     strings=list(map(str, range(num_variables))),
+                     integers=list(range(1000)),
+                     empty=[],
+                     none=None,
+                     )
+
+    params = iterables.keys()
+    param_names = ['iterable']
+
+    def time_construction(self, key):
+        Variables(self.iterables[key])
 
 
 class TimeIteration:
     num_variables = 1000
 
-    variables = dict(string=dimod.variables.Variables(map(str, range(num_variables))),
-                     index=dimod.variables.Variables(range(num_variables)),
-                     integer=dimod.variables.Variables(range(num_variables, 0, -1))
+    variables = dict(string=Variables(map(str, range(num_variables))),
+                     index=Variables(range(num_variables)),
+                     integer=Variables(range(num_variables, 0, -1))
                      )
 
     params = variables.keys()

--- a/benchmarks/variables.py
+++ b/benchmarks/variables.py
@@ -1,0 +1,31 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import dimod
+
+
+class TimeIteration:
+    num_variables = 1000
+
+    variables = dict(string=dimod.variables.Variables(map(str, range(num_variables))),
+                     index=dimod.variables.Variables(range(num_variables)),
+                     integer=dimod.variables.Variables(range(num_variables, 0, -1))
+                     )
+
+    params = variables.keys()
+    param_names = ['labels']
+
+    def time_iteration(self, key):
+        for v in self.variables[key]:
+            pass

--- a/dimod/cyvariables.pyx
+++ b/dimod/cyvariables.pyx
@@ -65,6 +65,15 @@ cdef class cyVariables:
             new._append(self.at(i), permissive=False)
         return new
 
+    def __iter__(self):
+        cdef Py_ssize_t i
+
+        if self._is_range():
+            yield from range(self._stop)
+        else:
+            for i in range(self._stop):
+                yield self.at(i)
+
     def __len__(self):
         return self.size()
 

--- a/releasenotes/notes/feature-speed-up-variables-iteration-bfe9d6596e24572f.yaml
+++ b/releasenotes/notes/feature-speed-up-variables-iteration-bfe9d6596e24572f.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Improve the performance of iteration over ``Variables`` objects.


### PR DESCRIPTION
New timing results for `for v in variables: pass`
```bash
                labels              
              --------- ------------
                string   34.3±0.7μs 
                index    11.2±0.3μs 
               integer   34.1±0.6μs 
```
vs the old timing results
```bash
                labels              
              --------- ------------
                string   63.0±0.3μs 
                index     53.1±1μs  
               integer    62.2±3μs  
```