### PR TITLE
Addressing issue #1364: option for a variable check in add_discrete method

### DIFF
--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -494,13 +494,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
 
             >>> d, e, f = dimod.Binaries(['d', 'e', 'f'])
             >>> cqm.add_discrete(d + e + f == 1, label='discrete-def')
-            'discrete-def'
-            
-            Add a discrete constraint, while skipping the variable overlap
-            check.
-            
-            >>> cqm.add_discrete(d + e + f == 1, label='discrete-def',
-            ...                  check_overlaps=False)
+            'discrete-def'            
 
         """
         # in python 3.8+ we can use singledispatchmethod

--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -500,7 +500,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
             check.
             
             >>> cqm.add_discrete(d + e + f == 1, label='discrete-def',
-                                 check_overlaps=False)
+            ...                  check_overlaps=False)
 
         """
         # in python 3.8+ we can use singledispatchmethod

--- a/releasenotes/notes/check-overlaps-keyword-in-add-discrete-f078c11e943cfb41.yaml
+++ b/releasenotes/notes/check-overlaps-keyword-in-add-discrete-f078c11e943cfb41.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``check_overlaps`` keyword argument to ``ConstrainedQuadraticModel.add_discrete()``,
+    see `#1364 <https://github.com/dwavesystems/dimod/issues/1364>`_.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -172,6 +172,31 @@ class TestAddDiscrete(unittest.TestCase):
         c = cqm.add_discrete(qm, label='hello')
         self.assertIn(c, cqm.discrete)
         self.assertTrue(cqm.constraints[c].lhs.is_equal(qm))
+        
+    def test_check_overlaps_keyword(self):
+        # If check_overlaps=False, we do not check for overlaps
+        # and there is no ValueError.
+        # This is expected behavior.
+        cqm = CQM()
+        cqm.add_discrete("xyz")
+        cqm.add_discrete("yzw", check_overlaps=False)
+
+        # Other exceptions should not be affected
+        cqm = CQM()
+        x,y = dimod.Binaries('xy')
+        with self.subTest("wrong sense"):
+            with self.assertRaises(ValueError):
+                cqm.add_discrete(x + y <= 1, check_overlaps=False)
+        with self.subTest("wrong rhs"):
+            with self.assertRaises(ValueError):
+                cqm.add_discrete(x + y == 2, check_overlaps=False)
+        with self.subTest("wrong vartype"):
+            s = dimod.Spin('s')
+            with self.assertRaises(ValueError):
+                cqm.add_discrete(x + s == 1, check_overlaps=False)
+        with self.subTest("quadratic"):
+            with self.assertRaises(ValueError):
+                cqm.add_discrete(x + y + x*y== 1, check_overlaps=False)
 
     def test_comparison(self):
         cqm = CQM()


### PR DESCRIPTION
As discussed in the issue #1364, the variable check in `ConstrainedQuadraticModel.add_discrete` method  can be skipped in some cases and the user can decide if this is truly necessary. 

This is implemented by adding a `do_var_check` boolean variable (default: `True`), which enables the check if it's true, in the methods `ConstrainedQuadraticModel.add_discrete_from_model`, `ConstrainedQuadraticModel.add_discrete_from_comparison`,  and `ConstrainedQuadraticModel.add_discrete_from_iterable`.  


