### PR TITLE
Fix ConstrainedQuadraticModel.from_discrete_quadratic_model()

### DIFF
--- a/releasenotes/notes/fix-CQM.from_dqm-f9b7b35c91118d0a.yaml
+++ b/releasenotes/notes/fix-CQM.from_dqm-f9b7b35c91118d0a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - Fix ``ConstrainedQuadraticModel.from_discrete_quadratic_model()`` incorrectly
+    formulating the discrete constraints. This bug was introcued in version 0.12.7.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -877,6 +877,13 @@ class TestFromDQM(unittest.TestCase):
 
         self.assertEqual(set(cqm.constraints), set(dqm.variables))
 
+        for v in dqm.variables:
+            self.assertEqual(cqm.constraints[v].lhs.num_variables, dqm.num_cases(v))
+            self.assertTrue(cqm.constraints[v].lhs.is_discrete())
+
+        self.assertEqual(cqm.constraints["v"].lhs.variables,
+                         [('v', 'blue'), ('v', 'yellow'), ('v', 'brown')])
+
     def test_empty(self):
         dqm = dimod.DiscreteQuadraticModel()
 
@@ -913,6 +920,10 @@ class TestFromDQM(unittest.TestCase):
 
         # keys of constraints are the variables of DQM
         self.assertEqual(set(cqm.constraints), set(dqm.variables))
+
+        for v in dqm.variables:
+            self.assertEqual(cqm.constraints[v].lhs.num_variables, dqm.num_cases(v))
+            self.assertTrue(cqm.constraints[v].lhs.is_discrete())
 
 
 class TestNumBiases(unittest.TestCase):


### PR DESCRIPTION
The error was due to Cython's automatic type assignment not using a reference resulting in a copy.