### PR TITLE
Add compress kwarg to CQM.to_file()

### DIFF
--- a/releasenotes/notes/compress-kwarg-4d7faa35d0bb2fb2.yaml
+++ b/releasenotes/notes/compress-kwarg-4d7faa35d0bb2fb2.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add ``compress`` keyword argument to ``ConstrainedQuadraticModel.to_file()``.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -968,6 +968,23 @@ class TestSerialization(unittest.TestCase):
     def tearDownClass(cls):
         dimod.REAL_INTERACTIONS = False
 
+    def test_compress(self):
+        num_variables = 50
+        cqm = dimod.CQM()
+        cqm.add_variables('BINARY', range(num_variables))
+        cqm.set_objective((v, 1) for v in range(num_variables))
+        cqm.add_constraint(((v, 1) for v in range(num_variables)), '==', 0)
+
+        with self.subTest("functional"):
+            new = dimod.CQM.from_file(cqm.to_file(compress=True))
+            self.assertTrue(new.is_equal(cqm))
+
+        with self.subTest("size"):
+            self.assertLess(len(cqm.to_file(compress=True).read()),
+                            len(cqm.to_file(compress=False).read()))
+            self.assertLess(len(cqm.to_file(compress=True).read()),
+                            len(cqm.to_file().read()))  # default
+
     def test_functional(self):
         cqm = CQM()
 


### PR DESCRIPTION
Address the CQM part of https://github.com/dwavesystems/dimod/issues/1235.

Because we use `zipfile` for our CQMs, we get backwards compatibility for free.