### PR TITLE
Restore project for C++ SDK doc build

### DIFF
--- a/docs/reference/cpp.rst
+++ b/docs/reference/cpp.rst
@@ -12,18 +12,20 @@ BinaryQuadraticModel
 
 .. doxygenclass:: dimod::BinaryQuadraticModel
     :members:
-
+    :project: dimod
 
 QuadraticModel
 --------------
 
 .. doxygenclass:: dimod::QuadraticModel
     :members:
+    :project: dimod
 
 Vartype
 -------
 
 .. doxygenenum:: dimod::Vartype
+   :project: dimod
 
 vartype_info
 ------------
@@ -31,6 +33,7 @@ vartype_info
 .. doxygenclass:: dimod::vartype_info
     :members:
     :undoc-members:
+    :project: dimod
 
 .. Todo: vartype_limits. Getting it to look nice is possible but fiddly
 
@@ -40,6 +43,7 @@ dimod::abc
 .. doxygenclass:: dimod::abc::QuadraticModelBase
     :members:
     :protected-members:
+    :project: dimod
 
 .. Todo: dimod lp
 
@@ -47,3 +51,4 @@ dimod::utils
 ============
 
 .. doxygenfunction:: zip_sort
+   :project: dimod


### PR DESCRIPTION
Reverts some changes made in 98cb0f08e7a2f313c3f93c751c7e91e5208d5ee9 to enable C++ doc build [here](https://docs.ocean.dwavesys.com/en/stable/docs_dimod/reference/cpp.html)