### PR TITLE
Added planting option for random_nae3sat and random_2in4sat, and minor changes to documentation

### DIFF
--- a/dimod/generators/fcl.py
+++ b/dimod/generators/fcl.py
@@ -12,13 +12,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import math
 import warnings
 
 from typing import Callable, Collection, List, Mapping, Optional
 
 import numpy.random
 
+from numpy import prod
 from dimod.binary_quadratic_model import BinaryQuadraticModel
 from dimod.decorators import graph_argument
 from dimod.typing import GraphLike, Variable
@@ -142,7 +142,7 @@ def frustrated_loop(graph: GraphLike,
         else:
             # randomly select from all frustrated loops (odd number of AFM edges)
             cycle_J = {(cycle[i], cycle[i+1]) : -1 for i in range(len(cycle)-1)}
-            cycle_J[(cycle[-1],cycle[0])] = (1 - 2*(len(cycle_J) & 1))*math.prod(cycle_J.values())
+            cycle_J[(cycle[-1],cycle[0])] = (1 - 2*(len(cycle_J) & 1))*prod(list(cycle_J.values()))
             
         # update the bqm
         bqm.add_interactions_from(cycle_J)
@@ -161,10 +161,11 @@ def frustrated_loop(graph: GraphLike,
                       "spin labels to match desired planting or "
                       "(2) SpinReversalComposite for presentation of a randomized "
                       "planted solution to some solver.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=3)
         # A spin-reversal transform for a BQM with zero linear biases
         for e in bqm.quadratic:
-            bqm.quadratic[e] = bqm.quadratic[e]*planted_solution[e[0]]*planted_solution[e[1]]
+            bqm.set_quadratic(e[0], e[1],
+                              bqm.quadratic[e]*planted_solution[e[0]]*planted_solution[e[1]])
 
     return bqm
 

--- a/dimod/generators/fcl.py
+++ b/dimod/generators/fcl.py
@@ -12,6 +12,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import math
+import warnings
+
 from typing import Callable, Collection, List, Mapping, Optional
 
 import numpy.random
@@ -33,18 +36,21 @@ def frustrated_loop(graph: GraphLike,
                     R: float = float('inf'),
                     cycle_predicates: Collection[Predicate] = tuple(),
                     max_failed_cycles: int = 100,
+                    plant_solution: bool = True,
                     planted_solution: Optional[Mapping[Variable, int]] = None,
                     seed: Optional[int] = None,
                     ) -> BinaryQuadraticModel:
     """Generate a frustrated-loop problem.
 
-    A generic frustrated-loop (FL) problem is a sum of Hamiltonians, each generated
-    from a single "good" loop, as follows:
+    A generic frustrated-loop (FL) problem is a sum of Hamiltonians, each 
+    generated from a single loop, as follows:
 
     1. Generate a loop by random walking on the specified graph, ``graph``.
     2. If the cycle meets provided predicates, continue; if not, return to  step 1.
-    3. Choose one edge of the loop to be anti-ferromagnetic (an interaction value
-       of `+1` for the edge) and all others ferromagnetic (`-1`).
+    3. Choose one edge of the loop uniformly at random to be anti-ferromagnetic 
+       (AFM, coupling value of `1`) and all others ferromagnetic 
+       (`-1`). Or if :code:`plant_solution is False`, sample uniformly couplers
+       subject to the constraint that there are an odd number of AFM couplers.
     4. Add the loop's interactions to the FL problem.
        If at any time the absolute value of an interaction in the FL problem,
        accumulated on an edge over good loops, exceeds a given maximum, ``R``,
@@ -73,10 +79,17 @@ def frustrated_loop(graph: GraphLike,
         max_failed_cycles:
             Maximum number of failures to find a cycle before terminating.
 
+        plant_solution: 
+            Select frustrated loops with only 1 AFM coupler all 1 (and all -1) 
+            solutions are among the ground states. 
+
         planted_solution:
-            Other solutions with the same energy may exist, but the energy value
-            of the (possibly degenerate) ground state will hold. If None,
-            planted_solution is: ``{v: -1 for v in graph}``
+            A dictionary assigning variables to spin states.  When provided, and
+            :code:`planted_solution=True` spin states are relabeled so that the
+            variable assignment becomes a planted ground state in place of the 
+            all 1 solution.  
+            This option is deprecated; use of spin-reversal transforms is 
+            recommended for this purpose.
 
         seed: Random seed.
 
@@ -94,8 +107,7 @@ def frustrated_loop(graph: GraphLike,
         raise ValueError("R should be a positive integer")
     if max_failed_cycles <= 0:
         raise ValueError("max_failed_cycles should be a positive integer")
-    if planted_solution is None:
-        planted_solution = {v: -1 for v in nodes}
+    
     r = numpy.random.RandomState(seed)
 
     adj = {v: set() for v in nodes}
@@ -122,17 +134,16 @@ def frustrated_loop(graph: GraphLike,
             continue
         good_cycles += 1
 
-        # If its a good cycle, modify J with it, according to plated solution
-        cycle_J = {}
-        for i, c in enumerate(cycle):
-            u, v = cycle[i - 1], cycle[i]
-            J = -planted_solution[u]*planted_solution[v]
-            cycle_J[(u, v)] = J
-
-        # randomly select an edge and flip it
-        idx = r.randint(len(cycle))
-        cycle_J[(cycle[idx - 1], cycle[idx])] *= -1
-
+        if plant_solution:
+            # randomly select from all frustrated loops with one AFM edge
+            cycle_J = {(cycle[i - 1], cycle[i]) : -1 for i in range(len(cycle))}
+            idx = r.randint(len(cycle))
+            cycle_J[(cycle[idx - 1], cycle[idx])] = 1
+        else:
+            # randomly select from all frustrated loops (odd number of AFM edges)
+            cycle_J = {(cycle[i], cycle[i+1]) : -1 for i in range(len(cycle)-1)}
+            cycle_J[(cycle[-1],cycle[0])] = (1 - 2*(len(cycle_J) & 1))*math.prod(cycle_J.values())
+            
         # update the bqm
         bqm.add_interactions_from(cycle_J)
         for u, v in cycle_J:
@@ -143,6 +154,17 @@ def frustrated_loop(graph: GraphLike,
     if good_cycles < num_cycles:
         raise RuntimeError(f"number of found cycles, {good_cycles}, is below " 
                            f"requested {num_cycles}")
+
+    if planted_solution is not None:
+        warnings.warn("planted_solution is deprecated; use spin-reversal transforms: "
+                      "(1) bqm.flip_variable() for superficial reorientation of "
+                      "spin labels to match desired planting or "
+                      "(2) SpinReversalComposite for presentation of a randomized "
+                      "planted solution to some solver.",
+                      DeprecationWarning)
+        # A spin-reversal transform for a BQM with zero linear biases
+        for e in bqm.quadratic:
+            bqm.quadratic[e] = bqm.quadratic[e]*planted_solution[e[0]]*planted_solution[e[1]]
 
     return bqm
 

--- a/dimod/generators/satisfiability.py
+++ b/dimod/generators/satisfiability.py
@@ -31,7 +31,7 @@ __all__ = ["random_nae3sat", "random_2in4sat"]
 
 def _kmcsat_interactions(num_variables: int, k: int, num_clauses: int,
                          *,
-                         planted_solution: bool = False,
+                         plant_solution: bool = False,
                          seed: typing.Union[None, int, np.random.Generator] = None,
                          ) -> typing.Iterator[typing.Tuple[int, int, int]]:
     rng = np.random.default_rng(seed)
@@ -43,7 +43,7 @@ def _kmcsat_interactions(num_variables: int, k: int, num_clauses: int,
 
         # randomly assign the negations
         signs = 2 * rng.integers(0, 1, endpoint=True, size=k) - 1
-        while planted_solution and abs(sum(signs))>1:
+        while plant_solution and abs(sum(signs))>1:
             # Rejection sample until signs are compatible with an all 1 ground
             # state:
             signs = 2 * rng.integers(0, 1, endpoint=True, size=k) - 1
@@ -58,12 +58,12 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
                   k: int,
                   num_clauses: int,
                   *,
-                  planted_solution: bool = False,
+                  plant_solution: bool = False,
                   seed: typing.Union[None, int, np.random.Generator] = None,
                   ) -> BinaryQuadraticModel:
     """Generate a random k Max-Cut satisfiability problem as a binary quadratic model.
 
-    kMC-SAT [#]_ is an NP-complete problem class
+    kMC-SAT [#ZK]_ is an NP-complete problem class
     that consists in satisfying a number of
     clauses of ``k`` literals (variables, or their negations).
     Each clause should encode a max-cut problem over the clause literals.
@@ -79,7 +79,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
         num_variables: The number of variables in the problem.
         k: number of variables participating in the clause.
         num_clauses: The number of clauses. Each clause contains three literals.
-        planted_solution: Create literals uniformly subject to the constraint that the
+        plant_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states (satisfy all clauses).
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -95,11 +95,11 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
         For large problems planting of an all 1 solution can
         be achieved (in some special cases) without modification of the hardness
         qualities of the instance class. Planting of a not all 1 ground state
-        can be achieved with a spin-reversal transform without loss of generality. [#]_
-    .. [#] Lenka Zdeborova and Florent Krzakala,
+        can be achieved with a spin-reversal transform without loss of generality. [#DKR]_
+    .. [#ZK] Lenka Zdeborová and Florent Krzakala,
        "Quiet Planting in the Locked Constraint Satisfaction Problems",
        https://epubs.siam.org/doi/10.1137/090750755
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+    .. [#DKR] Adam Douglass, Andrew D. King & Jack Raymond,
        "Constructing SAT Filters with a Quantum Annealer",
        https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
     """
@@ -121,7 +121,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
 
     bqm = BinaryQuadraticModel(num_variables, Vartype.SPIN)
     bqm.add_quadratic_from(_kmcsat_interactions(num_variables, k, num_clauses,
-                                                planted_solution=planted_solution, seed=seed))
+                                                plant_solution=plant_solution, seed=seed))
 
     if labels:
         bqm.relabel_variables(dict(enumerate(labels)))
@@ -132,7 +132,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
 def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
                    num_clauses: int,
                    *,
-                   planted_solution: bool = False,
+                   plant_solution: bool = False,
                    seed: typing.Union[None, int, np.random.Generator] = None,
                    ) -> BinaryQuadraticModel:
     """Generate a random not-all-equal 3-satisfiability problem as a binary quadratic model.
@@ -150,7 +150,7 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
     bound matches the ground state energy in satisfiable instances. The number 
     of violated clauses is :math:`(H(s) - E_{SAT})/4`.
 
-    NAE3SAT problems have been studied with the D-Wave quantum annealer [#]_.
+    NAE3SAT problems have been studied with the D-Wave quantum annealer [#DKR]_.
 
     .. _NAE3SAT: https://en.wikipedia.org/wiki/Not-all-equal_3-satisfiability
 
@@ -158,7 +158,7 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
     Args:
         num_variables: The number of variables in the problem.
         num_clauses: The number of clauses. Each clause contains three literals.
-        planted_solution: Create literals uniformly subject to the constraint that the
+        plant_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states satisfying all clauses.
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -185,23 +185,23 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
         generality. Planting can significantly modify the hardness of 
         optimization problems.
 
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+    .. [#DKR] Adam Douglass, Andrew D. King & Jack Raymond,
        "Constructing SAT Filters with a Quantum Annealer",
        https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
 
     """
-    return random_kmcsat(variables, 3, num_clauses, planted_solution=planted_solution, seed=seed)
+    return random_kmcsat(variables, 3, num_clauses, plant_solution=plant_solution, seed=seed)
 
 
 def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
                    num_clauses: int,
                    *,
-                   planted_solution: bool = False,
+                   plant_solution: bool = False,
                    seed: typing.Union[None, int, np.random.Generator] = None,
                    ) -> BinaryQuadraticModel:
     """Generate a random 2-in-4 satisfiability problem as a binary quadratic model.
 
-    2-in-4 satisfiability [#]_ is an NP-complete problem class
+    2-in-4 satisfiability [#DKR]_ is an NP-complete problem class
     that consists in satisfying a number of conjunctive
     clauses of four literals (variables, or their negations).
     For valid solutions, two of the literals in each clause should ``+1`` and
@@ -217,7 +217,7 @@ def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
     Args:
         num_variables: The number of variables in the problem.
         num_clauses: The number of clauses. Each clause contains three literals.
-        planted_solution: Create literals uniformly subject to the constraint that the
+        plant_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states satisfying all clauses.
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -235,13 +235,13 @@ def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
         generality. Planting can significantly modify the hardness of 
         optimization problems. However, for large problems planting of a 
         solution can be achieved (in the SAT phase) without modification of the
-        hardness qualities of the instance class. [#]_ 
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+        hardness qualities of the instance class. [#ZK]_ 
+    .. [#DKR] Adam Douglass, Andrew D. King & Jack Raymond,
        "Constructing SAT Filters with a Quantum Annealer",
        https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
-    .. [#] Lenka Zdeborova and Florent Krzakala,
+    .. [#ZK] Lenka Zdeborová and Florent Krzakala,
        "Quiet Planting in the Locked Constraint Satisfaction Problems",
        https://epubs.siam.org/doi/10.1137/090750755
 
     """
-    return random_kmcsat(variables, 4, num_clauses, planted_solution=planted_solution, seed=seed)
+    return random_kmcsat(variables, 4, num_clauses, plant_solution=plant_solution, seed=seed)

--- a/dimod/generators/satisfiability.py
+++ b/dimod/generators/satisfiability.py
@@ -31,11 +31,12 @@ __all__ = ["random_nae3sat", "random_2in4sat"]
 
 def _kmcsat_interactions(num_variables: int, k: int, num_clauses: int,
                          *,
-                         is_planted: bool = True,
+                         is_planted: bool = False,
                          seed: typing.Union[None, int, np.random.Generator] = None,
                          ) -> typing.Iterator[typing.Tuple[int, int, int]]:
     rng = np.random.default_rng(seed)
 
+    # Use of for and while loops is for clarity, optimizations are possible.
     for _ in range(num_clauses):
         # randomly select the variables
         variables = rng.choice(num_variables, k, replace=False)
@@ -57,7 +58,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
                   k: int,
                   num_clauses: int,
                   *,
-                  is_planted: bool = True,
+                  is_planted: bool = False,
                   seed: typing.Union[None, int, np.random.Generator] = None,
                   ) -> BinaryQuadraticModel:
     """Generate a random k Max-Cut satisfiability problem as a binary quadratic model.
@@ -130,7 +131,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
 def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
                    num_clauses: int,
                    *,
-                   is_planted: bool = True,
+                   is_planted: bool = False,
                    seed: typing.Union[None, int, np.random.Generator] = None,
                    ) -> BinaryQuadraticModel:
     """Generate a random not-all-equal 3-satisfiability problem as a binary quadratic model.
@@ -185,7 +186,7 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
         optimization problems.
 
     """
-    return random_kmcsat(variables, 3, num_clauses, seed=seed, is_planted=is_planted)
+    return random_kmcsat(variables, 3, num_clauses, is_planted=is_planted, seed=seed)
 
 
 def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
@@ -237,4 +238,4 @@ def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
        https://epubs.siam.org/doi/10.1137/090750755
 
     """
-    return random_kmcsat(variables, 4, num_clauses, seed=seed, is_planted=is_planted)
+    return random_kmcsat(variables, 4, num_clauses, is_planted=is_planted, seed=seed)

--- a/dimod/generators/satisfiability.py
+++ b/dimod/generators/satisfiability.py
@@ -31,7 +31,7 @@ __all__ = ["random_nae3sat", "random_2in4sat"]
 
 def _kmcsat_interactions(num_variables: int, k: int, num_clauses: int,
                          *,
-                         is_planted: bool = False,
+                         planted_solution: bool = False,
                          seed: typing.Union[None, int, np.random.Generator] = None,
                          ) -> typing.Iterator[typing.Tuple[int, int, int]]:
     rng = np.random.default_rng(seed)
@@ -43,7 +43,7 @@ def _kmcsat_interactions(num_variables: int, k: int, num_clauses: int,
 
         # randomly assign the negations
         signs = 2 * rng.integers(0, 1, endpoint=True, size=k) - 1
-        while is_planted and abs(sum(signs))>1:
+        while planted_solution and abs(sum(signs))>1:
             # Rejection sample until signs are compatible with an all 1 ground
             # state:
             signs = 2 * rng.integers(0, 1, endpoint=True, size=k) - 1
@@ -58,31 +58,28 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
                   k: int,
                   num_clauses: int,
                   *,
-                  is_planted: bool = False,
+                  planted_solution: bool = False,
                   seed: typing.Union[None, int, np.random.Generator] = None,
                   ) -> BinaryQuadraticModel:
     """Generate a random k Max-Cut satisfiability problem as a binary quadratic model.
 
     kMC-SAT [#]_ is an NP-complete problem class
-    that consists in satisfying a number of conjunctive
+    that consists in satisfying a number of
     clauses of ``k`` literals (variables, or their negations).
     Each clause should encode a max-cut problem over the clause literals.
     
-    Each clause contributes -:code:`k//2' to the energy when the clause is 
+    Each clause contributes -:code:`k//2` to the energy when the clause is 
     satisfied, and at least 0 when unsatisfied. The energy :math:`H(s)` for a 
     spin assignment :math:`s` is thus lower bounded by :math:`E_{SAT}=-`:code:`k//2 * num_clauses`, 
     this lower bound matches the ground state energy in satisfiable instances. 
     For k>3, energy penalties per clause violation are non-uniform.
 
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
-       "Constructing SAT Filters with a Quantum Annealer",
-       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
 
     Args:
         num_variables: The number of variables in the problem.
         k: number of variables participating in the clause.
         num_clauses: The number of clauses. Each clause contains three literals.
-        is_planted: Create literals uniformly subject to the constraint that the
+        planted_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states (satisfy all clauses).
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -93,14 +90,18 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
         clauses *with replacement* which can result in collisions. However,
         collisions are allowed in standard problem definitions, are absent with
         high probability in interesting cases, and are almost always harmless
-        when they do occur. For large problems planting of an all 1 solution can
+        when they do occur. 
+
+        For large problems planting of an all 1 solution can
         be achieved (in some special cases) without modification of the hardness
         qualities of the instance class. Planting of a not all 1 ground state
-        can be achieved with a spin-reversal transform without loss of generality.
+        can be achieved with a spin-reversal transform without loss of generality. [#]_
     .. [#] Lenka Zdeborova and Florent Krzakala,
        "Quiet Planting in the Locked Constraint Satisfaction Problems",
        https://epubs.siam.org/doi/10.1137/090750755
-
+    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+       "Constructing SAT Filters with a Quantum Annealer",
+       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
     """
     if isinstance(variables, collections.abc.Sequence):
         num_variables = len(variables)
@@ -108,19 +109,19 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
     else:
         num_variables = variables
         labels = None
-    if k < 1:
-        raise ValueError("Number of variables per clause must be atleast 1")
-    elif k > num_variables:
-        raise ValueError(f"Number of variables per clause must be at most {num_variables}")
+        
+    if num_variables < 1:
+        raise ValueError("number of variables must be non-negative")
+    elif k < 1:
+        raise ValueError("number of variables must be non-negative")
+    elif num_clauses < 0:
+        raise ValueError("{num_clauses} must be non-negative")
     elif num_variables < k:
-        raise ValueError(f"must use at least {k} variables")
-
-    if num_clauses < 0:
-        raise ValueError("num_clauses must be non-negative")
+        raise ValueError(f"must use at least {k}<= number of variables")
 
     bqm = BinaryQuadraticModel(num_variables, Vartype.SPIN)
     bqm.add_quadratic_from(_kmcsat_interactions(num_variables, k, num_clauses,
-                                                is_planted=is_planted, seed=seed))
+                                                planted_solution=planted_solution, seed=seed))
 
     if labels:
         bqm.relabel_variables(dict(enumerate(labels)))
@@ -131,7 +132,7 @@ def random_kmcsat(variables: typing.Union[int, typing.Sequence[dimod.typing.Vari
 def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
                    num_clauses: int,
                    *,
-                   is_planted: bool = False,
+                   planted_solution: bool = False,
                    seed: typing.Union[None, int, np.random.Generator] = None,
                    ) -> BinaryQuadraticModel:
     """Generate a random not-all-equal 3-satisfiability problem as a binary quadratic model.
@@ -144,7 +145,7 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
     are valid for each clause.
 
     Each clause contributes -1 to the energy when the clause is satisfied,
-    and +3 when unsatisfied. The energy :math:`H(s)` for a spin assignment :math:`s` 
+    and +3 when unsatisfied. The energy :math:`H(s)` for a spin assignment :math:`s`
     is thus lower bounded by :math:`E_{SAT}=-`:code:`num_clauses`, this lower 
     bound matches the ground state energy in satisfiable instances. The number 
     of violated clauses is :math:`(H(s) - E_{SAT})/4`.
@@ -153,14 +154,11 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
 
     .. _NAE3SAT: https://en.wikipedia.org/wiki/Not-all-equal_3-satisfiability
 
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
-       "Constructing SAT Filters with a Quantum Annealer",
-       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
-
+    
     Args:
         num_variables: The number of variables in the problem.
         num_clauses: The number of clauses. Each clause contains three literals.
-        is_planted: Create literals uniformly subject to the constraint that the
+        planted_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states satisfying all clauses.
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -180,19 +178,25 @@ def random_nae3sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
         clauses *with replacement* which can result in collisions. However,
         collisions are allowed in standard problem definitions, are absent with
         high probability in interesting cases, and are almost always harmless
-        when they do occur. Planting of a not all 1 solution state
+        when they do occur. 
+
+        Planting of a not all 1 solution state
         can be achieved with a spin-reversal transform without loss of 
-        generality, planting can significantly modify the hardness of 
+        generality. Planting can significantly modify the hardness of 
         optimization problems.
 
+    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+       "Constructing SAT Filters with a Quantum Annealer",
+       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
+
     """
-    return random_kmcsat(variables, 3, num_clauses, is_planted=is_planted, seed=seed)
+    return random_kmcsat(variables, 3, num_clauses, planted_solution=planted_solution, seed=seed)
 
 
 def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Variable]],
                    num_clauses: int,
                    *,
-                   is_planted: bool = False,
+                   planted_solution: bool = False,
                    seed: typing.Union[None, int, np.random.Generator] = None,
                    ) -> BinaryQuadraticModel:
     """Generate a random 2-in-4 satisfiability problem as a binary quadratic model.
@@ -209,14 +213,11 @@ def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
     this lower bound matches the ground state energy in satisfiable instances. 
     The number of violated clauses is at most :math:`(H(s) - E_{SAT})/2`.
 
-    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
-       "Constructing SAT Filters with a Quantum Annealer",
-       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
-
+    
     Args:
         num_variables: The number of variables in the problem.
         num_clauses: The number of clauses. Each clause contains three literals.
-        is_planted: Create literals uniformly subject to the constraint that the
+        planted_solution: Create literals uniformly subject to the constraint that the
             all 1 (and all -1) are ground states satisfying all clauses.
         seed: Passed to :func:`numpy.random.default_rng()`, which is used
             to generate the clauses and the variable negations.
@@ -227,15 +228,20 @@ def random_2in4sat(variables: typing.Union[int, typing.Sequence[dimod.typing.Var
         clauses *with replacement* which can result in collisions. However,
         collisions are allowed in standard problem definitions, are absent with
         high probability in interesting cases, and are almost always harmless
-        when they do occur. Planting of a not all 1 ground state
+        when they do occur. 
+
+        Planting of a not all 1 ground state
         can be achieved with a spin-reversal transform without loss of 
-        generality, planting can significantly modify the hardness of 
+        generality. Planting can significantly modify the hardness of 
         optimization problems. However, for large problems planting of a 
         solution can be achieved (in the SAT phase) without modification of the
         hardness qualities of the instance class. [#]_ 
+    .. [#] Adam Douglass, Andrew D. King & Jack Raymond,
+       "Constructing SAT Filters with a Quantum Annealer",
+       https://link.springer.com/chapter/10.1007/978-3-319-24318-4_9
     .. [#] Lenka Zdeborova and Florent Krzakala,
        "Quiet Planting in the Locked Constraint Satisfaction Problems",
        https://epubs.siam.org/doi/10.1137/090750755
 
     """
-    return random_kmcsat(variables, 4, num_clauses, is_planted=is_planted, seed=seed)
+    return random_kmcsat(variables, 4, num_clauses, planted_solution=planted_solution, seed=seed)

--- a/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
+++ b/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
@@ -1,4 +1,9 @@
 ---
 features:
   - |
-    Add ``planted_solution`` keyword argument to ``dimod.generators.random_nae3sat()`` and ``dimod.generators.random_2in4sat()`` functions.
+    Add ``plant_solution`` keyword argument to ``dimod.generators.random_nae3sat()``, ``dimod.generators.random_2in4sat()`` and ``dimod.generators.frustrated_loop`` functions.
+    Add 
+deprecations:
+  - |
+    Deprecated ``planted_solution`` keyword argument in ``dimod.generators.frustrated_loop``.
+    

--- a/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
+++ b/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``planted_solution`` keyword argument to ``dimod.generators.random_nae3sat()`` and ``dimod.generators.random_2in4sat()`` functions.

--- a/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
+++ b/releasenotes/notes/planted-sat-f0200528096b73e3.yaml
@@ -5,5 +5,5 @@ features:
     Add 
 deprecations:
   - |
-    Deprecated ``planted_solution`` keyword argument in ``dimod.generators.frustrated_loop``.
+    Deprecated ``planted_solution`` keyword argument in ``dimod.generators.frustrated_loop()``.
     

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -960,13 +960,11 @@ class TestSatisfiability(unittest.TestCase):
         self.assertEqual(np.min(all_energies),E_SAT)
         self.assertEqual(all_energies[0],E_SAT) #all -1 state
         self.assertEqual(all_energies[-1],E_SAT) #all 1 state
-        disp(all_energies)
         
         num_clauses = 12 #Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be SAT by chance.
         bqm = dimod.generators.random_2in4sat(num_var, num_clauses, seed=seed, is_planted=True)
         E_SAT = - 2*num_clauses;
         all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
-        disp(all_energies)
         self.assertEqual(np.min(all_energies),E_SAT)
         self.assertEqual(all_energies[0],E_SAT) #all -1 state
         self.assertEqual(all_energies[-1],E_SAT) #all 1 state

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -954,7 +954,7 @@ class TestSatisfiability(unittest.TestCase):
         num_var = 6 # test is 2^num_var, keep small.
         num_clauses = 24 #Deep in UNSAT phase (num_clause/num_var>>2.1), very unlikely to be SAT by chance.
         
-        bqm = dimod.generators.random_nae3sat(num_var, num_clauses, seed=seed, is_planted=True)
+        bqm = dimod.generators.random_nae3sat(num_var, num_clauses, is_planted=True)
         E_SAT = - num_clauses;
         all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
         self.assertEqual(np.min(all_energies),E_SAT)
@@ -962,7 +962,7 @@ class TestSatisfiability(unittest.TestCase):
         self.assertEqual(all_energies[-1],E_SAT) #all 1 state
         
         num_clauses = 12 #Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be SAT by chance.
-        bqm = dimod.generators.random_2in4sat(num_var, num_clauses, seed=seed, is_planted=True)
+        bqm = dimod.generators.random_2in4sat(num_var, num_clauses, is_planted=True)
         E_SAT = - 2*num_clauses;
         all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
         self.assertEqual(np.min(all_energies),E_SAT)

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -16,6 +16,7 @@ import unittest
 import unittest.mock
 
 import dimod
+import itertools
 
 import numpy as np
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -949,25 +949,34 @@ class TestSatisfiability(unittest.TestCase):
                 self.assertEqual(sum(ss.first.sample.values()), 0)
                 
     def test_planting_sat(self):
-        #NP-hard to prove successful planting (rule out lower energies), this test
-        #could fail coincidentally, but unlikely.        
-        num_var = 6 # test is 2^num_var, keep small.
-        num_clauses = 24 #Deep in UNSAT phase (num_clause/num_var>>2.1), very unlikely to be SAT by chance.
+        # NP-hard to prove successful planting (rule out lower energies), this
+        # test could fail coincidentally, but unlikely.        
+
+        # test run time is O(2^num_var), keep num_var small.
+        num_var = 6
+        all_spin_assignments = np.array(list(itertools.product([-1, 1], repeat=num_var)))
+
+        # NAE3SAT
+        # Deep in UNSAT phase (num_clause/num_var>>2.1), very unlikely to be
+        # SAT by chance.
+        num_clauses = 24 
+        bqm = dimod.generators.random_nae3sat(num_var, num_clauses, planted_solution=True)
+        E_SAT = - num_clauses
+        all_energies = bqm.energies((all_spin_assignments, bqm.variables))
+        self.assertEqual(np.min(all_energies), E_SAT)
+        self.assertEqual(all_energies[0], E_SAT) #all -1 state
+        self.assertEqual(all_energies[-1], E_SAT) #all 1 state
         
-        bqm = dimod.generators.random_nae3sat(num_var, num_clauses, is_planted=True)
-        E_SAT = - num_clauses;
-        all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
-        self.assertEqual(np.min(all_energies),E_SAT)
-        self.assertEqual(all_energies[0],E_SAT) #all -1 state
-        self.assertEqual(all_energies[-1],E_SAT) #all 1 state
-        
-        num_clauses = 12 #Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be SAT by chance.
-        bqm = dimod.generators.random_2in4sat(num_var, num_clauses, is_planted=True)
-        E_SAT = - 2*num_clauses;
-        all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
-        self.assertEqual(np.min(all_energies),E_SAT)
-        self.assertEqual(all_energies[0],E_SAT) #all -1 state
-        self.assertEqual(all_energies[-1],E_SAT) #all 1 state
+        # 2in4SAT
+        # Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be
+        # SAT by chance.
+        num_clauses = 12
+        bqm = dimod.generators.random_2in4sat(num_var, num_clauses, planted_solution=True)
+        E_SAT = - 2*num_clauses
+        all_energies = bqm.energies((all_spin_assignments, bqm.variables))
+        self.assertEqual(np.min(all_energies), E_SAT)
+        self.assertEqual(all_energies[0], E_SAT) #all -1 state
+        self.assertEqual(all_energies[-1], E_SAT) #all 1 state
         
     def test_labels(self):
         self.assertEqual(dimod.generators.random_2in4sat(10, 1).variables, range(10))

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -385,23 +385,25 @@ class TestFCL(unittest.TestCase):
         num_var = 3
         triangle = nx.Graph()
         triangle.add_edges_from({(u, v) for u in range(num_var) for v in range(u)})
-        
-        bqm = dimod.generators.frustrated_loop(triangle, 1, plant_solution=False)
         all_spin_assignments = np.array(list(itertools.product([-1, 1], repeat=num_var)))
-        all_energies = bqm.energies((all_spin_assignments,bqm.variables))
-        E_SAT = -1
-        self.assertLessEqual(E_SAT,np.min(all_energies))
-        self.assertEqual(all_energies[0],E_SAT) # All -1 planted
-        self.assertEqual(all_energies[-1],E_SAT) # All 1 planted
+        for plant_solution in [True, False]:
+            bqm = dimod.generators.frustrated_loop(triangle, 1, plant_solution=plant_solution)
+            all_energies = bqm.energies((all_spin_assignments,bqm.variables))
+            E_SAT = -1
+            self.assertLessEqual(E_SAT,np.min(all_energies))
+            self.assertEqual(all_energies[0],E_SAT) # All -1 planted
+            self.assertEqual(all_energies[-1],E_SAT) # All 1 planted
         
         
                         
     def test_planted_solution(self):
-        # This will be deprecated
+        # This tests a deprecated workflow,
+        # test_plant_solution provides a generalized test for successful planting.
         G = self.G
 
         planted = {v:v%2*2-1 for v in G}
-        bqm = dimod.generators.frustrated_loop(G, 10, planted_solution=planted)
+        with self.assertWarns(DeprecationWarning):
+            bqm = dimod.generators.frustrated_loop(G, 10, planted_solution=planted)
 
         inv_solution = {k:-v for k,v in planted.items()}
         self.assertEqual(bqm.energy(planted),bqm.energy(inv_solution))

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -946,7 +946,30 @@ class TestSatisfiability(unittest.TestCase):
                 # in the ground state they should not be all equal
                 ss = dimod.ExactSolver().sample(bqm)
                 self.assertEqual(sum(ss.first.sample.values()), 0)
-
+                
+    def test_planting_sat(self):
+        #NP-hard to prove successful planting (rule out lower energies), this test
+        #could fail coincidentally, but unlikely.        
+        num_var = 6 # test is 2^num_var, keep small.
+        num_clauses = 24 #Deep in UNSAT phase (num_clause/num_var>>2.1), very unlikely to be SAT by chance.
+        
+        bqm = dimod.generators.random_nae3sat(num_var, num_clauses, seed=seed, is_planted=True)
+        E_SAT = - num_clauses;
+        all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
+        self.assertEqual(np.min(all_energies),E_SAT))
+        self.assertEqual(all_energies[0],E_SAT) #all -1 state
+        self.assertEqual(all_energies[-1],E_SAT)) #all 1 state
+        disp(all_energies)
+        
+        num_clauses = 12 #Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be SAT by chance.
+        bqm = dimod.generators.random_2in4sat(num_var, num_clauses, seed=seed, is_planted=True)
+        E_SAT = - 2*num_clauses;
+        all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
+        disp(all_energies)
+        self.assertEqual(np.min(all_energies),E_SAT))
+        self.assertEqual(all_energies[0],E_SAT) #all -1 state
+        self.assertEqual(all_energies[-1],E_SAT)) #all 1 state
+        
     def test_labels(self):
         self.assertEqual(dimod.generators.random_2in4sat(10, 1).variables, range(10))
         self.assertEqual(dimod.generators.random_2in4sat('abdef', 1).variables, 'abdef')

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -957,9 +957,9 @@ class TestSatisfiability(unittest.TestCase):
         bqm = dimod.generators.random_nae3sat(num_var, num_clauses, seed=seed, is_planted=True)
         E_SAT = - num_clauses;
         all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
-        self.assertEqual(np.min(all_energies),E_SAT))
+        self.assertEqual(np.min(all_energies),E_SAT)
         self.assertEqual(all_energies[0],E_SAT) #all -1 state
-        self.assertEqual(all_energies[-1],E_SAT)) #all 1 state
+        self.assertEqual(all_energies[-1],E_SAT) #all 1 state
         disp(all_energies)
         
         num_clauses = 12 #Deep in UNSAT phase (num_clause/num_var>>0.9), very unlikely to be SAT by chance.
@@ -967,9 +967,9 @@ class TestSatisfiability(unittest.TestCase):
         E_SAT = - 2*num_clauses;
         all_energies = bqm.energies((np.array(list(itertools.product([-1,1], repeat=num_var))),bqm.variables))
         disp(all_energies)
-        self.assertEqual(np.min(all_energies),E_SAT))
+        self.assertEqual(np.min(all_energies),E_SAT)
         self.assertEqual(all_energies[0],E_SAT) #all -1 state
-        self.assertEqual(all_energies[-1],E_SAT)) #all 1 state
+        self.assertEqual(all_energies[-1],E_SAT) #all 1 state
         
     def test_labels(self):
         self.assertEqual(dimod.generators.random_2in4sat(10, 1).variables, range(10))


### PR DESCRIPTION
Added planting to random_nae3sat, random_2in4sat, and random_kmcsat problem generators.
Planting in random constraint satisfaction problems is useful for benchmarking, particularly in the SAT phase - problems can be generated with a guaranteed ground state without impacting hardness properties of the problem class. This is useful in benchmarking where knowing the ground state allows unambiguous tests of optimality. Planting is also important with respect to the SAT filter application.
Minor changes to docstrings independent of the planting option are also implemented.