### PR TITLE
Repair windows wheels using delvewheel (in cibw build job)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             python3 -m venv env
             . env/bin/activate
             pip install pip --upgrade
-            pip install cibuildwheel==2.6.0
+            pip install cibuildwheel==2.8.0
             cibuildwheel --output-dir dist
       - save_cache: &build-linux-save-cache
           paths:
@@ -134,7 +134,7 @@ jobs:
           name: build wheels
           command: |
             python -m pip install pip --upgrade
-            python -m pip install cibuildwheel==2.6.0
+            python -m pip install cibuildwheel==2.8.0
             python -m cibuildwheel --output-dir dist
       - store_artifacts: *store-artifacts
       - persist_to_workspace: *persist-to-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,9 @@ jobs:
       <<: *global-environment
       CIBW_PROJECT_REQUIRES_PYTHON: ~=<< parameters.python-version>>
       CIBW_ARCHS_WINDOWS: AMD64
+      # use delvewheel on windows
+      CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
     steps:
       - checkout


### PR DESCRIPTION
`delvewheel` is not yet used by default for windows builds in CIBW (unlike delocate for macos, or auditwheel for linux), but official
delvewheel shoutout was added to CIBW docs in https://github.com/pypa/cibuildwheel/pull/650.

With `delocate` already used for macos CIBW builds, this PR closes #870.