### PR TITLE
Convert floats representing integers to int in sample set serialization

### DIFF
--- a/dimod/sampleset.py
+++ b/dimod/sampleset.py
@@ -1767,7 +1767,7 @@ class SampleSet(abc.Iterable, abc.Sized):
             :meth:`~.SampleSet.from_serializable`
 
         """
-        schema_version = "3.1.0"
+        schema_version = "3.2.0"
 
         # developer note: numpy's record array stores the samples, energies,
         # num_occ. etc as a struct array. If we dumped that array directly to

--- a/dimod/serialization/utils.py
+++ b/dimod/serialization/utils.py
@@ -34,7 +34,7 @@ def _replace_float_with_int(arr: Union[List[float], List[List]]):
     ``int``.
 
     This function assumes some uniformity of the list structure. For instance giving it
-    a list like ``[0.0, 0]`` or ``[0.0, [0.0]`` will cause it to fail.
+    a list like ``[0.0, 0]`` or ``[0.0, [0.0]]`` will cause it to fail.
 
     Acts on the list(s) in-place.
     """
@@ -51,7 +51,7 @@ def _replace_float_with_int(arr: Union[List[float], List[List]]):
 
     else:
         raise ValueError("expected a (possibly nested) list of floats, "
-                         f"recieved a (possible nested) list of {type(arr[0])}")
+                         f"received a (possibly nested) list of {type(arr[0])}")
 
 
 def serialize_ndarray(arr, use_bytes=False, bytes_type=bytes):

--- a/releasenotes/notes/sampleset-serialization-replace-float-with-int-5a3133c66480b8f4.yaml
+++ b/releasenotes/notes/sampleset-serialization-replace-float-with-int-5a3133c66480b8f4.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Implement ``SampleSet`` serialization schema version 3.2.0.
+
+    Version 3.2.0 replaces ``float`` values that represent integers with ``int``
+    in the ``"data"`` field of any arrays returned by ``SampleSet.to_serializable()``.
+    In some pathological cases this can result in a much smaller representation
+    when the data dictionaries are json-serialized by avoiding the redundant
+    ``.0`` appended to every value.
+
+    This is a backwards-compatible change.


### PR DESCRIPTION
This does come with a performance hit. However it is relatively minor. Testing two edge cases on my system

```python
import time

import dimod
import numpy as np

arr = np.full((100, 500000), 1, dtype=float)  # can be converted

t = time.perf_counter()
dimod.serialization.utils.serialize_ndarray(arr)
print(time.perf_counter() - t)
```
takes `~5.5` seconds on this branch and `~1` second on dimod 0.12.10.

```python
import time

import dimod
import numpy as np

arr = np.full((100, 500000), 1.5, dtype=float)  # cannot be converted

t = time.perf_counter()
dimod.serialization.utils.serialize_ndarray(arr)
print(time.perf_counter() - t)
```
takes `~3.5` seconds on this branch and `~1` second on dimod 0.12.10.

For context, actually Json-serializing the resulting object at this scale takes `~27.8` seconds to dump to a file and `~6.7` seconds to dump to a string.