### PR TITLE
Add QuadraticModelBase::remove_variables() method

### DIFF
--- a/dimod/include/dimod/abc.h
+++ b/dimod/include/dimod/abc.h
@@ -925,6 +925,8 @@ void QuadraticModelBase<bias_type, index_type>::remove_variable(index_type v) {
 template <class bias_type, class index_type>
 void QuadraticModelBase<bias_type, index_type>::remove_variables(
         const std::vector<index_type>& variables) {
+    if (!variables.size()) return;  // shortcut
+
     if (!std::is_sorted(variables.begin(), variables.end())) {
         // create a copy and sort it
         std::vector<index_type> sorted_indices = variables;
@@ -956,7 +958,7 @@ void QuadraticModelBase<bias_type, index_type>::remove_variables(
                     ++it;
                 }
 
-                if (*it == term.v) return true;  // remove matches
+                if (it != end && *it == term.v) return true;  // remove matches
 
                 // otherwise decrement v by the number of indices that have
                 // been removed but don't remove the term itself

--- a/dimod/include/dimod/expression.h
+++ b/dimod/include/dimod/expression.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
@@ -648,16 +649,18 @@ void Expression<bias_type, index_type>::remove_variables(Iter first, Iter last) 
     std::sort(to_remove.begin(), to_remove.end());
 
     // remove the indices from variables_ and the underlying
-    variables_.erase(utils::remove_by_index(variables_.begin(), variables_.end(), to_remove.begin(), to_remove.end()), variables_.end());
+    variables_.erase(utils::remove_by_index(variables_.begin(), variables_.end(), to_remove.begin(),
+                                            to_remove.end()),
+                     variables_.end());
 
     // remove the indices from the underlying quadratic model
     base_type::remove_variables(to_remove);
 
-     // finally fix the indices by rebuilding from scratch
+    // finally fix the indices by rebuilding from scratch
     indices_.clear();
     for (size_type i = 0, end = variables_.size(); i < end; ++i) {
         indices_[variables_[i]] = i;
-    }   
+    }
 }
 
 template <class bias_type, class index_type>

--- a/dimod/include/dimod/expression.h
+++ b/dimod/include/dimod/expression.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "dimod/abc.h"
+#include "dimod/utils.h"
 #include "dimod/vartypes.h"
 
 namespace dimod {
@@ -271,6 +272,10 @@ class Expression : public abc::QuadraticModelBase<Bias, Index> {
     /// Remove several variables from the expression.
     template<class Iter>
     void remove_variables(Iter first, Iter last);
+
+    void remove_variables(const std::vector<index_type>& variables) override {
+        return remove_variables(variables.begin(), variables.end());
+    }
 
     /// Set the linear bias of variable `v`.
     void set_linear(index_type v, bias_type bias);
@@ -632,33 +637,27 @@ void Expression<bias_type, index_type>::remove_variable(index_type v) {
 template <class bias_type, class index_type>
 template <class Iter>
 void Expression<bias_type, index_type>::remove_variables(Iter first, Iter last) {
-    std::unordered_set<index_type> to_remove;
+    // get the indices of any variables that need to be removed
+    std::vector<index_type> to_remove;
     for (auto it = first; it != last; ++it) {
-        if (indices_.find(*it) != indices_.end()) {
-            to_remove.emplace(*it);
+        auto search = indices_.find(*it);
+        if (search != indices_.end()) {
+            to_remove.emplace_back(search->second);
         }
     }
+    std::sort(to_remove.begin(), to_remove.end());
 
-    if (!to_remove.size()) {
-        return;  // nothing to remove
-    }
+    // remove the indices from variables_ and the underlying
+    variables_.erase(utils::remove_by_index(variables_.begin(), variables_.end(), to_remove.begin(), to_remove.end()), variables_.end());
 
-    // now remove any variables found in to_remove
-    size_type i = 0;
-    while (i < this->num_variables()) {
-        if (to_remove.count(variables_[i])) {
-            base_type::remove_variable(i);
-            variables_.erase(variables_.begin() + i);
-        } else {
-            ++i;
-        }
-    }
+    // remove the indices from the underlying quadratic model
+    base_type::remove_variables(to_remove);
 
-    // finally fix the indices by rebuilding from scratch
+     // finally fix the indices by rebuilding from scratch
     indices_.clear();
     for (size_type i = 0, end = variables_.size(); i < end; ++i) {
         indices_[variables_[i]] = i;
-    }
+    }   
 }
 
 template <class bias_type, class index_type>

--- a/dimod/include/dimod/expression.h
+++ b/dimod/include/dimod/expression.h
@@ -273,7 +273,7 @@ class Expression : public abc::QuadraticModelBase<Bias, Index> {
     template<class Iter>
     void remove_variables(Iter first, Iter last);
 
-    void remove_variables(const std::vector<index_type>& variables) override {
+    void remove_variables(const std::vector<index_type>& variables) {
         return remove_variables(variables.begin(), variables.end());
     }
 

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -86,6 +87,9 @@ class QuadraticModel : public abc::QuadraticModelBase<Bias, Index> {
 
     /// Remove variable `v`.
     void remove_variable(index_type v);
+
+    /// Remove variables.
+    void remove_variables(const std::vector<index_type>& variables) override;
 
     // Resize the model to contain `n` variables.
     void resize(index_type n);
@@ -267,6 +271,19 @@ template <class bias_type, class index_type>
 void QuadraticModel<bias_type, index_type>::remove_variable(index_type v) {
     base_type::remove_variable(v);
     varinfo_.erase(varinfo_.begin() + v);
+}
+
+template <class bias_type, class index_type>
+void QuadraticModel<bias_type, index_type>::remove_variables(const std::vector<index_type>& variables) {
+    if (!std::is_sorted(variables.begin(), variables.end())) {
+        // create a copy and sort it
+        std::vector<index_type> sorted_indices = variables;
+        std::sort(sorted_indices.begin(), sorted_indices.end());
+        QuadraticModel<bias_type, index_type>::remove_variables(sorted_indices);
+        return;
+    }
+    base_type::remove_variables(variables);
+    varinfo_.erase(utils::remove_by_index(varinfo_.begin(), varinfo_.end(), variables.begin(), variables.end()), varinfo_.end());
 }
 
 template <class bias_type, class index_type>

--- a/dimod/include/dimod/quadratic_model.h
+++ b/dimod/include/dimod/quadratic_model.h
@@ -89,7 +89,7 @@ class QuadraticModel : public abc::QuadraticModelBase<Bias, Index> {
     void remove_variable(index_type v);
 
     /// Remove variables.
-    void remove_variables(const std::vector<index_type>& variables) override;
+    void remove_variables(const std::vector<index_type>& variables);
 
     // Resize the model to contain `n` variables.
     void resize(index_type n);

--- a/dimod/include/dimod/utils.h
+++ b/dimod/include/dimod/utils.h
@@ -33,7 +33,7 @@ ValueIter remove_by_index(ValueIter vfirst, ValueIter vlast, IndexIter ifirst, I
 
     using value_type = typename std::iterator_traits<ValueIter>::value_type;
 
-    ssize_t loc = 0;  // location in the values
+    typename std::iterator_traits<IndexIter>::value_type loc = 0;  // location in the values
     IndexIter it = ifirst;
     auto pred = [&](const value_type&) {
         if (it != ilast && *it == loc) {

--- a/dimod/include/dimod/utils.h
+++ b/dimod/include/dimod/utils.h
@@ -22,6 +22,34 @@
 namespace dimod {
 namespace utils {
 
+// Remove all elements in the range defined by vfirst to vlast at indices
+// specified by ifirst to ilast.
+// All iterators must be forward iterators
+// Indices must be non-negative, sorted, and unique.
+template <class ValueIter, class IndexIter>
+ValueIter remove_by_index(ValueIter vfirst, ValueIter vlast, IndexIter ifirst, IndexIter ilast) {
+    assert(std::is_sorted(ifirst, ilast));
+    assert((ifirst == ilast || *ifirst >= 0));
+
+    using value_type = typename std::iterator_traits<ValueIter>::value_type;
+
+    ssize_t loc = 0;  // location in the values
+    IndexIter it = ifirst;
+    auto pred = [&](const value_type&) {
+        if (it != ilast && *it == loc) {
+            ++loc;
+            ++it;
+            return true;
+        } else {
+            ++loc;
+            return false;
+        }
+    };
+
+    // relies on this being executed sequentially
+    return std::remove_if(vfirst, vlast, pred);
+}
+
     // zip_sort is a modification of the code found here :
     // https://www.geeksforgeeks.org/iterative-quick-sort/
 

--- a/releasenotes/notes/QuadraticModelBase.remove_variables-e65ed0c138c3ed75.yaml
+++ b/releasenotes/notes/QuadraticModelBase.remove_variables-e65ed0c138c3ed75.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - Add C++ ``dimod::abc::QuadraticModelBase::remove_variables()`` method and accompanying overloads.
+  - Speed up C++ ``dimod::Expression::remove_variables()`` method.

--- a/testscpp/tests/test_binary_quadratic_model.cpp
+++ b/testscpp/tests/test_binary_quadratic_model.cpp
@@ -38,6 +38,19 @@ TEST_CASE("BinaryQuadraticModel tests") {
             }
         }
 
+        WHEN("we use remove_variables()") {
+            bqm.remove_variables(std::vector<int>{3, 1});
+
+            THEN("The variables are removed and the model is reindexed") {
+                REQUIRE(bqm.num_variables() == 3);
+                REQUIRE(bqm.num_interactions() == 0);
+                CHECK(bqm.linear(0) == 0);
+                CHECK(bqm.linear(1) == 2);  // this was reindexed
+                CHECK(bqm.linear(2) == 4);  // this was reindexed twice
+                CHECK(bqm.offset() == 5);
+            }
+        }
+
         WHEN("we use fix_variable()") {
             bqm.fix_variable(2, -1);
             THEN("the variable is removed, its biases distributed and the model is reindexed") {
@@ -80,6 +93,35 @@ TEST_CASE("BinaryQuadraticModel tests") {
 
         WHEN("we use remove_variable()") {
             bqm.remove_variable(2);
+
+            THEN("everything is reindexed") {
+                REQUIRE(bqm.num_variables() == 4);
+                REQUIRE(bqm.num_interactions() == 2);
+                CHECK(bqm.linear(0) == 0);
+                CHECK(bqm.linear(1) == -1);
+                CHECK(bqm.linear(2) == -3);  // this was reindexed
+                CHECK(bqm.linear(3) == 4);   // this was reindexed
+                CHECK(bqm.quadratic(0, 1) == 1);
+                CHECK(bqm.quadratic(2, 3) == 34);  // this was reindexed
+                CHECK(bqm.offset() == 5);
+            }
+        }
+
+        WHEN("we use remove_variables()") {
+            bqm.remove_variables(std::vector<int>{3, 1});
+
+            THEN("The variables are removed and the model is reindexed") {
+                REQUIRE(bqm.num_variables() == 3);
+                CHECK(bqm.linear(0) == 0);
+                CHECK(bqm.linear(1) == 2);  // this was reindexed
+                CHECK(bqm.linear(2) == 4);  // this was reindexed twice
+                CHECK(bqm.offset() == 5);
+                CHECK(bqm.num_interactions() == 0);  // no remaining quadratic
+            }
+        }
+
+        WHEN("we use remove_variables() to remove one variable") {
+            bqm.remove_variables({2});
 
             THEN("everything is reindexed") {
                 REQUIRE(bqm.num_variables() == 4);

--- a/testscpp/tests/test_binary_quadratic_model.cpp
+++ b/testscpp/tests/test_binary_quadratic_model.cpp
@@ -136,6 +136,23 @@ TEST_CASE("BinaryQuadraticModel tests") {
             }
         }
 
+        WHEN("we use remove_variables() to remove no variables") {
+            bqm.remove_variables({});
+
+            THEN("nothing has changed") {
+                REQUIRE(bqm.num_variables() == 5);
+                REQUIRE(bqm.num_interactions() == 4);
+                CHECK(bqm.linear(0) == 0);
+                CHECK(bqm.linear(1) == -1);
+                CHECK(bqm.linear(2) == 2);
+                CHECK(bqm.linear(3) == -3);
+                CHECK(bqm.linear(4) == 4);
+                CHECK(bqm.quadratic(0, 1) == 1);
+                CHECK(bqm.quadratic(3, 4) == 34);
+                CHECK(bqm.offset() == 5);
+            }
+        }
+
         AND_GIVEN("another identical BQM") {
             auto bqm2 = BinaryQuadraticModel<double>(5, Vartype::SPIN);
             bqm2.set_offset(5);

--- a/testscpp/tests/test_quadratic_model.cpp
+++ b/testscpp/tests/test_quadratic_model.cpp
@@ -53,6 +53,28 @@ TEST_CASE("QuadraticModel tests") {
             }
         }
 
+        WHEN("we use remove_variables()") {
+            qm.remove_variables({2});
+
+            THEN("the variable is removed and the model is reindexed") {
+                REQUIRE(qm.num_variables() == 4);
+                REQUIRE(qm.num_interactions() == 0);
+                CHECK(qm.offset() == 5);
+                CHECK(qm.linear(0) == 0);
+                CHECK(qm.linear(1) == -1);
+                CHECK(qm.linear(2) == -3);  // this was reindexed
+                CHECK(qm.linear(3) == 4);   // this was reindexed
+                CHECK(qm.vartype(0) == Vartype::BINARY);
+                CHECK(qm.vartype(1) == Vartype::INTEGER);
+                CHECK(qm.vartype(2) == Vartype::REAL);  // this was reindexed
+                CHECK(qm.vartype(3) == Vartype::SPIN);  // this was reindexed
+                CHECK(qm.lower_bound(1) == -1);
+                CHECK(qm.lower_bound(2) == -3);  // this was reindexed
+                CHECK(qm.upper_bound(1) == 1);
+                CHECK(qm.upper_bound(2) == 3);  // this was reindexed
+            }
+        }
+
         WHEN("we use fix_variable()") {
             qm.fix_variable(2, -1);
             THEN("the variable is removed, its biases distributed and the model is reindexed") {

--- a/testscpp/tests/test_utils.cpp
+++ b/testscpp/tests/test_utils.cpp
@@ -14,12 +14,55 @@
 
 #include <iostream>
 #include <random>
+#include <vector>
 
 #include "catch2/catch.hpp"
 #include "dimod/utils.h"
 
 namespace dimod {
 namespace utils {
+
+TEST_CASE("remove_by_index()") {
+    GIVEN("A vector") {
+        auto v = std::vector<int>{0, 1, 2, 3, 4, 5, 6};
+
+        AND_GIVEN("some indices") {
+            auto i = std::vector<int>{1, 3, 4};
+
+            WHEN("We use remove_by_index() to shrink the vector") {
+                v.erase(remove_by_index(v.begin(), v.end(), i.begin(), i.end()), v.end());
+
+                THEN("The vector has the values we expect") {
+                    REQUIRE_THAT(v, Catch::Approx(std::vector<int>{0, 2, 5, 6}));
+                }
+            }
+        }
+
+        AND_GIVEN("Some indices that are out-of-range") {
+            auto i = std::vector<int>{5, 105};
+
+            WHEN("We use remove_by_index() to shrink the vector") {
+                v.erase(remove_by_index(v.begin(), v.end(), i.begin(), i.end()), v.end());
+
+                THEN("The vector has the values we expect") {
+                    REQUIRE_THAT(v, Catch::Approx(std::vector<int>{0, 1, 2, 3, 4, 6}));
+                }
+            }
+        }
+
+        AND_GIVEN("An empty indices vector") {
+            auto i = std::vector<int>{};
+
+            WHEN("We use remove_by_index() to shrink the vector") {
+                v.erase(remove_by_index(v.begin(), v.end(), i.begin(), i.end()), v.end());
+
+                THEN("The vector has the values we expect") {
+                    REQUIRE_THAT(v, Catch::Approx(std::vector<int>{0, 1, 2, 3, 4, 5, 6}));
+                }
+            }
+        }
+    }
+}
 
     TEST_CASE("Two vectors are zip-sorted", "[utils]") {
         std::default_random_engine generator;


### PR DESCRIPTION
And overloads for base classes.

This significantly improves the performance of `Expression::remove_variables()`.

Testing was done with the following script. The version implemented in this PR was named `remove_variables2`.
```c++
// g++ -std=c++11 -DNDEBUG -g -O3 scratch.cpp -o scratch.out -I dimod/include && ./scratch.out

#include <chrono>
#include <iostream>
#include <vector>
#include <unordered_set>

#include "dimod/binary_quadratic_model.h"
#include "dimod/constrained_quadratic_model.h"


int main(int argc, char* argv[]) {
    const int num_variables = 250000;

    std::vector<int> variables;
    for (int i = 0; i < num_variables; i += 2) {
        variables.emplace_back(i);
    }

    auto bqm = dimod::BinaryQuadraticModel<double>(num_variables, dimod::Vartype::BINARY);

    auto cqm1 = dimod::ConstrainedQuadraticModel<double, int>();
    cqm1.set_objective(bqm);

    auto cqm2 = dimod::ConstrainedQuadraticModel<double, int>();
    cqm2.set_objective(bqm);

    {
        const auto start{std::chrono::steady_clock::now()};

        cqm1.objective.remove_variables(variables.begin(), variables.end());

        const auto end{std::chrono::steady_clock::now()};
        const std::chrono::duration<double> elapsed_seconds{end - start};

        std::cout << elapsed_seconds.count() << "s\n";
    }

    {
        const auto start{std::chrono::steady_clock::now()};

        cqm2.objective.remove_variables2(variables.begin(), variables.end());

        const auto end{std::chrono::steady_clock::now()};
        const std::chrono::duration<double> elapsed_seconds{end - start};

        std::cout << elapsed_seconds.count() << "s\n";
    }
}
```
The script produced the follwing output:
```bash
5.13436s                                                                        
0.00507951s  
```