### PR TITLE
Speed up `QM.add_linear_from()`

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
         "python -m pip install -r requirements.txt",
         "python -m pip install parameterized",
         "python setup.py build",
-        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+        "DIMOD_NUM_BUILD_JOBS=20 PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
     "branches": ["main"],
     "environment_type": "virtualenv",

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -462,17 +462,38 @@ class QuadraticModel(QuadraticViewsMixin):
         """
         add_linear = self.data.add_linear
 
-        if default_vartype is not None:
-            default_vartype = as_vartype(default_vartype, extended=True)
-
         if isinstance(linear, Mapping):
             linear = linear.items()
 
-        for v, bias in linear:
-            add_linear(v, bias,
-                       default_vartype=default_vartype,
-                       default_lower_bound=default_lower_bound,
-                       default_upper_bound=default_upper_bound)
+        # checking whether the keyword arguments are present actually
+        # results in a pretty shocking performance difference, almost x2
+        # for when they are not there
+        # I did try using functools.partial() as well
+        if default_vartype is None:
+            if default_lower_bound is None and default_upper_bound is None:
+                for v, bias in linear:
+                    add_linear(v, bias)
+            else:
+                for v, bias in linear:
+                    add_linear(v, bias,
+                               default_lower_bound=default_lower_bound,
+                               default_upper_bound=default_upper_bound,
+                               )
+        else:
+            default_vartype = as_vartype(default_vartype, extended=True)
+
+            if default_lower_bound is None and default_upper_bound is None:
+                for v, bias in linear:
+                    add_linear(v, bias,
+                               default_vartype=default_vartype,
+                               )
+            else:
+                for v, bias in linear:
+                    add_linear(v, bias,
+                               default_vartype=default_vartype,
+                               default_lower_bound=default_lower_bound,
+                               default_upper_bound=default_upper_bound,
+                               )
 
     @forwarding_method
     def add_quadratic(self, u: Variable, v: Variable, bias: Bias):

--- a/releasenotes/notes/fix-qm.add_linear-performance-regression-8d97458c4a494240.yaml
+++ b/releasenotes/notes/fix-qm.add_linear-performance-regression-8d97458c4a494240.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix a performance regression to ``QuadraticModel.add_linear_from()`` introduced by
+    `#1170 <https://github.com/dwavesystems/dimod/pull/1170>`_ as part of
+    the `0.11.0 <https://github.com/dwavesystems/dimod/releases/tag/0.11.0>`_
+    release.


### PR DESCRIPTION
77fd6af995c2b940dedc4975d320c690aa019b31 (see https://github.com/dwavesystems/dimod/pull/1170) introduced a performance regression. This commit fixes it.

Comparing 0.10.17 to 0.11.0
```
+        311±10μs         646±30μs     2.08  qm.TimeAddLinearFrom.time_add_linear_from(<class 'int'>, <class 'dict'>)
+        322±20μs         630±20μs     1.95  qm.TimeAddLinearFrom.time_add_linear_from(<class 'int'>, <class 'list'>)
      1.07±0.04ms       1.69±0.2ms    ~1.57  qm.TimeAddLinearFrom.time_add_linear_from(<class 'str'>, <class 'dict'>)
+     1.06±0.03ms      1.41±0.04ms     1.32  qm.TimeAddLinearFrom.time_add_linear_from(<class 'str'>, <class 'list'>)
```
Comparing 0.10.17 to this commit
```
         311±10μs        295±0.8μs     0.95  qm.TimeAddLinearFrom.time_add_linear_from(<class 'int'>, <class 'dict'>)
         322±20μs          290±4μs    ~0.90  qm.TimeAddLinearFrom.time_add_linear_from(<class 'int'>, <class 'list'>)
-     1.07±0.04ms         971±10μs     0.90  qm.TimeAddLinearFrom.time_add_linear_from(<class 'str'>, <class 'dict'>)
      1.06±0.03ms         974±20μs     0.91  qm.TimeAddLinearFrom.time_add_linear_from(<class 'str'>, <class 'list'>)
```

there are other similar patterns we could do for `add_quadratic_from()` but in that case the binary search for insertion dominates for moderately sized models