### PR TITLE
Add QuadraticModelBase::remove_interactions() method

### DIFF
--- a/releasenotes/notes/QuadraticModelBase.remove_interactions-1580cb5e00bc96f4.yaml
+++ b/releasenotes/notes/QuadraticModelBase.remove_interactions-1580cb5e00bc96f4.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add C++ ``QuadraticModelBase::remove_interactions()`` method.

--- a/testscpp/tests/test_quadratic_model.cpp
+++ b/testscpp/tests/test_quadratic_model.cpp
@@ -546,4 +546,26 @@ SCENARIO("quadratic models can be swapped", "[qm]") {
         }
     }
 }
+
+SCENARIO("quadratic models can have their interactions filtered") {
+    GIVEN("a binary quadratic model") {
+        auto bqm = dimod::BinaryQuadraticModel<double>(5, dimod::Vartype::BINARY);
+        bqm.add_quadratic(0, 1, 1.5);
+        bqm.add_quadratic(1, 2, 2.5);
+        bqm.add_quadratic(2, 3, 3.5);
+
+        WHEN("We filter all interactions with variable 1") {
+            CHECK(bqm.remove_interactions([](int u, int v, double) { return u == 1 || v == 1; }) ==
+                  2);
+
+            CHECK(bqm.quadratic(0, 1) == 0);
+            CHECK(bqm.quadratic(1, 2) == 0);
+            CHECK(bqm.quadratic(2, 3) == 3.5);
+
+            CHECK(bqm.quadratic(1, 0) == 0);
+            CHECK(bqm.quadratic(2, 1) == 0);
+            CHECK(bqm.quadratic(3, 2) == 3.5);
+        }
+    }
+}
 }  // namespace dimod


### PR DESCRIPTION
This is designed to be used by `dwave-preprocessing` to speed up the removal of small biases.