### PR TITLE
Expose C++ QuadraticModelBase::energy() to Cython level

### DIFF
--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -423,7 +423,7 @@ class QuadraticModelBase {
      * `num_variables()` long.
      */
     template <class Iter>  // todo: allow different return types
-    bias_type energy(Iter sample_start) {
+    bias_type energy(Iter sample_start) const {
         bias_type en = offset();
 
         for (index_type u = 0; u < static_cast<index_type>(num_variables()); ++u) {
@@ -451,7 +451,7 @@ class QuadraticModelBase {
      * `num_variables()` long.
      */
     template <class T>
-    bias_type energy(const std::vector<T>& sample) {
+    bias_type energy(const std::vector<T>& sample) const {
         // todo: check length?
         return energy(sample.cbegin());
     }

--- a/dimod/libcpp.pxd
+++ b/dimod/libcpp.pxd
@@ -88,6 +88,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         const_quadratic_iterator cbegin_quadratic()
         const_quadratic_iterator cend_quadratic()
         void change_vartype(cppVartype)
+        bias_type energy[Iter](Iter sample_start)
         bint is_linear()
         bias_type& linear(index_type)
         const bias_type lower_bound(index_type)
@@ -140,6 +141,7 @@ cdef extern from "dimod/quadratic_model.h" namespace "dimod" nogil:
         const_quadratic_iterator cbegin_quadratic()
         void change_vartype(cppVartype, index_type) except +
         const_quadratic_iterator cend_quadratic()
+        bias_type energy[Iter](Iter sample_start)
         bint is_linear()
         bias_type& linear(index_type)
         const bias_type& lower_bound(index_type)

--- a/releasenotes/notes/cppbqm-energy-d8bf4cd3632b2c0c.yaml
+++ b/releasenotes/notes/cppbqm-energy-d8bf4cd3632b2c0c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``dimod::QuadraticModelBase::energy()`` method to ``dimod/libcpp.pxd``
+    for Cython access.


### PR DESCRIPTION
Needed to resolve the CI failures in https://github.com/dwavesystems/dwave-samplers/pull/24.