### PR TITLE
Generate an .xml file for Python coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,8 +187,9 @@ jobs:
             pip install -r requirements.txt -r tests/requirements.txt
             python setup.py build_ext --inplace
             coverage run -m unittest
+            coverage xml
       - codecov/upload:
-          file: .coverage
+          file: coverage.xml
       - codecov/upload:
           file: testscpp/coverage.info
 


### PR DESCRIPTION
Codecov does not support `coverage`'s default file format ([link](https://docs.codecov.com/docs/supported-report-formats)). So we explicitly cast to xml.