### PR TITLE
Improve the performance of removing variables from expressions

### DIFF
--- a/dimod/include/dimod/abc.h
+++ b/dimod/include/dimod/abc.h
@@ -707,7 +707,7 @@ void QuadraticModelBase<bias_type, index_type>::fix_variable(index_type v, T ass
     add_offset(assignment * linear(v));
 
     // finally remove v
-    remove_variable(v);
+    QuadraticModelBase<bias_type, index_type>::remove_variable(v);
 }
 
 template <class bias_type, class index_type>

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -64,6 +64,15 @@ class QuadraticModel : public abc::QuadraticModelBase<Bias, Index> {
     /// Change the vartype of `v`, updating the biases appropriately.
     void change_vartype(Vartype vartype, index_type v);
 
+    /**
+     * Remove variable `v` from the model by fixing its value.
+     *
+     * Note that this causes a reindexing, where all variables above `v` have
+     * their index reduced by one.
+     */
+    template <class T>
+    void fix_variable(index_type v, T assignment);
+
     /// Return the lower bound on variable ``v``.
     bias_type lower_bound(index_type v) const;
 
@@ -227,6 +236,13 @@ void QuadraticModel<bias_type, index_type>::change_vartype(Vartype vartype, inde
         // todo: there are more we could support
         throw std::logic_error("unsupported vartype change");
     }
+}
+
+template <class bias_type, class index_type>
+template <class T>
+void QuadraticModel<bias_type, index_type>::fix_variable(index_type v, T assignment) {
+    base_type::fix_variable(v, assignment);
+    varinfo_.erase(varinfo_.begin() + v);
 }
 
 template <class bias_type, class index_type>

--- a/releasenotes/notes/expression-fix-variables-performance-f13a65b6a16fa484.yaml
+++ b/releasenotes/notes/expression-fix-variables-performance-f13a65b6a16fa484.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Improve the performance of fixing and removing variables from constrained
+    quadratic model expressions.
+  - |
+    Implement the ``Expression::fix_variable()`` C++ method. Previously it would
+    throw ``std::logic_error("not implemented - fix_variable")``.
+upgrade:
+  - |
+    Add an overload to the C++ ``QuadraticModel::remove_variable()`` method.
+    This is binary compatible, but it makes ``&remove_variable`` ambiguous.

--- a/testscpp/tests/test_constrained_quadratic_model.cpp
+++ b/testscpp/tests/test_constrained_quadratic_model.cpp
@@ -410,16 +410,36 @@ SCENARIO("ConstrainedQuadraticModel  tests") {
             }
         }
 
-        // WHEN("we fix a variable") {
-        //     cqm.fix_variable(x, 0);
+        WHEN("we fix a variable that is not used in the expression") {
+            const0.fix_variable(y, 2);
 
-        //     THEN("everything is updated correctly") {
-        //         REQUIRE(cqm.num_variables() == 3);
+            THEN("nothing changes") {
+                REQUIRE(const0.num_variables() == 3);
+                CHECK(const0.linear(x) == 0);
+                CHECK(const0.linear(y) == 0);
+                CHECK(const0.linear(i) == 3);
+                CHECK(const0.linear(j) == 0);
 
-        //         REQUIRE(const0.num_variables() == 2);
-        //         REQUIRE(const0.linear(i-1) == 3);
-        //     }
-        // }
+                CHECK(const0.num_interactions() == 2);
+                CHECK(const0.quadratic(x, j) == 2);
+                CHECK(const0.quadratic(i, j) == 5);
+            }
+        }
+
+        WHEN("we fix a variable that is used in the expression") {
+            const0.fix_variable(x, 2);
+
+            THEN("the biases are updated") {
+                REQUIRE(const0.num_variables() == 2);
+                CHECK(const0.linear(x) == 0);
+                CHECK(const0.linear(y) == 0);
+                CHECK(const0.linear(i) == 3);
+                CHECK(const0.linear(j) == 4);
+
+                CHECK(const0.num_interactions() == 1);
+                CHECK(const0.quadratic(i, j) == 5);
+            }
+        }
     }
 
     GIVEN("A constraint with one-hot constraints") {


### PR DESCRIPTION
This provides a pretty significant performance improvement when fixing variables in individual constraints.
```python
import time

import dimod

num_variables = 10_000

cqm = dimod.ConstrainedQuadraticModel()
cqm.add_variables("BINARY", num_variables)
c0 = cqm.add_constraint(((v, 1) for v in range(num_variables)), '==', 1)
expr = cqm.constraints[c0].lhs

t = time.perf_counter()
for v in range(num_variables):
    expr.fix_variable(v, 0)
print(time.perf_counter() - t)
```
Gives a time of ~0.15s vs 1.37s on 0.12.4 on my system.

The majority of the improvement comes from optimizing `remove_variable()`. In fact, the C++ `fix_variable()` is not even called from the Python code. I did test adding a dedicated Cython call rather than [using the view](https://github.com/dwavesystems/dimod/blob/5ef7897af313fcad59b4fd38617d07904ffb6470/dimod/views/quadratic.py#L429-L448), but that doesn't change the performance very much at all since the vast majority of the time is spent on rebuilding the indices.

*Additional Context*
This is a first step to addressing https://github.com/dwavesystems/dimod/issues/1317. But it doesn't actually touch the relevant code (yet).