### PR TITLE
Restore the performance of CQM.from_file()

### DIFF
--- a/dimod/constrained.py
+++ b/dimod/constrained.py
@@ -1207,13 +1207,15 @@ class ConstrainedQuadraticModel:
                 discrete = any(zf.read(f"constraints/{constraint}/discrete"))
 
                 label = deserialize_variable(json.loads(constraint))
-                if f"constraints/{constraint}/weight" in zf.namelist() \
-                        and f"constraints/{constraint}/penalty" in zf.namelist():
-                    weight = np.frombuffer(zf.read(f"constraints/{constraint}/weight"), np.float64)[0]
+
+                try:
+                    weight = np.frombuffer(zf.read(f"constraints/{constraint}/weight"))
                     penalty = zf.read(f"constraints/{constraint}/penalty").decode('ascii')
-                    cqm.add_constraint(lhs, rhs=rhs, sense=sense, label=label, weight=weight, penalty=penalty)
-                else:
-                    cqm.add_constraint(lhs, rhs=rhs, sense=sense, label=label)
+                except KeyError:
+                    weight = None
+                    penalty = None
+
+                cqm.add_constraint(lhs, rhs=rhs, sense=sense, label=label, weight=weight, penalty=penalty)
                 if discrete:
                     cqm.discrete.add(label)
 

--- a/releasenotes/notes/fix-CQM.from_file-performance-f434f2c0e66932d4.yaml
+++ b/releasenotes/notes/fix-CQM.from_file-performance-f434f2c0e66932d4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix the performance of ``ConstrainedQuadraticModel.from_file()`` for
+    constrained quadratic models with a large number of constraints.
+    The poor performanc was accidentally introduced in 0.11.6.dev0.


### PR DESCRIPTION
Fix a performance hit we took when introducing weighted constraints.
