### PR TITLE
Use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=46.4.0",
     "wheel",
     "Cython>=0.29.21,<3.0",
-    'numpy~=1.21.0',
+    'oldest-supported-numpy',
 ]
 build-backend = "setuptools.build_meta"
 

--- a/releasenotes/notes/oldest-supported-numpy-56de85613d641810.yaml
+++ b/releasenotes/notes/oldest-supported-numpy-56de85613d641810.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Build with `oldest-supported-numpy <https://github.com/scipy/oldest-supported-numpy>`_ for compatibility.
+    See `#208 <https://github.com/dwavesystems/dwave-ocean-sdk/issues/208>`_.


### PR DESCRIPTION
Although we need some newer features of NumPy at runtime, we can safely build against the older headers. I was not able to detect any performance regressions from doing so.

See https://github.com/dwavesystems/dwave-ocean-sdk/issues/208