### PR TITLE
Improve the performance of CQM.fix_variables()

### DIFF
--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -813,51 +813,39 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
                           "and will be removed in 0.14.0", DeprecationWarning,
                           stacklevel=2)
 
-        # get the discrete constaints that are possibly affected
-        discrete = dict()
-        for label in self.discrete:
-            lhs = self.constraints[label].lhs
-            if v in lhs.variables:
-                discrete[label] = lhs
-
         super().fix_variable(v, value)
 
-        if discrete:
-            if value == 1:
-                self.discrete -= discrete
-            else:
-                for label, lhs in discrete.items():
-                    if lhs.num_variables <= 1:
-                        self.discrete.discard(label)
         return {}
 
     def fix_variables(self,
                       fixed: Union[Mapping[Variable, float],
-                                          Iterable[Tuple[Variable, float]]],
+                                   Iterable[Tuple[Variable, float]]],
                       *,
+                      inplace: bool = True,
                       cascade: Optional[bool] = None,
-                      ) -> Dict[Variable, float]:
+                      ) -> ConstrainedQuadraticModel:
         """Fix the value of the variables and remove them.
 
         Args:
             fixed: Dictionary or iterable of 2-tuples of variable assignments.
+            inplace: If False, a new model is returned with the variables fixed.
             cascade: Deprecated. Does nothing.
 
         Returns:
-            An empty dictionary, for legacy reasons.
+            A constrained quadratic model. Itself by default, or a copy if
+            ``inplace`` is set to False.
 
         .. deprecated:: 0.12.0
             The ``cascade`` keyword argument will be removed in 0.14.0.
             It currently does nothing.
 
         """
-        if isinstance(fixed, Mapping):
-            fixed = fixed.items()
+        if cascade is not None:
+            warnings.warn("The 'cascade' keyword argument is deprecated since dimod 0.12.0 "
+                          "and will be removed in 0.14.0", DeprecationWarning,
+                          stacklevel=2)
 
-        for v, val in fixed:
-            self.fix_variable(v, val, cascade=cascade)
-
-        return {}
+        return super().fix_variables(fixed, inplace=inplace)
 
     def flip_variable(self, v: Variable):
         r"""Flip the specified binary variable in the objective and constraints.

--- a/dimod/include/dimod/constrained_quadratic_model.h
+++ b/dimod/include/dimod/constrained_quadratic_model.h
@@ -162,7 +162,12 @@ class ConstrainedQuadraticModel {
     /// Create a new model by fixing many variables.
     template <class VarIter, class AssignmentIter>
     ConstrainedQuadraticModel fix_variables(VarIter first, VarIter last,
-                                            AssignmentIter assignments) const;
+                                            AssignmentIter assignment) const;
+
+    /// Create a new model by fixing many variables.
+    template <class T>
+    ConstrainedQuadraticModel fix_variables(std::initializer_list<index_type> variables,
+                                            std::initializer_list<T> assignments) const;
 
     /// Return the lower bound on variable ``v``.
     bias_type lower_bound(index_type v) const;
@@ -627,6 +632,14 @@ ConstrainedQuadraticModel<bias_type, index_type>::fix_variables(VarIter first, V
     }
 
     return cqm;
+}
+
+template <class bias_type, class index_type>
+template <class T>
+ConstrainedQuadraticModel<bias_type, index_type>
+ConstrainedQuadraticModel<bias_type, index_type>::fix_variables(
+        std::initializer_list<index_type> variables, std::initializer_list<T> assignments) const {
+    return fix_variables(variables.begin(), variables.end(), assignments.begin());
 }
 
 template <class bias_type, class index_type>

--- a/dimod/include/dimod/constrained_quadratic_model.h
+++ b/dimod/include/dimod/constrained_quadratic_model.h
@@ -626,7 +626,7 @@ ConstrainedQuadraticModel<bias_type, index_type>::fix_variables(VarIter first, V
         new_constraint.set_weight(old_constraint_ptr->weight());
         new_constraint.set_penalty(old_constraint_ptr->penalty());
         new_constraint.mark_discrete(old_constraint_ptr->marked_discrete() &&
-                                     old_constraint_ptr->is_onehot());
+                                     new_constraint.is_onehot());
 
         cqm.add_constraint(std::move(new_constraint));
     }

--- a/dimod/include/dimod/constrained_quadratic_model.h
+++ b/dimod/include/dimod/constrained_quadratic_model.h
@@ -593,9 +593,6 @@ ConstrainedQuadraticModel<bias_type, index_type>::fix_variables(VarIter first, V
     // We could inherit the type from AssignmentIter, but again this seems simpler.
     std::vector<bias_type> assignments(this->num_variables());
 
-    // Map from the new indices to the old
-    std::vector<index_type> new_to_old;
-
     // Fill in our various data vectors and add the variables to the new model
     for (auto it = first; it != last; ++it, ++assignment) {
         old_to_new[*it] = -1;
@@ -606,7 +603,6 @@ ConstrainedQuadraticModel<bias_type, index_type>::fix_variables(VarIter first, V
 
         old_to_new[i] =
                 cqm.add_variable(this->vartype(i), this->lower_bound(i), this->upper_bound(i));
-        new_to_old.push_back(i);
     }
 
     // Objective

--- a/dimod/libcpp/constrained_quadratic_model.pxd
+++ b/dimod/libcpp/constrained_quadratic_model.pxd
@@ -41,6 +41,7 @@ cdef extern from "dimod/constrained_quadratic_model.h" namespace "dimod" nogil:
         Constraint[bias_type, index_type]& constraint_ref(index_type)
         weak_ptr[Constraint[bias_type, index_type]] constraint_weak_ptr(index_type)
         void fix_variable[T](index_type, T)
+        ConstrainedQuadraticModel fix_variables[VarIter, AssignmentIter](VarIter, VarIter, AssignmentIter)
         bias_type lower_bound(index_type)
         Constraint[bias_type, index_type] new_constraint()
         size_t num_constraints()

--- a/dimod/libcpp/expression.pxd
+++ b/dimod/libcpp/expression.pxd
@@ -58,4 +58,4 @@ cdef extern from "dimod/expression.h" namespace "dimod" nogil:
 
         bint has_variable(index_type)
         bint is_disjoint(const Expression&)
-        vector[index_type]& variables()
+        const vector[index_type]& variables()

--- a/releasenotes/notes/fix-variables-performance-9c90a58c968aa710.yaml
+++ b/releasenotes/notes/fix-variables-performance-9c90a58c968aa710.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Improve the performance of ``ConstrainedQuadraticModel.fix_variable()`` and
+    ``ConstrainedQuadraticModel.fix_variables()``.
+  - |
+    Add ``inplace`` keyword argument to ``ConstrainedQuadraticModel.fix_variables()``.
+upgrade:
+  - |
+    The ``ConstrainedQuadraticModel.fix_variables()`` function now returns
+    a ``ConstrainedQuadraticModel`` rather than an empty dictionary.

--- a/testscpp/tests/test_constrained_quadratic_model.cpp
+++ b/testscpp/tests/test_constrained_quadratic_model.cpp
@@ -442,6 +442,35 @@ SCENARIO("ConstrainedQuadraticModel  tests") {
         }
     }
 
+    GIVEN("A discrete constraint") {
+        auto cqm = ConstrainedQuadraticModel<double>();
+        cqm.add_variables(Vartype::BINARY, 5);
+        auto c0 = cqm.add_linear_constraint({0, 1, 2, 3, 4}, {1, 1, 1, 1, 1}, Sense::EQ, 1);
+        cqm.constraint_ref(c0).mark_discrete();
+
+        WHEN("we fix a variable to 0 while making a new cqm") {
+            auto sub_cqm = cqm.fix_variables({2}, {0});
+
+            THEN("the constraint is still discrete") {
+                CHECK(sub_cqm.num_variables() == 4);
+                REQUIRE(sub_cqm.num_constraints() == 1);
+                CHECK(sub_cqm.constraint_ref(0).marked_discrete());
+                CHECK(sub_cqm.constraint_ref(0).is_onehot());
+            }
+        }
+
+        WHEN("we fix a variable to 1 while making a new cqm") {
+            auto sub_cqm = cqm.fix_variables({2}, {1});
+
+            THEN("the constraint is no longer discrete") {
+                CHECK(sub_cqm.num_variables() == 4);
+                REQUIRE(sub_cqm.num_constraints() == 1);
+                CHECK(!sub_cqm.constraint_ref(0).marked_discrete());
+                CHECK(!sub_cqm.constraint_ref(0).is_onehot());
+            }
+        }
+    }
+
     GIVEN("A constraint with one-hot constraints") {
         auto cqm = ConstrainedQuadraticModel<double>();
         cqm.add_variables(Vartype::BINARY, 10);


### PR DESCRIPTION
Add the ability to generate a new model when fixing variables rather than acting on the CQM in-place. This is almost always more performant. For instance, see the times for a 1000 variable and 1000 constraint CQM with different numbers of variables fixed.

![trials](https://user-images.githubusercontent.com/8395238/228688269-be381b17-f5e2-4c0d-b01e-5ec34e77d941.png)

Closes #1319 
