### PR TITLE
Support numpy>=1.17.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
     parameters:
       python-version:
         type: string
-      numpy-version:
+      dependencies:
         type: string
 
     docker:
@@ -269,9 +269,8 @@ jobs:
           command: |
             python -m venv env
             . env/bin/activate
-            pip install -r requirements.txt
             pip install dimod --no-index -f dist/ --force-reinstall --no-deps
-            pip install 'numpy<< parameters.numpy-version >>' --upgrade --only-binary=numpy
+            pip install << parameters.dependencies >> --upgrade --only-binary=numpy
       - run: &unix-run-tests
           name: run tests
           command: |
@@ -410,20 +409,18 @@ workflows:
       - test-codecov
       - test-doctest
       - test-linux:
-          name: test-linux-numpy<< matrix.numpy-version >>-py<< matrix.python-version >>
+          name: test-linux-<< matrix.dependencies >>-py<< matrix.python-version >>
           requires:
             - build-linux
           matrix:
             parameters:
-              # test the lowest numpy version and the highest minor of each
-              # currently deployed
-              numpy-version: [==1.20.0, ~=1.21.0, ~=1.22.0]
+              # test the lowest supported numpy and the latest
+              dependencies: [oldest-supported-numpy, numpy]
               python-version: *python-versions
             exclude:
-              - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
-                python-version: 3.10.0
-              - numpy-version: ~=1.22.0  # NumPy 1.22 does not support 3.7
-                python-version: 3.7.9
+              # we don't support 1.14.5, the oldest version for Python 3.7.9
+              - python-version: 3.7.9
+                dependencies: oldest-supported-numpy
       - test-linux-cpp11
       - test-osx:
           name: test-osx-py<< matrix.python-version >>

--- a/releasenotes/notes/loosen-numpy-ae59b80981918338.yaml
+++ b/releasenotes/notes/loosen-numpy-ae59b80981918338.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Expand supported NumPy version range to ``numpy>=1.17.3,<2.0.0``

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,9 @@ setup(
         'dimod/include/',
         ],
     install_requires=[
-        'numpy>=1.20.0,<2.0.0',
+        # this is the oldest supported NumPy on Python 3.8, we cannot
+        # support the oldest for 3.7, 1.14.5
+        'numpy>=1.17.3,<2.0.0',
         ],
     # we use the generic 'all' so that in the future we can add or remove
     # packages without breaking things


### PR DESCRIPTION
This makes it easier for packages that depend on dimod to use `oldest-supported-numpy`.

The issue is when a package specifies say `dimod==0.11.0,oldest-supported-numpy` in their pyproject.toml, the pip install fails because dimod requires `numpy>=1.20.0` at runtime.
E.g. https://app.circleci.com/pipelines/github/dwavesystems/dwave-preprocessing/83/workflows/1bd72543-e11d-463d-a56e-5cdcad38f3c9/jobs/2368

So we loosen the range as much as possible. Unfortunately, the oldest supported numpy for Python 3.7 (1.14.5) is missing some pretty key stuff, like `default_rng`. So it's not really practical to support it. That means that [dwave-preprocessing](https://github.com/dwavesystems/dwave-preprocessing) will need to do something like
```
    'numpy==1.17.3;python_version<"3.8"',
    'oldest-supported-numpy;python_version>="3.8"',
```
in its `pyproject.toml`. At least until we can drop Python 3.7 on [June 27 2023](https://endoflife.date/python).

See also https://github.com/dwavesystems/dwave-ocean-sdk/issues/208