### PR TITLE
Update sphinx version to support Win10 builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-# temp upper bound to remove error from C++ docs until a patch is released
-sphinx<4.1.0
+sphinx
 sphinx_rtd_theme
 
 breathe


### PR DESCRIPTION
Currently dimod's ``requirement.txt`` file specifies ``sphinx<4.1.0`` but on Windows that produces a build error:

```
from types import Union as types_Union
ImportError: cannot import name 'Union' from 'types' (C:\Users\jpasvolsky\.pyenv\pyenv-win\versions\3.10.2\lib\types.py)
```

I upgraded to version 5.2.2 and built with working CPP docs on both unix and windows OSs.