### PR TITLE
Add ConstrainedQuadraticModel.add_linear_constraints() method

### DIFF
--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -709,7 +709,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
         Args:
             A: Each row of ``A`` specifies the coefficients of a linear constraint.
             sense: One of `<=`, `>=`, `==`.
-            b: An array of left-hand-sides of the constraints.
+            b: An array of right-hand-sides of the constraints.
             variable_labels: The variable labels corresponding to the columns of `A`.
                 If ``None``, defaults to ``range(A.shape[1])``.
             constraint_labels: The labels of the constraints. Labels of additional
@@ -725,7 +725,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
                 -x_0 + x_1 \le 1 \\
                 3x_1 + x_2 \le 3
 
-            We can specify the constraints using matrices and vectors
+            You can specify the constraints using matrices and vectors:
 
             >>> cqm = dimod.ConstrainedQuadraticModel()
             >>> cqm.add_variables("BINARY", 3)

--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -702,7 +702,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
                 A_{ub}x \le b_{ub}, \\
                 A_{eq}x = b_{eq}
 
-        where `x` is a vector of binary decision variables,
+        where `x` is a vector of decision variables,
         :math:`b_{ub}` and :math:`b_{eq}` are vectors,
         and :math:`A_{ub}` and :math:`A_{eq}` are matrices.
 

--- a/dimod/constrained/cyconstrained.pyx
+++ b/dimod/constrained/cyconstrained.pyx
@@ -20,6 +20,8 @@ import typing
 
 from copy import deepcopy
 
+cimport cython
+
 from cython.operator cimport preincrement as inc, dereference as deref
 from libc.math cimport ceil, floor
 from libcpp.unordered_set cimport unordered_set
@@ -32,7 +34,7 @@ from dimod.binary import BinaryQuadraticModel
 from dimod.constrained.expression import ObjectiveView, ConstraintView
 from dimod.cyqmbase cimport cyQMBase
 from dimod.cyqmbase.cyqmbase_float64 import BIAS_DTYPE, INDEX_DTYPE
-from dimod.cyutilities cimport as_numpy_float
+from dimod.cyutilities cimport as_numpy_float, ConstNumeric, ConstNumeric2
 from dimod.cyutilities cimport cppvartype
 from dimod.libcpp.abc cimport QuadraticModelBase as cppQuadraticModelBase
 from dimod.libcpp.constrained_quadratic_model cimport Sense as cppSense, Penalty as cppPenalty, Constraint as cppConstraint
@@ -279,6 +281,57 @@ cdef class cyConstrainedQuadraticModel:
         v = self.variables._append(v)
         self.cppcqm.add_variable(vt, lb, ub)
         return v
+
+    # dev note: we explicitly don't want contiguous to allow fancy indexing
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def add_linear_constraints(self, ConstNumeric[:, :] A, object sense, ConstNumeric2[:] b,
+                               *,
+                               variable_labels=None, constraint_labels=None):
+
+        # Input parsing for A, b
+        cdef Py_ssize_t num_constraints = A.shape[0]
+        cdef Py_ssize_t num_variables = A.shape[1]
+        if b.shape[0] != num_constraints:
+            raise ValueError("the number of rows in A must equal the number of values in b")
+
+        # Input parsing for sense
+        cdef cppSense sense_ = cppsense(sense)
+
+        # Input parsing for variable labels
+        if variable_labels is None:
+            variable_labels = range(num_variables)
+
+        cdef vector[index_type] variables  # map input variable row to internal index
+        variables.reserve(num_variables)
+        for v in variable_labels:
+            variables.push_back(self.variables.index(v))
+        if variables.size() != num_variables:
+            raise ValueError("expected the length of variable_labels to equal the number of columns in A")
+
+        # Input parsing for constraint_labels
+        # if the list is too short, we start generating random labels
+        if constraint_labels is None:
+            constraint_labels = itertools.repeat(None)
+        else:
+            constraint_labels = itertools.chain(constraint_labels, itertools.repeat(None))
+
+        # At this point we've checked everything, so it should be safe to just
+        # add new constraints to the model, because we shouldn't be able to get
+        # a malformed model partway through
+        cdef Py_ssize_t ci, vi
+        for ci in range(num_constraints):
+            constraint = self.cppcqm.new_constraint()
+
+            constraint.set_sense(sense_)
+            constraint.set_rhs(b[ci])
+
+            for vi in range(num_variables):
+                if A[ci, vi]:
+                    constraint.add_linear(variables[vi], A[ci, vi])
+
+            self.cppcqm.add_constraint(move(constraint))
+            self.constraint_labels._append(next(constraint_labels))
 
     def change_vartype(self, vartype, v):
         vartype = as_vartype(vartype, extended=True)

--- a/dimod/cyutilities.pxd
+++ b/dimod/cyutilities.pxd
@@ -66,6 +66,15 @@ ctypedef fused ConstNumeric:
     const float
     const double
 
+# for when there are two input arguments of different types 
+ctypedef fused ConstNumeric2:
+    const signed char
+    const signed short
+    const signed int
+    const signed long long
+    const float
+    const double
+
 
 cdef object as_numpy_float(cython.floating)
 

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -168,6 +168,7 @@ CQM Methods
    ~ConstrainedQuadraticModel.add_discrete_from_comparison
    ~ConstrainedQuadraticModel.add_discrete_from_iterable
    ~ConstrainedQuadraticModel.add_discrete_from_model
+   ~ConstrainedQuadraticModel.add_linear_constraints
    ~ConstrainedQuadraticModel.add_variable
    ~ConstrainedQuadraticModel.check_feasible
    ~ConstrainedQuadraticModel.fix_variable

--- a/releasenotes/notes/CQM.add_linear_constraints-532d0d1d18916748.yaml
+++ b/releasenotes/notes/CQM.add_linear_constraints-532d0d1d18916748.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``ConstrainedQuadraticModel.add_linear_constraints()`` method.


### PR DESCRIPTION
Speeds up adding linear constraints to the CQM. We get about a 10x speedup.

```python
import time

import dimod
import numpy as np

num_variables = 1_000
num_constraints = 5_000
pnz = .25  # probability that a bias is non-zero

rng = np.random.default_rng(42)

A = rng.uniform(size=(num_constraints, num_variables))
A[A > pnz] = 0
b = rng.uniform(size=num_constraints)

####################

t = time.perf_counter()

cqm = dimod.ConstrainedQuadraticModel()
cqm.add_variables("BINARY", num_variables)

ci = 0
for rhs, lhs in zip(A, b):
    cqm.add_constraint(((v, bias) for v, bias in enumerate(rhs) if bias), '==', lhs, label=ci)
    ci += 1

print(f"old: {time.perf_counter() - t}")

old = cqm

###################

t = time.perf_counter()

cqm = dimod.ConstrainedQuadraticModel()
cqm.add_variables("BINARY", num_variables)
cqm.add_linear_constraints(A, '==', b, constraint_labels=range(num_constraints))

print(f"new: {time.perf_counter() - t}")
```
Gives
```
old: 0.6515062270009366
new: 0.07133342499946593
```