### PR TITLE
Use codecov's orb rather than their removed pypi package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,10 @@ jobs:
             pip install -r requirements.txt -r tests/requirements.txt
             python setup.py build_ext --inplace
             coverage run -m unittest
-      - codecov/upload
+      - codecov/upload:
+          file: .coverage
+      - codecov/upload:
+          file: testscpp/coverage.info
 
   test-doctest:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.3
+  codecov: codecov/codecov@3
   win: circleci/windows@2.2.0
 
 environment: &global-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 orbs:
+  codecov: codecov/codecov@3.2.3
   win: circleci/windows@2.2.0
 
 environment: &global-environment
@@ -186,11 +187,7 @@ jobs:
             pip install -r requirements.txt -r tests/requirements.txt
             python setup.py build_ext --inplace
             coverage run -m unittest
-      - run:
-          name: codecov
-          command: |
-            . env/bin/activate
-            codecov
+      - codecov/upload
 
   test-doctest:
     docker:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 coverage[toml]
-codecov
 
 parameterized==0.7.4
 


### PR DESCRIPTION
Codecov was removed from pypi ([link](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/), [link](https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259), and [link](https://about.codecov.io/blog/message-regarding-the-pypi-package/)).

They recommend using their orb, so let's give that a go.