### PR TITLE
add method `ConstrainedQuadraticModel.objective.add_quadartic_from()` 

### DIFF
--- a/dimod/views/quadratic.py
+++ b/dimod/views/quadratic.py
@@ -353,6 +353,10 @@ class QuadraticViewsMixin(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def add_quadratic(self, u: Variable, v: Variable, bias: Bias):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def degree(self, v: Variable) -> int:
         raise NotImplementedError
 
@@ -425,6 +429,28 @@ class QuadraticViewsMixin(abc.ABC):
 
     add_variables_from = add_linear_from
     """Alias for :meth:`add_linear_from`."""
+
+    def add_quadratic_from(self, quadratic: Union[Iterable, Mapping]):
+        """Add variables and quadratic biases to a binary quadratic model.
+
+        Args:
+            quadratic:
+                Variables and their associated quadratic biases, as either a dict of
+                form ``{u, v: bias, ...}`` or an iterable of ``(u, v, bias)`` triple,
+                where ``u``, ``v`` are variables and ``bias`` is its associated
+                quadratic bias.
+
+        """
+        if isinstance(quadratic, collections.abc.Mapping):
+            iterator = quadratic.items()
+        elif isinstance(quadratic, collections.abc.Iterable):
+            iterator = quadratic
+        else:
+            raise TypeError(
+                "expected 'quadratic' to be a dict or an iterable of 3-tuples.")
+
+        for u, v, bias in iterator:
+            self.add_quadratic(u, v, bias)
 
     def fix_variable(self, v: Variable, value: float):
         """Remove a variable by fixing its value.

--- a/dimod/views/quadratic.py
+++ b/dimod/views/quadratic.py
@@ -405,7 +405,8 @@ class QuadraticViewsMixin(abc.ABC):
     def set_quadratic(self, u: Variable, v: Variable, bias: Bias):
         raise NotImplementedError
 
-    def add_linear_from(self, linear: Union[Iterable, Mapping]):
+    def add_linear_from(self, linear: Union[Mapping[Variable, Bias],
+                                            Iterable[Tuple[Variable, Bias]]]):
         """Add variables and linear biases to a binary quadratic model.
 
         Args:
@@ -430,7 +431,8 @@ class QuadraticViewsMixin(abc.ABC):
     add_variables_from = add_linear_from
     """Alias for :meth:`add_linear_from`."""
 
-    def add_quadratic_from(self, quadratic: Union[Iterable, Mapping]):
+    def add_quadratic_from(self, quadratic: Union[Mapping[Tuple[Variable, Variable], Bias],
+                                                  Iterable[Tuple[Variable, Variable, Bias]]]):
         """Add variables and quadratic biases to a binary quadratic model.
 
         Args:
@@ -441,16 +443,16 @@ class QuadraticViewsMixin(abc.ABC):
                 quadratic bias.
 
         """
-        if isinstance(quadratic, collections.abc.Mapping):
-            iterator = quadratic.items()
+        if isinstance(quadratic, collections.abc.Mapping):            
+            for (u, v), bias in quadratic.items():
+                self.add_quadratic(u, v, bias)
         elif isinstance(quadratic, collections.abc.Iterable):
-            iterator = quadratic
+            for u, v, bias in quadratic:
+                self.add_quadratic(u, v, bias)
         else:
             raise TypeError(
                 "expected 'quadratic' to be a dict or an iterable of 3-tuples.")
 
-        for u, v, bias in iterator:
-            self.add_quadratic(u, v, bias)
 
     def fix_variable(self, v: Variable, value: float):
         """Remove a variable by fixing its value.

--- a/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
+++ b/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add method ``QuadraticViewsMixin.add_quadratic_from()`` to add quadratic
+    interactions. This method is intended to be used as follows:
+    ``ConstrainedQuadraticModel.objective.add_quadratic_from()``, similarly to
+    ``ConstrainedQuadraticModel.objective.add_linear_from()``.

--- a/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
+++ b/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
@@ -7,7 +7,7 @@ features:
     interactions. This method is intended to be used as follows:
     ``ConstrainedQuadraticModel.objective.add_quadratic_from()``, similarly to
     ``ConstrainedQuadraticModel.objective.add_linear_from()``.
-critical:
+upgrade:
   - |
     All sublcasses of ``QuadraticViewsMixin``, including ``ObjectiveView``, 
     ``QuadraticModel`` and ``BinaryQuadraticModel``, now require to have 

--- a/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
+++ b/releasenotes/notes/add-quadratic-from-52f923c89ce762cb.yaml
@@ -1,7 +1,14 @@
 ---
 features:
   - |
-    Add method ``QuadraticViewsMixin.add_quadratic_from()`` to add quadratic
+    Add an abstract method ``QuadraticViewsMixin.add_quadratic()``.
+  - |
+    Add a method ``QuadraticViewsMixin.add_quadratic_from()`` to add quadratic
     interactions. This method is intended to be used as follows:
     ``ConstrainedQuadraticModel.objective.add_quadratic_from()``, similarly to
     ``ConstrainedQuadraticModel.objective.add_linear_from()``.
+critical:
+  - |
+    All sublcasses of ``QuadraticViewsMixin``, including ``ObjectiveView``, 
+    ``QuadraticModel`` and ``BinaryQuadraticModel``, now require to have 
+    the method ``add_quadratic()``.

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1896,6 +1896,15 @@ class TestViews(unittest.TestCase):
 
         self.assertEqual(cqm.objective.linear, {'x': 3})
 
+    def test_add_quadratic_from(self):
+        x, y = dimod.Binaries('xy')
+        cqm = dimod.CQM()
+        lbl = cqm.add_constraint(x + y <= 1)
+
+        cqm.objective.add_quadratic_from([('x', 'y', 3)])
+
+        self.assertEqual(cqm.objective.quadratic, {('x', 'y'): 3})
+
     def test_add_variable(self):
         x, y = dimod.Binaries('xy')
         cqm = dimod.CQM()

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -1889,21 +1889,43 @@ class TestViews(unittest.TestCase):
 
     def test_add_linear_from(self):
         x, y = dimod.Binaries('xy')
+        # test iterable
         cqm = dimod.CQM()
         lbl = cqm.add_constraint(x + y <= 1)
 
         cqm.objective.add_linear_from([('x', 3)])
 
         self.assertEqual(cqm.objective.linear, {'x': 3})
+        # test mapping     
+        cqm = dimod.CQM()
+        lbl = cqm.add_constraint(x + y <= 1)
+        cqm.objective.add_linear_from({'x': 3})
+        self.assertEqual(cqm.objective.linear, {'x': 3})
+
+        # test missing variable
+        cqm = dimod.CQM()
+        with self.assertRaises(ValueError):
+            cqm.objective.add_linear_from([('x', 3)])
 
     def test_add_quadratic_from(self):
         x, y = dimod.Binaries('xy')
+        # test iterable
         cqm = dimod.CQM()
         lbl = cqm.add_constraint(x + y <= 1)
 
         cqm.objective.add_quadratic_from([('x', 'y', 3)])
 
         self.assertEqual(cqm.objective.quadratic, {('x', 'y'): 3})
+        # test mapping        
+        cqm = dimod.CQM()
+        lbl = cqm.add_constraint(x + y <= 1)
+        cqm.objective.add_quadratic_from({('x', 'y'): 3})
+        self.assertEqual(cqm.objective.quadratic, {('x', 'y'): 3})
+        
+        # test missing variable
+        cqm = dimod.CQM()        
+        with self.assertRaises(ValueError):
+            cqm.objective.add_quadratic_from([('x', 'y', 3)])        
 
     def test_add_variable(self):
         x, y = dimod.Binaries('xy')


### PR DESCRIPTION
While there is a method `ConstrainedQuadraticModel.objective.add_linear_from()`, which adds linear biases to the objective, there is no corresponding method for quadratic biases.

Here, we add a method `ConstrainedQuadraticModel.objective.add_quadartic_from()` to allow adding quadratic terms to the objective in a similar way to the linear biases. We also add an abstract method `ConstrainedQuadraticModel.objective.add_quadartic()` to be overloaded in the subclasses.

Closes the issue https://github.com/dwavesystems/dimod/issues/1367

