### PR TITLE
Make optional sampler args keyword-only

### DIFF
--- a/dimod/reference/samplers/exact_solver.py
+++ b/dimod/reference/samplers/exact_solver.py
@@ -214,8 +214,10 @@ class ExactCQMSolver():
         self.properties = {}
         self.parameters = {}
 
-    def sample_cqm(self, cqm: ConstrainedQuadraticModel, rtol: float = 1e-6,
-                   atol: float = 1e-8, **kwargs) -> SampleSet:
+    def sample_cqm(self, cqm: ConstrainedQuadraticModel, *,
+                   rtol: float = 1e-6,
+                   atol: float = 1e-8,
+                   **kwargs) -> SampleSet:
         """Sample from a constrained quadratic model.
 
         Args:

--- a/dimod/reference/samplers/identity_sampler.py
+++ b/dimod/reference/samplers/identity_sampler.py
@@ -73,7 +73,7 @@ class IdentitySampler(Sampler, Initialized):
 
     properties = {}
 
-    def sample(self, bqm: BinaryQuadraticModel,
+    def sample(self, bqm: BinaryQuadraticModel, *,
                initial_states: typing.Optional[SamplesLike] = None,
                initial_states_generator: InitialStateGenerator = 'random',
                num_reads: typing.Optional[int] = None,

--- a/dimod/reference/samplers/random_sampler.py
+++ b/dimod/reference/samplers/random_sampler.py
@@ -45,7 +45,7 @@ class RandomSampler(Sampler):
         self.parameters = {'num_reads': []}
         self.properties = {}
 
-    def sample(self, bqm, num_reads=10, seed=None, **kwargs):
+    def sample(self, bqm, *, num_reads=10, seed=None, **kwargs):
         """Return random samples for a binary quadratic model.
 
         Variable assignments are chosen by coin flip.

--- a/dimod/reference/samplers/simulated_annealing.py
+++ b/dimod/reference/samplers/simulated_annealing.py
@@ -58,7 +58,7 @@ class SimulatedAnnealingSampler(Sampler):
                            'num_sweeps': []}
         self.properties = {}
 
-    def sample(self, bqm, beta_range=None, num_reads=10, num_sweeps=1000, **kwargs):
+    def sample(self, bqm, *, beta_range=None, num_reads=10, num_sweeps=1000, **kwargs):
         """Sample from low-energy spin states using simulated annealing.
 
         Args:

--- a/releasenotes/notes/sampler-kwarg-only-args-060c1b5ac2615463.yaml
+++ b/releasenotes/notes/sampler-kwarg-only-args-060c1b5ac2615463.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - Make ``beta_range``, ``num_reads``, and ``num_sweeps`` keyword-only arguments for ``SimulatedAnnealingSampler.sample()``.
+  - Make ``num_reads`` and ``seed`` keyword-only arguments for ``RandomSampler.sample()``.
+  - Make ``initial_states``, ``initial_states_generator``, ``num_reads`` and ``seed`` keyword-only arguments for ``IdentitySampler.sample()``.
+  - Make ``rtol`` and ``atol`` keyword-only arguments for ``ExactCQMSolver.sample_cqm()``.


### PR DESCRIPTION
This helps avoid confusing results when switching between samplers.

This is a backwards compatibility break, but a minor one so I think it's safe.