### PR TITLE
Add C++ CQM class

### DIFF
--- a/dimod/include/dimod/constrained_quadratic_model.h
+++ b/dimod/include/dimod/constrained_quadratic_model.h
@@ -1,0 +1,493 @@
+// Copyright 2022 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "dimod/abc.h"
+#include "dimod/constraint.h"
+#include "dimod/expression.h"
+#include "dimod/vartypes.h"
+
+namespace dimod {
+
+template <class Bias, class Index = int>
+class ConstrainedQuadraticModel {
+ public:
+    /// The first template parameter (Bias).
+    using bias_type = Bias;
+
+    /// The second template parameter (Index).
+    using index_type = Index;
+
+    /// Unsigned integral type that can represent non-negative values.
+    using size_type = std::size_t;
+
+    ConstrainedQuadraticModel();
+
+    ConstrainedQuadraticModel(const ConstrainedQuadraticModel& other);
+    ConstrainedQuadraticModel(ConstrainedQuadraticModel&& other) noexcept;
+    ~ConstrainedQuadraticModel() = default;
+    ConstrainedQuadraticModel& operator=(ConstrainedQuadraticModel other);
+    ConstrainedQuadraticModel& operator=(ConstrainedQuadraticModel&& other) noexcept;
+
+    index_type add_constraint();
+
+    template <class B, class I, class T>
+    index_type add_constraint(const abc::QuadraticModelBase<B, I>& lhs, Sense sense, bias_type rhs,
+                              const std::vector<T>& mapping);
+
+    index_type add_constraints(index_type n);
+
+    index_type add_linear_constraint(std::initializer_list<index_type> variables,
+                                     std::initializer_list<bias_type> biases, Sense sense,
+                                     bias_type rhs);
+
+    index_type add_variable(Vartype vartype, bias_type lb, bias_type ub);
+
+    index_type add_variable(Vartype vartype);
+
+    index_type add_variables(Vartype vartype, index_type n);
+
+    index_type add_variables(Vartype vartype, index_type n, bias_type lb, bias_type ub);
+
+    void change_vartype(Vartype vartype, index_type v);
+
+    Constraint<bias_type, index_type>& constraint_ref(index_type c);
+    const Constraint<bias_type, index_type>& constraint_ref(index_type c) const;
+
+    template <class T>
+    void fix_variable(index_type v, T assignment);
+
+    /// Return the lower bound on variable ``v``.
+    bias_type lower_bound(index_type v) const;
+
+    /// Return the number of constraints in the model.
+    size_type num_constraints() const;
+
+    /// Return the number of variables in the model.
+    size_type num_variables() const;
+
+    /// Remove a constraint from the model.
+    void remove_constraint(index_type c);
+
+    void remove_variable(index_type v);
+
+    void set_lower_bound(index_type v, bias_type lb);
+
+    template <class B, class I>
+    void set_objective(const abc::QuadraticModelBase<B, I>& objective);
+
+    template <class B, class I, class T>
+    void set_objective(const abc::QuadraticModelBase<B, I>& objective,
+                       const std::vector<T>& mapping);
+
+    void set_upper_bound(index_type v, bias_type ub);
+    void set_vartype(index_type v, Vartype vartype);
+
+    void substitute_variable(index_type v, bias_type multiplier, bias_type offset);
+
+    /// Return the upper bound on variable ``v``.
+    bias_type upper_bound(index_type v) const;
+
+    /// Return the variable type of variable ``v``.
+    Vartype vartype(index_type v) const;
+
+    Expression<bias_type, index_type> objective;
+
+    friend void swap(ConstrainedQuadraticModel& first, ConstrainedQuadraticModel& second) {
+        first.myswap(second);
+    }
+
+ private:
+    // I can't figure out how to get Expression to grant friendship to friend swap...
+    // Will look into it some other time.
+    void myswap(ConstrainedQuadraticModel& other) {
+        using std::swap;
+
+        // for objective and constraints, we need to make sure that their
+        // parent_ pointers are pointing at the correct object.
+
+        swap(this->objective, other.objective);
+        this->objective.parent_ = this;
+        other.objective.parent_ = &other;
+
+        swap(this->constraints_, other.constraints_);
+        for (auto& c : this->constraints_) {
+            c.parent_ = this;
+        }
+        for (auto& c : other.constraints_) {
+            c.parent_ = &other;
+        }
+
+        swap(this->varinfo_, other.varinfo_);
+    }
+
+    std::vector<Constraint<bias_type, index_type>> constraints_;
+
+    struct varinfo_type {
+        Vartype vartype;
+        bias_type lb;
+        bias_type ub;
+
+        varinfo_type(Vartype vartype, bias_type lb, bias_type ub)
+                : vartype(vartype), lb(lb), ub(ub) {
+            assert(lb <= ub);
+
+            assert(lb >= vartype_info<bias_type>::min(vartype));
+            assert(ub <= vartype_info<bias_type>::max(vartype));
+
+            assert(vartype != Vartype::BINARY || lb == 0);
+            assert(vartype != Vartype::BINARY || ub == 1);
+
+            assert(vartype != Vartype::SPIN || lb == -1);
+            assert(vartype != Vartype::SPIN || ub == +1);
+        }
+
+        explicit varinfo_type(Vartype vartype)
+                : vartype(vartype),
+                  lb(vartype_info<bias_type>::default_min(vartype)),
+                  ub(vartype_info<bias_type>::default_max(vartype)) {}
+    };
+
+    std::vector<varinfo_type> varinfo_;
+};
+
+template <class bias_type, class index_type>
+ConstrainedQuadraticModel<bias_type, index_type>::ConstrainedQuadraticModel()
+        : objective(this), constraints_(), varinfo_() {}
+
+template <class bias_type, class index_type>
+ConstrainedQuadraticModel<bias_type, index_type>::ConstrainedQuadraticModel(
+        const ConstrainedQuadraticModel& other)
+        : objective(other.objective), constraints_(other.constraints_), varinfo_(other.varinfo_) {
+    objective.parent_ = this;
+    for (auto& c : constraints_) {
+        c.parent_ = this;
+    }
+}
+
+template <class bias_type, class index_type>
+ConstrainedQuadraticModel<bias_type, index_type>::ConstrainedQuadraticModel(
+        ConstrainedQuadraticModel&& other) noexcept
+        : ConstrainedQuadraticModel() {
+    swap(*this, other);
+}
+
+template <class bias_type, class index_type>
+ConstrainedQuadraticModel<bias_type, index_type>&
+ConstrainedQuadraticModel<bias_type, index_type>::operator=(ConstrainedQuadraticModel other) {
+    swap(*this, other);
+    return *this;
+}
+
+template <class bias_type, class index_type>
+ConstrainedQuadraticModel<bias_type, index_type>&
+ConstrainedQuadraticModel<bias_type, index_type>::operator=(
+        ConstrainedQuadraticModel&& other) noexcept {
+    swap(*this, other);
+    return *this;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_constraint() {
+    constraints_.emplace_back(this);
+    return constraints_.size() - 1;
+}
+
+template <class bias_type, class index_type>
+template <class B, class I, class T>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_constraint(
+        const abc::QuadraticModelBase<B, I>& lhs, Sense sense, bias_type rhs,
+        const std::vector<T>& mapping) {
+    // todo: move version
+    assert(mapping.size() == objective.num_variables());
+
+    add_constraint();
+    Constraint<bias_type, index_type>& constraint = constraints_.back();
+
+    for (size_type i = 0; i < lhs.num_variables(); ++i) {
+        assert(vartype(mapping[i]) == lhs.vartype(i));
+        assert(lower_bound(mapping[i]) == lhs.lower_bound(i));
+        assert(upper_bound(mapping[i]) == lhs.upper_bound(i));
+
+        constraint.add_linear(mapping[i], lhs.linear(i));
+    }
+
+    // quadratic biases
+    for (auto it = lhs.cbegin_quadratic(); it != lhs.cend_quadratic(); ++it) {
+        constraint.add_quadratic(mapping[it->u], mapping[it->v], it->bias);
+    }
+
+    // offset
+    constraint.add_offset(lhs.offset());
+
+    // sense and rhs
+    constraint.set_sense(sense);
+    constraint.set_rhs(rhs);
+
+    return constraints_.size() - 1;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_constraints(index_type n) {
+    assert(n >= 0);
+    index_type size = constraints_.size();
+    for (index_type i = 0; i < n; ++i) {
+        constraints_.emplace_back(this);
+    }
+    return size;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_linear_constraint(
+        std::initializer_list<index_type> variables, std::initializer_list<bias_type> biases,
+        Sense sense, bias_type rhs) {
+    Constraint<bias_type, index_type> constraint(this);
+
+    auto vit = variables.begin();
+    auto bit = biases.begin();
+    for (; vit != variables.end() && bit != biases.end(); ++vit, ++bit) {
+        constraint.add_linear(*vit, *bit);
+    }
+
+    constraint.set_rhs(rhs);
+    constraint.set_sense(sense);
+
+    constraints_.push_back(std::move(constraint));
+    return constraints_.size() - 1;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_variable(Vartype vartype) {
+    index_type v = num_variables();
+    varinfo_.emplace_back(vartype);
+    return v;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_variable(Vartype vartype,
+                                                                          bias_type lb,
+                                                                          bias_type ub) {
+    index_type v = num_variables();
+    varinfo_.emplace_back(vartype, lb, ub);  // also handles asserts
+    return v;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_variables(Vartype vartype,
+                                                                           index_type n) {
+    index_type start = num_variables();
+    varinfo_.insert(varinfo_.end(), n, varinfo_type(vartype));
+    return start;
+}
+
+template <class bias_type, class index_type>
+index_type ConstrainedQuadraticModel<bias_type, index_type>::add_variables(Vartype vartype,
+                                                                           index_type n,
+                                                                           bias_type lb,
+                                                                           bias_type ub) {
+    index_type start = num_variables();
+    varinfo_.insert(varinfo_.end(), n, varinfo_type(vartype, lb, ub));
+    return start;
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::change_vartype(Vartype vartype,
+                                                                      index_type v) {
+    const Vartype& source = this->vartype(v);
+    const Vartype& target = vartype;
+
+    // todo: just call this->substitute_variable
+
+    if (source == target) {
+        return;
+    } else if (source == Vartype::SPIN && target == Vartype::BINARY) {
+        objective.substitute_variable(v, 2, -1);
+        for (auto& constraint : constraints_) {
+            constraint.substitute_variable(v, 2, -1);
+        }
+        varinfo_[v].lb = 0;
+        varinfo_[v].ub = 1;
+        varinfo_[v].vartype = Vartype::BINARY;
+    } else if (source == Vartype::BINARY && target == Vartype::SPIN) {
+        objective.substitute_variable(v, .5, .5);
+        for (auto& constraint : constraints_) {
+            constraint.substitute_variable(v, .5, .5);
+        }
+        varinfo_[v].lb = -1;
+        varinfo_[v].ub = +1;
+        varinfo_[v].vartype = Vartype::SPIN;
+    } else if (source == Vartype::SPIN && target == Vartype::INTEGER) {
+        // first go to BINARY, then INTEGER
+        change_vartype(Vartype::BINARY, v);
+        change_vartype(Vartype::INTEGER, v);
+    } else if (source == Vartype::BINARY && target == Vartype::INTEGER) {
+        // nothing need to change except the vartype itself
+        varinfo_[v].vartype = Vartype::INTEGER;
+    } else {
+        // todo: there are more we could support
+        throw std::logic_error("unsupported vartype change");
+    }
+}
+
+template <class bias_type, class index_type>
+Constraint<bias_type, index_type>& ConstrainedQuadraticModel<bias_type, index_type>::constraint_ref(
+        index_type c) {
+    assert(c >= 0 && static_cast<size_type>(c) < num_constraints());
+    return constraints_[c];
+}
+
+template <class bias_type, class index_type>
+const Constraint<bias_type, index_type>&
+ConstrainedQuadraticModel<bias_type, index_type>::constraint_ref(index_type c) const {
+    assert(c >= 0 && static_cast<size_type>(c) < num_constraints());
+    return constraints_[c];
+}
+
+template <class bias_type, class index_type>
+template <class T>
+void ConstrainedQuadraticModel<bias_type, index_type>::fix_variable(index_type v, T assignment) {
+    assert(v >= 0 && static_cast<size_type>(v) < num_variables());
+    substitute_variable(v, 0, assignment);
+    remove_variable(v);
+}
+
+template <class bias_type, class index_type>
+bias_type ConstrainedQuadraticModel<bias_type, index_type>::lower_bound(index_type v) const {
+    return varinfo_[v].lb;
+}
+
+template <class bias_type, class index_type>
+std::size_t ConstrainedQuadraticModel<bias_type, index_type>::num_constraints() const {
+    return constraints_.size();
+}
+
+template <class bias_type, class index_type>
+std::size_t ConstrainedQuadraticModel<bias_type, index_type>::num_variables() const {
+    return varinfo_.size();
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::remove_constraint(index_type c) {
+    constraints_.erase(constraints_.begin() + c, constraints_.begin() + c + 1);
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::remove_variable(index_type v) {
+    assert(v >= 0 && static_cast<size_type>(v) < num_variables());
+    for (auto& constraint : constraints_) constraint.reindex_variables(v);
+    objective.reindex_variables(v);
+    varinfo_.erase(varinfo_.begin() + v);
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::set_lower_bound(index_type v, bias_type lb) {
+    varinfo_[v].lb = lb;
+}
+
+template <class bias_type, class index_type>
+template <class B, class I>
+void ConstrainedQuadraticModel<bias_type, index_type>::set_objective(
+        const abc::QuadraticModelBase<B, I>& objective) {
+    // todo: move version
+    // todo: support sparse mapping
+
+    // add missing variables
+    for (size_type v = num_variables(); v < objective.num_variables(); ++v) {
+        add_variable(objective.vartype(v), objective.lower_bound(v), objective.upper_bound(v));
+    }
+
+    this->objective.clear();
+
+    // linear biases
+    for (size_type v = 0; v < objective.num_variables(); ++v) {
+        // this checks the overlapping variables. todo: do this in a NDEBUG ifdef?
+        assert(vartype(v) == objective.vartype(v));
+        assert(lower_bound(v) == objective.lower_bound(v));
+        assert(upper_bound(v) == objective.upper_bound(v));
+
+        this->objective.add_linear(v, objective.linear(v));
+    }
+
+    // quadratic biases
+    for (auto it = objective.cbegin_quadratic(); it != objective.cend_quadratic(); ++it) {
+        this->objective.add_quadratic(it->u, it->v, it->bias);
+    }
+
+    // offset
+    this->objective.add_offset(objective.offset());
+}
+
+// variables must all be present in this case!
+template <class bias_type, class index_type>
+template <class B, class I, class T>
+void ConstrainedQuadraticModel<bias_type, index_type>::set_objective(
+        const abc::QuadraticModelBase<B, I>& objective, const std::vector<T>& mapping) {
+    // there are a tonne of potential optimizations here, but let's keep it simple for now
+    assert(mapping.size() == objective.num_variables());
+
+    this->objective.clear();
+
+    for (size_type i = 0; i < objective.num_variables(); ++i) {
+        assert(vartype(mapping[i]) == objective.vartype(i));
+        assert(lower_bound(mapping[i]) == objective.lower_bound(i));
+        assert(upper_bound(mapping[i]) == objective.upper_bound(i));
+
+        this->objective.add_linear(mapping[i], objective.linear(i));
+    }
+
+    // quadratic biases
+    for (auto it = objective.cbegin_quadratic(); it != objective.cend_quadratic(); ++it) {
+        this->objective.add_quadratic(mapping[it->u], mapping[it->v], it->bias);
+    }
+
+    // offset
+    this->objective.add_offset(objective.offset());
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::set_upper_bound(index_type v, bias_type ub) {
+    varinfo_[v].ub = ub;
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::set_vartype(index_type v, Vartype vartype) {
+    varinfo_[v].vartype = vartype;
+}
+
+template <class bias_type, class index_type>
+void ConstrainedQuadraticModel<bias_type, index_type>::substitute_variable(index_type v,
+                                                                           bias_type multiplier,
+                                                                           bias_type offset) {
+    objective.substitute_variable(v, multiplier, offset);
+    for (auto& constraint : constraints_) {
+        constraint.substitute_variable(v, multiplier, offset);
+    }
+}
+
+template <class bias_type, class index_type>
+bias_type ConstrainedQuadraticModel<bias_type, index_type>::upper_bound(index_type v) const {
+    return varinfo_[v].ub;
+}
+
+template <class bias_type, class index_type>
+Vartype ConstrainedQuadraticModel<bias_type, index_type>::vartype(index_type v) const {
+    return varinfo_[v].vartype;
+}
+
+}  // namespace dimod

--- a/dimod/include/dimod/constraint.h
+++ b/dimod/include/dimod/constraint.h
@@ -1,0 +1,178 @@
+// Copyright 2022 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "dimod/abc.h"
+#include "dimod/expression.h"
+#include "dimod/vartypes.h"
+
+namespace dimod {
+
+enum Sense { LE, GE, EQ };
+
+enum Penalty { LINEAR, QUADRATIC, CONSTANT };
+
+template <class Bias, class Index>
+class Constraint : public Expression<Bias, Index> {
+ public:
+    /// The type of the base class.
+    using base_type = Expression<Bias, Index>;
+
+    /// The first template parameter (Bias).
+    using bias_type = Bias;
+
+    /// The second template parameter (Index).
+    using index_type = Index;
+
+    using size_type = typename base_type::size_type;
+
+    using parent_type = ConstrainedQuadraticModel<bias_type, index_type>;
+
+    Constraint();
+    explicit Constraint(parent_type* parent);
+
+    bool is_onehot() const;
+    bool is_soft() const;
+    void mark_discrete(bool mark = true);
+    bool marked_discrete() const;
+    Penalty penalty() const;
+    bias_type rhs() const;
+
+    // note: flips sign when negative
+    void scale(bias_type scalar);
+
+    Sense sense() const;
+    void set_penalty(Penalty penalty);
+    void set_rhs(bias_type rhs);
+    void set_sense(Sense sense);
+    void set_weight(bias_type weight);
+    bias_type weight() const;
+
+ private:
+    Sense sense_;
+    bias_type rhs_;
+    bias_type weight_;
+    Penalty penalty_;
+
+    // marker(s) - these ar not enforced by code
+    bool marked_discrete_ = false;
+};
+
+template <class bias_type, class index_type>
+Constraint<bias_type, index_type>::Constraint() : Constraint(nullptr) {}
+
+template <class bias_type, class index_type>
+Constraint<bias_type, index_type>::Constraint(parent_type* parent)
+        : base_type(parent),
+          sense_(Sense::EQ),
+          rhs_(0),
+          weight_(std::numeric_limits<bias_type>::infinity()),
+          penalty_(Penalty::LINEAR) {}
+
+template <class bias_type, class index_type>
+bool Constraint<bias_type, index_type>::is_onehot() const {
+    // must be linear and must have at least two variables
+    if (!base_type::is_linear() || base_type::num_variables() < 2) return false;
+
+    // all of out variables must be binary
+    for (const auto& v : base_type::variables()) {
+        if (base_type::vartype(v) != Vartype::BINARY) return false;
+    }
+
+    // we get a bit cute here and check the linear biases using the
+    // underlying model, thereby bypassing the dict lookup. This is not
+    // super future-proof but faster.
+    for (size_type i = 0; i < base_type::num_variables(); ++i) {
+        if (base_type::base_type::linear(i) != rhs_) return false;
+    }
+
+    return true;
+}
+
+template <class bias_type, class index_type>
+bool Constraint<bias_type, index_type>::is_soft() const {
+    // some sort of tolerance value?
+    return weight_ != std::numeric_limits<bias_type>::infinity();
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::mark_discrete(bool marker) {
+    marked_discrete_ = marker;
+}
+
+template <class bias_type, class index_type>
+bool Constraint<bias_type, index_type>::marked_discrete() const {
+    return marked_discrete_;
+}
+
+template <class bias_type, class index_type>
+Penalty Constraint<bias_type, index_type>::penalty() const {
+    return penalty_;
+}
+
+template <class bias_type, class index_type>
+bias_type Constraint<bias_type, index_type>::rhs() const {
+    return rhs_;
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::scale(bias_type scalar) {
+    base_type::scale(scalar);
+    rhs_ *= scalar;
+    if (scalar < 0) {
+        if (sense_ == Sense::LE) {
+            sense_ = Sense::GE;
+        } else if (sense_ == Sense::GE) {
+            sense_ = Sense::LE;
+        }
+    }
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::set_penalty(Penalty penalty) {
+    penalty_ = penalty;
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::set_rhs(bias_type rhs) {
+    rhs_ = rhs;
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::set_sense(Sense sense) {
+    sense_ = sense;
+}
+
+template <class bias_type, class index_type>
+void Constraint<bias_type, index_type>::set_weight(bias_type weight) {
+    weight_ = weight;
+}
+
+template <class bias_type, class index_type>
+Sense Constraint<bias_type, index_type>::sense() const {
+    return sense_;
+}
+
+template <class bias_type, class index_type>
+bias_type Constraint<bias_type, index_type>::weight() const {
+    return weight_;
+}
+
+}  // namespace dimod

--- a/dimod/include/dimod/expression.h
+++ b/dimod/include/dimod/expression.h
@@ -1,0 +1,587 @@
+// Copyright 2022 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <limits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "dimod/abc.h"
+#include "dimod/vartypes.h"
+
+namespace dimod {
+
+// forward declaration
+template <class Bias, class Index>
+class ConstrainedQuadraticModel;
+
+template <class Bias, class Index = int>
+class Expression : public abc::QuadraticModelBase<Bias, Index> {
+ public:
+    /// The type of the base class.
+    using base_type = abc::QuadraticModelBase<Bias, Index>;
+
+    /// The first template parameter (Bias).
+    using bias_type = Bias;
+
+    /// The second template parameter (Index).
+    using index_type = Index;
+
+    /// Unsigned integral type that can represent non-negative values.
+    using size_type = std::size_t;
+
+    using parent_type = ConstrainedQuadraticModel<bias_type, index_type>;
+
+    /// @private  <- don't doc
+    class ConstQuadraticIterator {
+     public:
+        using value_type = abc::TwoVarTerm<bias_type, index_type>;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        ConstQuadraticIterator() : expression_(nullptr), it_(), end_(), term_(0) {}
+        ConstQuadraticIterator(const Expression* expression,
+                               const abc::ConstQuadraticIterator<bias_type, index_type>& it,
+                               const abc::ConstQuadraticIterator<bias_type, index_type>& end)
+                : expression_(expression), it_(it), end_(end), term_(0) {
+            if (it_ != end_) {
+                term_ = value_type(expression_->variables()[it_->u],
+                                   expression_->variables()[it_->v], it_->bias);
+            }
+        }
+
+        reference operator*() { return term_; }
+
+        const pointer operator->() { return &term_; }
+
+        ConstQuadraticIterator& operator++() {
+            ++it_;
+            if (it_ != end_) {
+                term_ = value_type(expression_->variables()[it_->u],
+                                   expression_->variables()[it_->v], it_->bias);
+            }
+            return *this;
+        }
+
+        ConstQuadraticIterator operator++(int) {
+            ConstQuadraticIterator tmp(*this);
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const ConstQuadraticIterator& a, const ConstQuadraticIterator& b) {
+            return a.it_ == b.it_;
+        }
+
+        friend bool operator!=(const ConstQuadraticIterator& a, const ConstQuadraticIterator& b) {
+            return a.it_ != b.it_;
+        }
+
+     private:
+        const Expression* expression_;
+        abc::ConstQuadraticIterator<bias_type, index_type> it_;
+        abc::ConstQuadraticIterator<bias_type, index_type> end_;
+        value_type term_;
+    };
+
+    using const_quadratic_iterator = ConstQuadraticIterator;
+
+    /// @private  <- don't doc
+    class ConstNeighborhoodIterator {
+     public:
+        using value_type = abc::OneVarTerm<bias_type, index_type>;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;  // could do random access
+
+        using wrapped_type =
+                typename abc::QuadraticModelBase<bias_type,
+                                                 index_type>::const_neighborhood_iterator;
+
+        reference operator*() { return term_; }
+
+        const pointer operator->() { return &term_; }
+
+        ConstNeighborhoodIterator() : expression_(nullptr), it_(), end_(), term_(-1, 0) {}
+        ConstNeighborhoodIterator(const Expression* expression, const wrapped_type& it,
+                                  const wrapped_type& end)
+                : expression_(expression), it_(it), end_(end), term_(-1, 0) {
+            if (it_ != end_) {
+                term_ = value_type(expression_->variables()[it_->v], it_->bias);
+            }
+        }
+
+        ConstNeighborhoodIterator& operator++() {
+            ++it_;
+            if (it_ != end_) {
+                term_ = value_type(expression_->variables()[it_->v], it_->bias);
+            }
+            return *this;
+        }
+
+        ConstNeighborhoodIterator operator++(int) {
+            ConstNeighborhoodIterator tmp(*this);
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const ConstNeighborhoodIterator& a,
+                               const ConstNeighborhoodIterator& b) {
+            return a.it_ == b.it_;
+        }
+        friend bool operator!=(const ConstNeighborhoodIterator& a,
+                               const ConstNeighborhoodIterator& b) {
+            return a.it_ != b.it_;
+        }
+
+     private:
+        const Expression* expression_;
+        wrapped_type it_;
+        wrapped_type end_;
+        value_type term_;
+    };
+
+    using const_neighborhood_iterator = ConstNeighborhoodIterator;
+
+    friend class ConstrainedQuadraticModel<bias_type, index_type>;
+
+    Expression();
+    explicit Expression(parent_type* parent);
+
+    Expression(parent_type* parent, base_type&& other);
+
+    /// Add linear bias to variable ``v``.
+    void add_linear(index_type v, bias_type bias);
+
+    void add_quadratic(index_type u, index_type v, bias_type bias);
+
+    void add_quadratic(std::initializer_list<index_type> row, std::initializer_list<index_type> col,
+                       std::initializer_list<bias_type> biases);
+
+    template <class ItRow, class ItCol, class ItBias>
+    void add_quadratic(ItRow row_iterator, ItCol col_iterator, ItBias bias_iterator,
+                       index_type length);
+
+    void add_quadratic_back(index_type u, index_type v, bias_type bias);
+
+    template <class T>
+    void add_quadratic_from_dense(const T dense[], index_type num_variables);
+
+    const_neighborhood_iterator cbegin_neighborhood(index_type v) const;
+
+    const_neighborhood_iterator cend_neighborhood(index_type v) const;
+
+    const_quadratic_iterator cbegin_quadratic() const;
+
+    const_quadratic_iterator cend_quadratic() const;
+
+    /// Remove the offset and all variables and interactions from the model. Does not affect parent
+    void clear();
+
+    /**
+     * Return the energy of the given sample.
+     *
+     * The `sample_start` must be random access iterator pointing to the
+     * beginning of the sample.
+     *
+     * The behavior of this function is undefined when the sample is not
+     * `num_variables()` long.
+     */
+    template <class Iter>
+    bias_type energy(Iter sample_start) const;
+
+    template <class T>
+    void fix_variable(index_type v, T assignment);
+
+    bool has_variable(index_type v) const;
+
+    bool is_disjoint(const Expression& other) const;
+
+    template <class B, class I>
+    bool is_equal(const abc::QuadraticModelBase<B, I>& other) const;
+
+    /// The linear bias of variable `v`.
+    bias_type linear(index_type v) const;
+
+    /// Return the lower bound on variable ``v``.
+    bias_type lower_bound(index_type v) const;
+
+    /**
+     * Total bytes consumed by the biases and indices.
+     *
+     * If `capacity` is true, use the capacity of the underlying vectors rather
+     * than the size.
+     */
+    size_type nbytes(bool capacity = false) const;
+
+    using base_type::num_interactions;
+
+    /// The number of other variables `v` interacts with.
+    size_type num_interactions(index_type v) const;
+
+    /**
+     * Return the quadratic bias associated with `u`, `v`.
+     *
+     * If `u` and `v` do not have a quadratic bias, returns 0.
+     *
+     * Note that this function does not return a reference, this is because
+     * each quadratic bias is stored twice.
+     *
+     */
+    bias_type quadratic(index_type u, index_type v) const;
+
+    /**
+     * Return the quadratic bias associated with `u`, `v`.
+     *
+     * Note that this function does not return a reference, this is because
+     * each quadratic bias is stored twice.
+     *
+     * Raises an `out_of_range` error if either `u` or `v` are not variables or
+     * if they do not have an interaction then the function throws an exception.
+     */
+    bias_type quadratic_at(index_type u, index_type v) const;
+
+    /// Remove the interaction between variables `u` and `v`.
+    bool remove_interaction(index_type u, index_type v);
+
+    virtual void remove_variable(index_type v);
+
+    /// Set the linear bias of variable `v`.
+    void set_linear(index_type v, bias_type bias);
+
+    /// Set the linear biases of of the variables beginning with `v`.
+    void set_linear(index_type v, std::initializer_list<bias_type> biases);
+
+    /// Set the quadratic bias for the given variables.
+    void set_quadratic(index_type u, index_type v, bias_type bias);
+
+    void substitute_variable(index_type v, bias_type multiplier, bias_type offset);
+
+    /// Return the upper bound on variable ``v``.
+    bias_type upper_bound(index_type v) const;
+
+    const std::vector<index_type>& variables() const;
+
+    /// Return the variable type of variable ``v``.
+    Vartype vartype(index_type v) const;
+
+ protected:
+    /// This removes a variable from the model *and* reindexes
+    void reindex_variables(index_type v);
+
+ private:
+    parent_type* parent_;
+
+    /// List of the parent's label used by expression
+    std::vector<index_type> variables_;
+
+    /// Map from parent's labels to the internal ones
+    std::unordered_map<index_type, index_type> indices_;  // todo: consider Tessil
+
+    /// Make sure ``v`` exists in the model and return the index in the underlying QM
+    index_type enforce_variable(index_type v) {
+        auto it = indices_.find(v);
+        if (it != indices_.end()) {
+            // we're already tracking it
+            return it->second;
+        }
+        // we need to create it
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+
+        index_type vi = variables_.size();
+        indices_[v] = vi;
+        variables_.emplace_back(v);
+        base_type::add_variable();
+        return vi;
+    }
+};
+
+template <class bias_type, class index_type>
+Expression<bias_type, index_type>::Expression() : Expression(nullptr) {}
+
+template <class bias_type, class index_type>
+Expression<bias_type, index_type>::Expression(parent_type* parent) : base_type(), parent_(parent) {}
+
+template <class bias_type, class index_type>
+Expression<bias_type, index_type>::Expression(parent_type* parent, base_type&& other) {
+    throw std::logic_error("not implemented - construction from other");
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::add_linear(index_type v, bias_type bias) {
+    base_type::add_linear(enforce_variable(v), bias);
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::add_quadratic(index_type u, index_type v, bias_type bias) {
+    base_type::add_quadratic(enforce_variable(u), enforce_variable(v), bias);
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::add_quadratic(std::initializer_list<index_type> row,
+                                                      std::initializer_list<index_type> col,
+                                                      std::initializer_list<bias_type> biases) {
+    throw std::logic_error("not implemented - add_quadratic from initializer_list");
+}
+
+template <class bias_type, class index_type>
+template <class ItRow, class ItCol, class ItBias>
+void Expression<bias_type, index_type>::add_quadratic(ItRow row_iterator, ItCol col_iterator,
+                                                      ItBias bias_iterator, index_type length) {
+    throw std::logic_error("not implemented - add_quadratic from iterators");
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::add_quadratic_back(index_type u, index_type v, bias_type bias) {
+    throw std::logic_error("not implemented - add_quadratic_back");
+}
+
+template <class bias_type, class index_type>
+    template <class T>
+void Expression<bias_type, index_type>::add_quadratic_from_dense(const T dense[], index_type num_variables) {
+    throw std::logic_error("not implemented - add_quadratic_from_dense");
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::const_neighborhood_iterator
+Expression<bias_type, index_type>::cbegin_neighborhood(index_type v) const {
+    auto it = indices_.find(v);
+    if (it == indices_.end()) {
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        auto empty = base_type::empty_neighborhood();
+        return const_neighborhood_iterator(this, empty.begin(), empty.end());
+    }
+    return const_neighborhood_iterator(this, base_type::cbegin_neighborhood(it->second),
+                                       base_type::cend_neighborhood(it->second));
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::const_neighborhood_iterator
+Expression<bias_type, index_type>::cend_neighborhood(index_type v) const {
+    auto it = indices_.find(v);
+    if (it == indices_.end()) {
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        auto empty = base_type::empty_neighborhood();
+        return const_neighborhood_iterator(this, empty.end(), empty.end());
+    }
+    return const_neighborhood_iterator(this, base_type::cend_neighborhood(it->second),
+                                       base_type::cend_neighborhood(it->second));
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::const_quadratic_iterator
+Expression<bias_type, index_type>::cbegin_quadratic() const {
+    return const_quadratic_iterator(this, base_type::cbegin_quadratic(),
+                                    base_type::cend_quadratic());
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::const_quadratic_iterator
+Expression<bias_type, index_type>::cend_quadratic() const {
+    return const_quadratic_iterator(this, base_type::cend_quadratic(), base_type::cend_quadratic());
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::clear() {
+    base_type::clear();
+    indices_.clear();
+    variables_.clear();
+}
+
+template <class bias_type, class index_type>
+template <class T>
+void Expression<bias_type, index_type>::fix_variable(index_type v, T assignment) {
+    throw std::logic_error("not implemented - fix_variable");
+}
+
+template <class bias_type, class index_type>
+bool Expression<bias_type, index_type>::has_variable(index_type v) const {
+    return indices_.count(v);
+}
+
+template <class bias_type, class index_type>
+bool Expression<bias_type, index_type>::is_disjoint(const Expression& other) const {
+    // we want to do the direction that has the fewest variables
+    if (other.num_variables() < base_type::num_variables()) {
+        return other.is_disjoint(*this);
+    }
+
+    for (const auto& v : variables_) {
+        if (other.indices_.count(v)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <class bias_type, class index_type>
+template <class B, class I>
+bool Expression<bias_type, index_type>:: is_equal(const abc::QuadraticModelBase<B, I>& other) const {
+    throw std::logic_error("not implemented - is_equal");
+}
+
+template <class bias_type, class index_type>
+template <class Iter>
+bias_type Expression<bias_type, index_type>::energy(Iter sample_start) const {
+    static_assert(std::is_same<std::random_access_iterator_tag,
+                               typename std::iterator_traits<Iter>::iterator_category>::value,
+                  "iterator must be random access");
+
+    // we could try to do this "virtually" but almost certainly we'll get better
+    // performance by just making a new sample in the order of the underlying base type
+    std::vector<typename std::iterator_traits<Iter>::value_type> subsample;
+    for (const auto& v : variables_) {
+        subsample.push_back(*(sample_start + v));
+    }
+
+    // now just calculate the energy as normal on the subsample
+    return base_type::energy(subsample.begin());
+}
+
+template <class bias_type, class index_type>
+bias_type Expression<bias_type, index_type>::linear(index_type v) const {
+    auto it = indices_.find(v);
+    if (it == indices_.end()) {
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        return 0;
+    }
+    return base_type::linear(it->second);
+}
+
+template <class bias_type, class index_type>
+bias_type Expression<bias_type, index_type>::lower_bound(index_type v) const {
+    return parent_->lower_bound(v);
+}
+
+template <class bias_type, class index_type>
+bias_type Expression<bias_type, index_type>::quadratic(index_type u, index_type v) const {
+    auto uit = indices_.find(u);
+    auto vit = indices_.find(v);
+    if (uit == indices_.end() || vit == indices_.end()) {
+        assert(u >= 0 && static_cast<size_type>(u) < parent_->num_variables());
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        return 0;
+    }
+    return base_type::quadratic(uit->second, vit->second);
+}
+
+template <class bias_type, class index_type>
+bias_type Expression<bias_type, index_type>::quadratic_at(index_type u, index_type v) const {
+    auto uit = indices_.find(u);
+    auto vit = indices_.find(v);
+    if (uit == indices_.end() || vit == indices_.end()) {
+        throw std::out_of_range("given variables have no interaction");
+    }
+    return base_type::quadratic_at(uit->second, vit->second);
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::size_type Expression<bias_type, index_type>::nbytes(
+        bool capacity) const {
+    throw std::logic_error("not implemented - nbytes");
+}
+
+template <class bias_type, class index_type>
+typename Expression<bias_type, index_type>::size_type
+Expression<bias_type, index_type>::num_interactions(index_type v) const {
+    auto it = indices_.find(v);
+    if (it == indices_.end()) {
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        return 0;
+    }
+    return base_type::num_interactions(it->second);
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::reindex_variables(index_type v) {
+    auto it = indices_.find(v);
+    if (it != indices_.end()) {
+        // in this case we actually need to remove a variable from the model
+        base_type::remove_variable(it->second);
+        variables_.erase(variables_.begin() + it->second);
+        indices_.erase(it);
+
+        assert(base_type::num_variables() == indices_.size());
+        assert(indices_.size() == variables_.size());
+    }
+
+    // we need to reindex all of the variable labels that are greater than v
+    // variables_ is not ordered, so we just need to go through the whole thing
+    bool reindex_happened = false;
+    for (auto& u : variables_) {
+        if (u < v) continue;  // no reindex needed
+        --u;
+        reindex_happened = true;
+    }
+
+    // doing it this way is safe, but no doubt there is a more performant way
+    // to do it
+    if (reindex_happened) {
+        indices_.clear();
+        for (size_type ui = 0; ui < variables_.size(); ++ui) {
+            indices_[variables_[ui]] = ui;
+        }
+    }
+
+    assert(indices_.size() == variables_.size());
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::remove_variable(index_type v) {
+    throw std::logic_error("not implemented - remove_variable");
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::set_linear(index_type v, bias_type bias) {
+    base_type::set_linear(enforce_variable(v), bias);
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::set_quadratic(index_type u, index_type v, bias_type bias) {
+    base_type::set_quadratic(enforce_variable(u), enforce_variable(v), bias);
+}
+
+template <class bias_type, class index_type>
+void Expression<bias_type, index_type>::substitute_variable(index_type v, bias_type multiplier,
+                                                            bias_type offset) {
+    auto it = indices_.find(v);
+    if (it == indices_.end()) {
+        assert(v >= 0 && static_cast<size_type>(v) < parent_->num_variables());
+        return;
+    }
+    return base_type::substitute_variable(it->second, multiplier, offset);
+}
+
+template <class bias_type, class index_type>
+bias_type Expression<bias_type, index_type>::upper_bound(index_type v) const {
+    return parent_->upper_bound(v);
+}
+
+template <class bias_type, class index_type>
+const std::vector<index_type>& Expression<bias_type, index_type>::variables() const {
+    return variables_;
+}
+
+template <class bias_type, class index_type>
+Vartype Expression<bias_type, index_type>::vartype(index_type v) const {
+    return parent_->vartype(v);
+}
+
+}  // namespace dimod

--- a/releasenotes/notes/C++-CQM-3d1b9b9c369c14dc.yaml
+++ b/releasenotes/notes/C++-CQM-3d1b9b9c369c14dc.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Add C++ ``dimod::ConstrainedQuadraticModel`` class.
+  

--- a/testscpp/tests/test_constrained_quadratic_model.cpp
+++ b/testscpp/tests/test_constrained_quadratic_model.cpp
@@ -1,0 +1,418 @@
+// Copyright 2022 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "catch2/catch.hpp"
+#include "dimod/constrained_quadratic_model.h"
+#include "dimod/quadratic_model.h"
+
+namespace dimod {
+
+SCENARIO("ConstrainedQuadraticModel  tests") {
+    GIVEN("an empty CQM") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+
+        THEN("some basic properties can be discovered") {
+            CHECK(cqm.num_variables() == 0);
+            CHECK(cqm.num_constraints() == 0);
+        }
+
+        THEN("the cqm can be copied") {
+            auto cqm2 = cqm;
+
+            THEN("some basic properties can be discovered") {
+                CHECK(cqm2.num_variables() == 0);
+                CHECK(cqm2.num_constraints() == 0);
+            }
+        }
+
+        WHEN("we add variables") {
+            cqm.add_variables(Vartype::INTEGER, 5);
+            cqm.add_variables(Vartype::REAL, 3, -10, 10);
+            cqm.add_variable(Vartype::SPIN);
+            cqm.add_variable(Vartype::BINARY, 0, 1);
+
+            THEN("we can read them off appropriately") {
+                REQUIRE(cqm.num_variables() == 10);
+
+                for (int i = 0; i < 5; ++i) CHECK(cqm.vartype(i) == Vartype::INTEGER);
+                for (int i = 5; i < 8; ++i) CHECK(cqm.vartype(i) == Vartype::REAL);
+                for (int i = 5; i < 8; ++i) CHECK(cqm.lower_bound(i) == -10);
+                for (int i = 5; i < 8; ++i) CHECK(cqm.upper_bound(i) == +10);
+                CHECK(cqm.vartype(8) == Vartype::SPIN);
+                CHECK(cqm.vartype(9) == Vartype::BINARY);
+            }
+
+            AND_WHEN("we try to set the linear biases in the objective") {
+                cqm.objective.set_linear(0, 1.5);
+
+                THEN("it is reflected in the model") {
+                    REQUIRE(cqm.objective.num_variables() == 1);
+                    CHECK(cqm.objective.linear(0) == 1.5);
+                }
+            }
+        }
+
+        AND_GIVEN("a quadratic model") {
+            auto qm = QuadraticModel<double>();
+            auto u = qm.add_variable(Vartype::INTEGER, -5, 5);
+            auto v = qm.add_variable(Vartype::BINARY);
+            qm.set_linear(u, 1);
+            qm.set_linear(v, 2);
+            qm.set_quadratic(u, v, 1.5);
+            qm.set_offset(10);
+
+            WHEN("we set the objective via the set_objective() method") {
+                cqm.set_objective(qm);
+
+                THEN("the objective updates appropriately") {
+                    REQUIRE(cqm.objective.num_variables() == 2);
+                    REQUIRE(cqm.objective.num_interactions() == 1);
+                    CHECK(cqm.objective.linear(0) == 1);
+                    CHECK(cqm.objective.linear(1) == 2);
+                    CHECK(cqm.objective.quadratic(0, 1) == 1.5);
+                    CHECK(cqm.objective.offset() == 10);
+                    CHECK(cqm.lower_bound(0) == -5);
+                    CHECK(cqm.upper_bound(0) == 5);
+                    CHECK(cqm.vartype(0) == Vartype::INTEGER);
+                    CHECK(cqm.vartype(1) == Vartype::BINARY);
+                }
+            }
+
+            WHEN("we set the objective via the set_objective() with a relabel") {
+                cqm.add_variable(Vartype::BINARY);
+                cqm.add_variable(Vartype::INTEGER, -5, 5);
+                cqm.set_objective(qm, std::vector<int>{1, 0});
+
+                THEN("the objective updates appropriately") {
+                    REQUIRE(cqm.objective.num_variables() == 2);
+                    REQUIRE(cqm.objective.num_interactions() == 1);
+                    CHECK(cqm.objective.linear(1) == 1);
+                    CHECK(cqm.objective.linear(0) == 2);
+                    CHECK(cqm.objective.quadratic(0, 1) == 1.5);
+                    CHECK(cqm.objective.offset() == 10);
+                    CHECK(cqm.lower_bound(1) == -5);
+                    CHECK(cqm.upper_bound(1) == 5);
+                    CHECK(cqm.vartype(1) == Vartype::INTEGER);
+                    CHECK(cqm.vartype(0) == Vartype::BINARY);
+                }
+
+                AND_WHEN("that objective is overwritten") {
+                    auto qm2 = QuadraticModel<double>();
+                    qm2.add_variable(Vartype::BINARY);
+                    qm2.set_linear(0, 10);
+                    cqm.set_objective(qm2, std::vector<int>{0});
+
+                    THEN("everything updates as expected") {
+                        REQUIRE(cqm.objective.num_variables() == 1);
+                        REQUIRE(cqm.objective.num_interactions() == 0);
+                        CHECK(cqm.objective.linear(1) == 0);
+                        CHECK(cqm.objective.linear(0) == 10);
+                        CHECK(cqm.objective.quadratic(0, 1) == 0);
+                        CHECK(cqm.objective.offset() == 0);
+                        CHECK(cqm.lower_bound(1) == -5);
+                        CHECK(cqm.upper_bound(1) == 5);
+                        CHECK(cqm.vartype(1) == Vartype::INTEGER);
+                        CHECK(cqm.vartype(0) == Vartype::BINARY);
+                    }
+                }
+            }
+        }
+
+        WHEN("we add an empty constraint") {
+            auto c0 = cqm.add_constraint();
+
+            THEN("that constraint is well formed") {
+                CHECK(cqm.constraint_ref(c0).num_variables() == 0);
+                CHECK(cqm.constraint_ref(c0).num_interactions() == 0);
+                CHECK(!cqm.constraint_ref(c0).is_soft());
+                CHECK(cqm.constraint_ref(c0).rhs() == 0);
+            }
+
+            AND_WHEN("we manipulate that constraint") {
+                auto u = cqm.add_variable(Vartype::BINARY);
+                auto v = cqm.add_variable(Vartype::INTEGER, -5, 5);
+                cqm.constraint_ref(c0).add_linear(u, 1.5);
+                cqm.constraint_ref(c0).add_linear(v, 12.5);
+            }
+        }
+
+        WHEN("the objective is set via a QM") {
+            auto qm = QuadraticModel<float>();
+            qm.add_variable(Vartype::SPIN);
+            qm.add_variable(Vartype::REAL, -5, +17);
+            qm.set_linear(0, {1.5, -5});
+            qm.add_quadratic(0, 1, -2);
+            qm.set_offset(5);
+
+            cqm.set_objective(qm);
+
+            REQUIRE(cqm.num_variables() == 2);
+            CHECK(cqm.objective.num_variables() == 2);
+            REQUIRE(cqm.objective.num_interactions() == 1);
+            CHECK(cqm.objective.linear(0) == 1.5);
+            CHECK(cqm.objective.linear(1) == -5);
+            CHECK(cqm.objective.quadratic_at(0, 1) == -2);
+            CHECK(cqm.objective.offset() == 5);
+            CHECK(cqm.objective.lower_bound(0) == qm.lower_bound(0));
+            CHECK(cqm.objective.upper_bound(0) == qm.upper_bound(0));
+            CHECK(cqm.objective.lower_bound(1) == qm.lower_bound(1));
+            CHECK(cqm.objective.upper_bound(1) == qm.upper_bound(1));
+        }
+
+        WHEN("10 variables and two empty constraints are added") {
+            cqm.add_constraints(2);
+            cqm.add_variable(Vartype::INTEGER);
+            cqm.add_variable(Vartype::INTEGER);
+
+            THEN("quadratic biases can be added") {
+                REQUIRE(cqm.num_constraints() == 2);
+
+                cqm.constraint_ref(0).add_quadratic(0, 1, 1.5);
+
+                CHECK(cqm.constraint_ref(0).num_interactions() == 1);
+                CHECK(cqm.constraint_ref(0).num_interactions(0) == 1);
+                CHECK(cqm.constraint_ref(0).num_interactions(1) == 1);
+                CHECK(cqm.constraint_ref(0).quadratic(0, 1) == 1.5);
+                CHECK(cqm.constraint_ref(0).quadratic(1, 0) == 1.5);
+            }
+        }
+    }
+
+    GIVEN("a CQM with an objective and a constraint") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+
+        // auto qm = QuadraticModel<double>();
+        cqm.add_variables(Vartype::INTEGER, 5, 0, 5);
+        cqm.add_variables(Vartype::BINARY, 5);
+        // qm.set_linear(0, {0, 1, -2, 3, -4, 5, -6, 7, -8, 9});
+        // qm.add_quadratic(0, 1, 1);
+        // qm.add_quadratic(1, 2, 2);
+        // qm.set_offset(5);
+        // cqm.set_objective(qm);
+
+        // cqm.add_constraints(1, Sense::EQ);
+        // cqm.constraint_ref(0).set_linear(2, 2);
+        // cqm.constraint_ref(0).set_linear(5, -5);
+        // cqm.constraint_ref(0).add_quadratic(2, 4, 8);
+        // cqm.constraint_ref(0).set_offset(4);
+
+        // todo: test Move, copy, constructors and operators
+    }
+
+    GIVEN("a CQM with 30 variables") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+
+        cqm.add_variables(Vartype::BINARY, 10);
+        cqm.add_variables(Vartype::INTEGER, 10, -5, 5);
+        cqm.add_variables(Vartype::REAL, 10, -100, 105);
+
+        WHEN("we add a constraint over only a few variables") {
+            auto c0 = cqm.add_constraint();
+
+            auto& constraint = cqm.constraint_ref(c0);
+
+            constraint.add_linear(5, 15);
+            constraint.add_linear(7, 105);
+            constraint.add_linear(3, 5);
+            constraint.add_quadratic(5, 7, 56);
+            constraint.add_quadratic(3, 7, 134);
+
+            THEN("we can iterate over the quadratic interactions") {
+                auto it = constraint.cbegin_quadratic();
+
+                CHECK(it->u == 7);
+                CHECK(it->v == 5);
+                CHECK(it->bias == 56);
+                it++;
+                CHECK(it->u == 3);
+                CHECK(it->v == 7);
+                CHECK(it->bias == 134);
+                it++;
+                CHECK(it == constraint.cend_quadratic());
+            }
+
+            THEN("we can iterate over the neighborhoods") {
+                auto it = constraint.cbegin_neighborhood(7);
+
+                CHECK(it->v == 5);
+                CHECK(it->bias == 56);
+                it++;
+                CHECK(it->v == 3);
+                CHECK(it->bias == 134);
+                it++;
+                CHECK(it == constraint.cend_neighborhood(7));
+            }
+        }
+    }
+
+    GIVEN("a CQM with a contraint") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+        cqm.add_variables(Vartype::BINARY, 3);
+
+        auto c0 = cqm.add_constraint();
+        cqm.constraint_ref(c0).set_linear(2, 1);
+        cqm.constraint_ref(c0).set_sense(Sense::GE);
+        cqm.constraint_ref(c0).set_rhs(1);
+
+        std::vector<int> sample{0, 0, 1};
+        CHECK(cqm.constraint_ref(c0).energy(sample.begin()) == 1);
+    }
+
+    GIVEN("A CQM with several constraints") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+        cqm.add_variables(Vartype::BINARY, 7);
+
+        auto c0 = cqm.add_constraint();
+        auto c1 = cqm.add_constraint();
+        auto c2 = cqm.add_constraint();
+
+        cqm.constraint_ref(c0).add_linear(0, 1.5);
+        cqm.constraint_ref(c0).add_linear(1, 2.5);
+        cqm.constraint_ref(c0).add_linear(2, 3.5);
+
+        cqm.constraint_ref(c1).add_linear(2, 4.5);
+        cqm.constraint_ref(c1).add_linear(3, 5.5);
+        cqm.constraint_ref(c1).add_linear(4, 6.5);
+
+        cqm.constraint_ref(c2).add_linear(5, 8.5);
+        cqm.constraint_ref(c2).add_linear(4, 7.5);
+
+        THEN("we can read off the values as expected") {
+            const auto& const2 = cqm.constraint_ref(c2);
+            REQUIRE(const2.num_variables() == 2);
+            CHECK(const2.linear(4) == 7.5);
+            CHECK(const2.linear(5) == 8.5);
+            CHECK(const2.variables() == std::vector<int>{5, 4});
+        }
+
+        WHEN("constraint c1 is removed") {
+            cqm.remove_constraint(c1);
+
+            THEN("all variables are preserved, but one constraint is removed") {
+                CHECK(cqm.num_variables() == 7);
+                CHECK(cqm.num_constraints() == 2);
+                CHECK(cqm.constraint_ref(1).linear(4) == 7.5);
+            }
+        }
+
+        WHEN("a variable is removed") {
+            cqm.remove_variable(3);
+
+            THEN("everything is updated appropriately") {
+                REQUIRE(cqm.num_variables() == 6);
+
+                const auto& const0 = cqm.constraint_ref(c0);
+                REQUIRE(const0.num_variables() == 3);
+                CHECK(const0.linear(0) == 1.5);
+                CHECK(const0.linear(1) == 2.5);
+                CHECK(const0.linear(2) == 3.5);
+                CHECK(const0.variables() == std::vector<int>{0, 1, 2});
+
+                const auto& const1 = cqm.constraint_ref(c1);
+                REQUIRE(const1.num_variables() == 2);
+                CHECK(const1.linear(2) == 4.5);
+                CHECK(const1.linear(3) == 6.5);                       // reindexed
+                CHECK(const1.variables() == std::vector<int>{2, 3});  // partly reindexed
+
+                const auto& const2 = cqm.constraint_ref(c2);
+                REQUIRE(const2.num_variables() == 2);
+                CHECK(const2.linear(3) == 7.5);                       // reindexed
+                CHECK(const2.linear(4) == 8.5);                       // reindexed
+                CHECK(const2.variables() == std::vector<int>{4, 3});  // reindexed
+            }
+        }
+    }
+
+    GIVEN("A CQM with two constraints") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+        auto x = cqm.add_variable(Vartype::BINARY);
+        auto y = cqm.add_variable(Vartype::BINARY);
+        auto i = cqm.add_variable(Vartype::INTEGER);
+        auto j = cqm.add_variable(Vartype::INTEGER);
+        // auto z = cqm.add_variable(Vartype::BINARY);
+
+        cqm.objective.set_linear(x, 1);
+        cqm.objective.set_linear(y, 2);
+        cqm.objective.set_linear(i, 3);
+        cqm.objective.set_linear(j, 4);
+
+        auto& const0 = cqm.constraint_ref(cqm.add_constraint());
+        const0.set_linear(i, 3);
+        const0.set_quadratic(x, j, 2);
+        const0.set_quadratic(i, j, 5);
+
+        CHECK(cqm.objective.num_variables() == 4);
+        CHECK(const0.num_variables() == 3);
+
+        WHEN("we substitute a variable with a 0 multiplier") {
+            cqm.substitute_variable(x, 0, 0);
+
+            THEN("the biases are updated in the objective and constraint") {
+                REQUIRE(cqm.objective.num_variables() == 4);
+                CHECK(cqm.objective.linear(x) == 0);
+                CHECK(cqm.objective.linear(y) == 2);
+                CHECK(cqm.objective.linear(i) == 3);
+                CHECK(cqm.objective.linear(j) == 4);
+
+                auto& const0 = cqm.constraint_ref(0);
+                REQUIRE(const0.num_variables() == 3);
+                REQUIRE(const0.num_interactions() == 2);
+                CHECK(const0.linear(i) == 3);
+                CHECK(const0.quadratic_at(x, j) == 0);
+                CHECK(const0.quadratic_at(i, j) == 5);
+
+            }
+        }
+
+        // WHEN("we fix a variable") {
+        //     cqm.fix_variable(x, 0);
+
+        //     THEN("everything is updated correctly") {
+        //         REQUIRE(cqm.num_variables() == 3);
+
+        //         REQUIRE(const0.num_variables() == 2);
+        //         REQUIRE(const0.linear(i-1) == 3);
+        //     }
+        // }
+    }
+
+    GIVEN("A constraint with one-hot constraints") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+        cqm.add_variables(Vartype::BINARY, 10);
+        auto c0 = cqm.add_linear_constraint({0, 1, 2, 3, 4}, {1, 1, 1, 1, 1}, Sense::EQ, 1);
+        auto c1 = cqm.add_linear_constraint({5, 6, 7, 8, 9}, {2, 2, 2, 2, 2}, Sense::EQ, 2);
+
+        THEN("the constraints can be tests for one-hotness") {
+            CHECK(cqm.constraint_ref(c0).is_onehot());
+            CHECK(cqm.constraint_ref(c1).is_onehot());
+            CHECK(cqm.constraint_ref(c0).is_disjoint(cqm.constraint_ref(c1)));
+        }
+
+        WHEN("we change a linear bias") {
+            cqm.constraint_ref(c0).set_linear(0, 1.5);
+
+            THEN("it's no longer one-hot") { CHECK(!cqm.constraint_ref(c0).is_onehot()); }
+        }
+
+        WHEN("we add an overlapping variable") {
+            cqm.constraint_ref(c0).set_linear(5, 1);
+            THEN("they are no longer disjoint") {
+                CHECK(cqm.constraint_ref(c0).is_onehot());
+                CHECK(cqm.constraint_ref(c1).is_onehot());
+                CHECK(!cqm.constraint_ref(c0).is_disjoint(cqm.constraint_ref(c1)));
+            }
+        }
+    }
+}
+}  // namespace dimod


### PR DESCRIPTION
Pulls the C++ CQM code from https://github.com/dwavesystems/dimod/pull/1258.

Does *not* implement docs. I am going to do that in a followup PR.

The `Expression` class also has some `not implemented` errors that will need to be implemented. Also will do in a followup PR.