### PR TITLE
Fix as_samples() when given a sampleset and a labels_type

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -1915,9 +1915,10 @@ def _as_samples_sampleset(samples_like: SampleSet,
                           dtype: Optional[DTypeLike] = None,
                           copy: bool = False,
                           order: ArrayOrder = 'C',
+                          labels_type: type = list,
                           ) -> typing.Tuple[np.ndarray, typing.List[Variable]]:
     # this isn't strictly necessary, but it improves performance
-    labels = list(samples_like.variables)
+    labels = labels_type(samples_like.variables)
     if dtype is None:
         arr = np.copy(samples_like.record.sample) if copy else samples_like.record.sample
         return arr, labels

--- a/releasenotes/notes/as-samples-from-sampleset-fefda032711b3044.yaml
+++ b/releasenotes/notes/as-samples-from-sampleset-fefda032711b3044.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix ``as_samples()`` when given a ``SampleSet`` and using the
+    ``labels_type`` keyword argument. Previously it would raise a ``TypeError``.
+    This fix allows constructions like ``bqm.energies(sampleset)`` to function
+    correctly.

--- a/tests/test_bqm.py
+++ b/tests/test_bqm.py
@@ -1174,6 +1174,28 @@ class TestEnergies(unittest.TestCase):
         with self.assertRaises(ValueError):
             bqm.energies([])
 
+    @parameterized.expand(BQMs.items())
+    def test_samples_like(self, name, BQM):
+        bqm = BQM({'a': 1}, {'ab': 2}, 3, 'BINARY')
+
+        samples = np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.int8)
+        labels = 'ab'
+
+        energies = [3, 3, 4, 6]
+
+        with self.subTest('tuple'):
+            np.testing.assert_array_equal(bqm.energies((samples, labels)), energies)
+
+        with self.subTest('dicts'):
+            np.testing.assert_array_equal(
+                bqm.energies([dict(zip(labels, row)) for row in samples]),
+                energies)
+
+        with self.subTest('sample set'):
+            np.testing.assert_array_equal(
+                bqm.energies(dimod.SampleSet.from_samples_bqm((samples, labels), bqm)),
+                energies)
+
 
 class TestMaximumDeltaEnergy(unittest.TestCase):
     @parameterized.expand(itertools.product(BQMs.values(), ('SPIN', 'BINARY')))

--- a/tests/test_quadratic_model.py
+++ b/tests/test_quadratic_model.py
@@ -467,6 +467,29 @@ class TestEnergies(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     qm.energy((arr, 'ij'))
 
+    def test_samples_like(self):
+        qm = dimod.QM.from_bqm(dimod.BQM({'a': 1}, {'ab': 2}, 3, 'BINARY'))
+
+        samples = np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=np.int8)
+        labels = 'ab'
+
+        energies = [3, 3, 4, 6]
+
+        with self.subTest('tuple'):
+            np.testing.assert_array_equal(qm.energies((samples, labels)), energies)
+
+        with self.subTest('dicts'):
+            np.testing.assert_array_equal(
+                qm.energies([dict(zip(labels, row)) for row in samples]),
+                energies)
+
+        with self.subTest('sample set'):
+            np.testing.assert_array_equal(
+                qm.energies(dimod.SampleSet.from_samples((samples, labels),
+                                                         energy=energies,
+                                                         vartype='BINARY')),
+                energies)
+
     def test_squared(self):
         i, j = dimod.Integers('ij')
         self.assertEqual((i**2 + 2*i*j + 3*j*j).energy({'i': 5, 'j': -1}), 18)

--- a/tests/test_sampleset.py
+++ b/tests/test_sampleset.py
@@ -160,6 +160,13 @@ class Test_as_samples(unittest.TestCase):
             self.assertIsInstance(labels, dimod.variables.Variables)
             self.assertEqual(set(labels), set('ab'))
 
+        with self.subTest('sampleset'):
+            sampleset = dimod.SampleSet.from_samples({'a': 1, 'b': 1}, vartype='BINARY', energy=0)
+
+            samples, labels = dimod.as_samples(sampleset, labels_type=dimod.variables.Variables)
+            self.assertIsInstance(labels, dimod.variables.Variables)
+            self.assertEqual(set(labels), set('ab'))
+
     def test_list_of_empty(self):
         arr, labels = dimod.as_samples([[], [], []])
         np.testing.assert_array_equal(arr, np.empty((3, 0)))


### PR DESCRIPTION
Adds missing case from 156d9787978a620d010dd0ddb7bdf168482d1cef. See https://github.com/dwavesystems/dimod/pull/1222