### PR TITLE
Implement CaseLabelDQM.to_file() when ignoring labels

### DIFF
--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -764,7 +764,7 @@ class DiscreteQuadraticModel:
         file.write(np.dtype('<u4').type(end - start).tobytes())
         file.seek(end)
 
-    def to_file(self, compress=False, compressed=None, ignore_labels=False,
+    def to_file(self, *, compress=False, compressed=None, ignore_labels=False,
                 spool_size=int(1e9)):
         """Convert the DQM to a file-like object.
 
@@ -1299,8 +1299,15 @@ class CaseLabelDQM(DQM):
         else:
             return list(range_)
 
-    def to_file(self, *args, **kwargs):
-        raise NotImplementedError
+    def to_file(self, *, ignore_labels=False, **kwargs):
+        # We keep the default value the same as the super class, but if
+        # we're ignoring the labels, the serialization is identical to
+        # that of the unlabelled DQM
+        if ignore_labels:
+            return super().to_file(ignore_labels=True, **kwargs)
+
+        raise NotImplementedError("serialization for CaseLabelDQM is not implemented, "
+                                  "try using ignore_labels=True")
 
     def map_sample(self, sample):
         """Transform a sample to reflect case labels.

--- a/releasenotes/notes/CaseLabelDQM.to_file-775d4d79237f01c7.yaml
+++ b/releasenotes/notes/CaseLabelDQM.to_file-775d4d79237f01c7.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Implement ``CaseLabelDQM.to_file()`` when the keyword argument ``ignore_labels``
+    is true. Also make the error message clearer in the case that ``ignore_labels``
+    is false.
+upgrade:
+  - Make the arguments of ``DiscreteQuadraticModel.to_file()`` keyword-only.

--- a/tests/test_discrete_quadratic_model.py
+++ b/tests/test_discrete_quadratic_model.py
@@ -362,6 +362,25 @@ class TestFile(unittest.TestCase):
         with dimod.DQM().to_file() as f:
             self.assertTrue(f.writable())
 
+    def test_case_label(self):
+        cldqm = dimod.CaseLabelDQM()
+        cldqm.add_variable('abcde')
+        cldqm.add_variable('fghijkl')
+
+        cldqm.set_linear('d', 1.5)
+        cldqm.set_quadratic('a', 'g', 1.5)
+        cldqm.set_quadratic('d', 'j', 1)
+
+        dqm = dimod.DQM()
+        dqm.add_variable(5)
+        dqm.add_variable(7)
+
+        dqm.set_linear_case(0, 3, 1.5)
+        dqm.set_quadratic(0, 1, {(0, 1): 1.5, (3, 4): 1})
+
+        with cldqm.to_file(ignore_labels=True) as f:
+            self.assertDQMEqual(dimod.DQM.from_file(f), dqm)
+
 
 class TestLinear(unittest.TestCase):
     def test_set_linear_case(self):


### PR DESCRIPTION
Currently, that method just raises a `NotImplementedError`. With this change, the case where the labels would be ignored will now function. Specifically, this allows it to work with [dwave-system's LeapHybridDQMSampler](https://github.com/dwavesystems/dwave-system/blob/2aff1a8e5c05de21bc03b287f340db4303f10254/dwave/system/samplers/leap_hybrid_sampler.py#L484-L485) without needing even more switching behavior.