### PR TITLE
Fix performance when loading linear BQMs

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -1268,6 +1268,10 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
                 else:
                     degree = int(2*num_interactions - ldata['nidx'][v])
 
+                if not degree:
+                    # not needed, but helps with performance
+                    continue
+
                 qdata = np.frombuffer(
                     file_like.read(degree*quadratic_dtype.itemsize),
                     dtype=quadratic_dtype)

--- a/releasenotes/notes/fix-bqm-linear-loading-c552e5a39d6a51e5.yaml
+++ b/releasenotes/notes/fix-bqm-linear-loading-c552e5a39d6a51e5.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a performance regression introduced in 0.10.0 when loading linear
+    binary quadratic models from files.


### PR DESCRIPTION
There is still a regression when the BQM has quadratic interactions, but that would be a more invasive fix. Will do that in a followup PR.