### PR TITLE
Speed up `QM.from_file()`

### DIFF
--- a/benchmarks/qm.py
+++ b/benchmarks/qm.py
@@ -14,6 +14,8 @@
 
 import dimod
 
+import itertools
+
 
 class TimeAddLinearFrom:
     params = ([str, int], [dict, list])
@@ -37,3 +39,28 @@ class TimeAddVariablesFrom:
 
     def time_add_variables_from(self, *args):
         self.qm.add_variables_from('BINARY', self.variables)
+
+
+class TimeFromFile:
+
+    dense = dimod.QM()
+    dense.add_variables_from('BINARY', range(2500))
+    dense.add_quadratic_from((u, v, 1) for u, v in itertools.combinations(dense.variables, 2))
+
+    dense_fp = dense.to_file()
+
+    # ideally this would be more determistic than just specifying the seed, but
+    # this is a lot easier.
+    sparse = dimod.QM.from_bqm(dimod.generators.gnm_random_bqm(5000, 5000, 'SPIN', random_state=42))
+
+    sparse_fp = sparse.to_file()
+
+    def setup(self):
+        self.dense_fp.seek(0)
+        self.sparse_fp.seek(0)
+
+    def time_from_file_dense(self):
+        dimod.QM.from_file(self.dense_fp)
+
+    def time_from_file_sparse(self):
+        dimod.QM.from_file(self.sparse_fp)

--- a/dimod/libcpp.pxd
+++ b/dimod/libcpp.pxd
@@ -83,6 +83,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         void add_quadratic(index_type, index_type, bias_type) except +
         void add_quadratic[T](const T dense[], index_type)
         void add_quadratic[ItRow, ItCol, ItBias](ItRow, ItCol, ItBias, index_type) except +
+        void add_quadratic_back(index_type, index_type, bias_type)
         index_type add_variable()
         const_quadratic_iterator cbegin_quadratic()
         const_quadratic_iterator cend_quadratic()
@@ -133,6 +134,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
             bint operator!=(const_quadratic_iterator&)
 
         void add_quadratic(index_type, index_type, bias_type) except +
+        void add_quadratic_back(index_type, index_type, bias_type)
         index_type add_variable(cppVartype) except+
         index_type add_variable(cppVartype, bias_type, bias_type) except +
         const_quadratic_iterator cbegin_quadratic()

--- a/releasenotes/notes/speed-up-qm.from_file-f843fffd8928d4e6.yaml
+++ b/releasenotes/notes/speed-up-qm.from_file-f843fffd8928d4e6.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add ``dimod::QuadraticModel::add_quadratic_back()`` and
+    ``dimod::BinaryQuadraticModel::add_quadratic_back()`` methods in C++ code.
+  - |
+    Improve the performance of ``QuadraticModel.from_file()``, which also
+    improves the performance of ``ConstrainedQuadraticModel.from_file()``.


### PR DESCRIPTION
I hate the duplicated code, but we need to do it this way to maintain binary compatibility, see https://github.com/dwavesystems/dimod/pull/1193.

Gives ~2x speed up on the benchmark problems. Will get a bigger speedup on larger problems.