### PR TITLE
Update docstrings to pass doctest

### DIFF
--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -1775,15 +1775,19 @@ class ConstrainedQuadraticModel:
             the same label.
 
         Examples:
+            Note that the ellipses in the outputs below are stand-ins for the
+            generated variable labels, which differ between runs.
+
             >>> from dimod import Integer, ConstrainedQuadraticModel
             >>> i = Integer('i')
             >>> cqm = ConstrainedQuadraticModel()
             >>> cqm.add_constraint(i*i <=3, label='i squared')
             'i squared'
-            >>> cqm.substitute_self_loops()                      # doctest: +IGNORE_RESULT
-            >>> cqm.constraints   # doctest: +IGNORE_RESULT
-            {'i squared': QuadraticModel({'i': 0.0, 'cf651f3d-bdf8-4735-9139-eee0a32e217f': 0.0}, {('cf651f3d-bdf8-4735-9139-eee0a32e217f', 'i'): 1.0}, 0.0, {'i': 'INTEGER', 'cf651f3d-bdf8-4735-9139-eee0a32e217f': 'INTEGER'}, dtype='float64') <= 3,
-            'cf651f3d-bdf8-4735-9139-eee0a32e217f': QuadraticModel({'i': 1.0, 'cf651f3d-bdf8-4735-9139-eee0a32e217f': -1.0}, {}, 0.0, {'i': 'INTEGER', 'cf651f3d-bdf8-4735-9139-eee0a32e217f': 'INTEGER'}, dtype='float64') == 0}
+            >>> cqm.substitute_self_loops() #doctest: +ELLIPSIS
+            {...}
+            >>> cqm.constraints #doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+            {'i squared': Le(QuadraticModel({'i': 0.0, '...': 0.0}, {('...', 'i'): 1.0}, 0.0, {'i': 'INTEGER', '...': 'INTEGER'}, dtype='float64'), 3),
+            '...': Eq(QuadraticModel({'i': 1.0, '...': -1.0}, {}, 0.0, {'i': 'INTEGER', '...': 'INTEGER'}, dtype='float64'), 0)}
         """
         mapping: Dict[Variable, Variable] = dict()
 

--- a/dimod/core/sampler.py
+++ b/dimod/core/sampler.py
@@ -305,10 +305,9 @@ class Sampler(metaclass=SamplerABCMeta):
             >>> with warnings.catch_warnings():
             ...     warnings.filterwarnings('ignore')
             ...     try:
-            ...         kwargs = sampler.remove_unknown_kwargs(num_reads=10,
-            ...                                                non_param=3)
+            ...         sampler.remove_unknown_kwargs(num_reads=10, non_param=3)
             ...     except dimod.exceptions.SamplerUnknownArgWarning:
-            ...:        pass
+            ...        pass
             {'num_reads': 10}
         """
         for kw in [k for k in kwargs if k not in self.parameters]:

--- a/docs/intro/intro_cqm.rst
+++ b/docs/intro/intro_cqm.rst
@@ -53,7 +53,8 @@ learning and testing with small CQMs.
 >>> y = dimod.Integer('y')
 >>> cqm = dimod.CQM()
 >>> objective = cqm.set_objective(x+y)
->>> cqm.add_constraint(y <= 3)          # doctest: +IGNORE_RESULT
+>>> cqm.add_constraint(y <= 3) #doctest: +ELLIPSIS
+'...'
 
 For very large models, you might read the data from a file or construct from a NumPy
 array.


### PR DESCRIPTION
**Issue description**
Three docstrings were failing doctest due to invalid syntax.

**Changes**
Avoided doctest errors by updating the relevant docstrings to use either ellipses (for when the output varies from run-to-run) or update the output to the correct one.