### PR TITLE
Remove ambiguous xrefs to reduce build warnings

### DIFF
--- a/dimod/core/structured.py
+++ b/dimod/core/structured.py
@@ -133,7 +133,8 @@ class Structured(abc.ABC):
     def structure(self) -> _Structure:
         """Structure of the structured sampler formatted as a
         :func:`~collections.namedtuple` where the 3-tuple values are the
-        :attr:`.nodelist`, :attr:`.edgelist` and :attr:`.adjacency` attributes.
+        :attr:`~.Structured.nodelist`, :attr:`~.Structured.edgelist` and 
+        :attr:`~.Structured.adjacency` attributes.
         """
         return _Structure(self.nodelist, self.edgelist, self.adjacency)
 

--- a/dimod/decorators.py
+++ b/dimod/decorators.py
@@ -48,7 +48,7 @@ def nonblocking_sample_method(f):
     The first value can be any object, but if the object has a `done()`
     method, that method will determine the value of :meth:`.SampleSet.done()`.
 
-    The second value must be a :class:`.SampleSet`, which will provide the
+    The second value must be a :class:`~dimod.SampleSet`, which will provide the
     samples to the user.
 
     The generator is executed until the first yield. The generator is then
@@ -93,7 +93,7 @@ def bqm_index_labels(f):
 
     Designed to be applied to :meth:`.Sampler.sample`. Expects the wrapped
     function or method to accept a :obj:`.BinaryQuadraticModel` as the second
-    input and to return a :obj:`.SampleSet`.
+    input and to return a :obj:`~dimod.SampleSet`.
 
     """
     @wraps(f)

--- a/dimod/generators/wireless.py
+++ b/dimod/generators/wireless.py
@@ -562,7 +562,7 @@ def mimo(modulation: Literal["BPSK", "QPSK", "16QAM", "64QAM", "256QAM"] = "BPSK
     a linear sum of bits, the optimization problem is a binary quadratic model.
     
     Depending on its parameters, this function can model code division multiple
-    access\  [#]_\ [#]_, 5G communication networks\ [#]_, or 
+    access (CDMA)\  [#]_\ [#]_, 5G communication networks\ [#]_, or 
     other problems.
 
     Args:

--- a/dimod/generators/wireless.py
+++ b/dimod/generators/wireless.py
@@ -562,7 +562,7 @@ def mimo(modulation: Literal["BPSK", "QPSK", "16QAM", "64QAM", "256QAM"] = "BPSK
     a linear sum of bits, the optimization problem is a binary quadratic model.
     
     Depending on its parameters, this function can model code division multiple
-    access (CDMA) _[#T02, #R20], 5G communication networks _[#Prince], or 
+    access\  [#]_\ [#]_, 5G communication networks\ [#]_, or 
     other problems.
 
     Args:
@@ -683,14 +683,14 @@ def mimo(modulation: Literal["BPSK", "QPSK", "16QAM", "64QAM", "256QAM"] = "BPSK
         ...     SNRb=SNRb, 
         ...     F_distribution = ('binary', 'real'))
 
-    .. [#T02] T. Tanaka IEEE TRANSACTIONS ON INFORMATION THEORY, VOL. 48, NO. 11, NOVEMBER 2002
+    .. [#] T. Tanaka IEEE TRANSACTIONS ON INFORMATION THEORY, VOL. 48, NO. 11, NOVEMBER 2002
 
-    .. [#R20] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, 
+    .. [#] J. Raymond, N. Ndiaye, G. Rayaprolu and A. D. King, 
         "Improving performance of logical qubits by parameter tuning and topology compensation," 
         2020 IEEE International Conference on Quantum Computing and Engineering (QCE), 
         Denver, CO, USA, 2020, pp. 295-305, doi: 10.1109/QCE49297.2020.00044.
 
-    .. [#Prince] Various (https://paws.princeton.edu/)
+    .. [#] Various (https://paws.princeton.edu/)
     """
 
     random_state = np.random.default_rng(seed)

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -1450,7 +1450,7 @@ def Integer(label: Optional[Variable] = None, bias: Bias = 1,
         upper_bound: Keyword-only argument to specify integer upper bound.
 
     Returns:
-        Instance of :class:`.QuadraticModel`.
+        Instance of :class:`~dimod.QuadraticModel`.
 
     Examples:
         This example generates a quadratic model to represent the polynomial,
@@ -1476,7 +1476,7 @@ def Integers(labels: Union[int, Iterable[Variable]],
         dtype: Data type for the returned quadratic models.
 
     Yields:
-        A :class:`.QuadraticModel` for each integer variable.
+        A :class:`~dimod.QuadraticModel` for each integer variable.
 
     Examples:
         >>> i, j = dimod.Integers(['i', 'j'])

--- a/dimod/reference/composites/structure.py
+++ b/dimod/reference/composites/structure.py
@@ -96,7 +96,7 @@ class StructureComposite(Sampler, Composite, Structured):
                 Binary quadratic model to be sampled from.
 
         Returns:
-            :obj:`.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         Examples:
             This example submits an Ising problem to a composed sampler that uses

--- a/dimod/reference/samplers/identity_sampler.py
+++ b/dimod/reference/samplers/identity_sampler.py
@@ -120,7 +120,7 @@ class IdentitySampler(Sampler, Initialized):
                 identical results. If not provided, a random seed is chosen.
 
         Returns:
-            A :obj:`.SampleSet` with the specified initial states, optionally
+            A :obj:`~dimod.SampleSet` with the specified initial states, optionally
             truncated or augmented.
 
         """

--- a/dimod/reference/samplers/random_sampler.py
+++ b/dimod/reference/samplers/random_sampler.py
@@ -63,7 +63,7 @@ class RandomSampler(Sampler):
                 provided, a random seed is chosen.
 
         Returns:
-            :obj:`.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         """
         # as an implementation detail, we can use IdentitySampler here, but

--- a/dimod/reference/samplers/simulated_annealing.py
+++ b/dimod/reference/samplers/simulated_annealing.py
@@ -78,7 +78,7 @@ class SimulatedAnnealingSampler(Sampler):
                 Number of sweeps or steps.
 
         Returns:
-            :obj:`.SampleSet`
+            :obj:`~dimod.SampleSet`
 
         Note:
             This is a reference implementation, not optimized for speed

--- a/dimod/testing/asserts.py
+++ b/dimod/testing/asserts.py
@@ -173,7 +173,7 @@ def assert_sampleset_energies(sampleset, bqm, precision=7):
     """Assert that each sample in the given sample set has the correct energy.
 
     Args:
-        sampleset (:obj:`.SampleSet`):
+        sampleset (:obj:`~dimod.SampleSet`):
             Sample set as returned by a dimod sampler.
 
         bqm (:obj:`.BinaryQuadraticModel`/:obj:`.BinaryPolynomial`):
@@ -219,7 +219,7 @@ def assert_sampleset_energies_dqm(sampleset, dqm, precision=7):
     """Assert that each sample in the given sample set has the correct energy.
 
     Args:
-        sampleset (:obj:`.SampleSet`):
+        sampleset (:obj:`~dimod.SampleSet`):
             Sample set as returned by a dimod sampler.
 
         dqm (:obj:`.DiscreteQuadraticModel`):
@@ -255,7 +255,7 @@ def assert_sampleset_energies_cqm(sampleset, cqm, precision=7):
     """Assert that each sample in the given sample set has the correct energy.
 
     Args:
-        sampleset (:obj:`.SampleSet`):
+        sampleset (:obj:`~dimod.SampleSet`):
             Sample set as returned by a dimod sampler.
 
         cqm (:obj:`.ConstrainedQuadraticModel`):

--- a/dimod/testing/asserts.py
+++ b/dimod/testing/asserts.py
@@ -146,7 +146,7 @@ def assert_response_energies(response, bqm, precision=7):
     """Assert that each sample in the given response has the correct energy.
 
     Args:
-        response (:obj:`.SampleSet`):
+        response (:obj:`~dimod.SampleSet`):
             Response as returned by a dimod sampler.
 
         bqm (:obj:`.BinaryQuadraticModel`):

--- a/dimod/variables.py
+++ b/dimod/variables.py
@@ -16,7 +16,7 @@
 A class and utilities for encoding variable objects.
 
 The :class:`Variables` class is intended to be used as an attribute of other
-classes, such as :class:`.DiscreteQuadraticModel` and :class:`.SampleSet`.
+classes, such as :class:`.DiscreteQuadraticModel` and :class:`~dimod.SampleSet`.
 
 The requirements for the class are:
     *   Have a minimal memory footprint when the variables are labeled `[0, n)`

--- a/docs/intro/intro_scaling.rst
+++ b/docs/intro/intro_scaling.rst
@@ -99,7 +99,7 @@ Time the construction:
 
 .. code-block:: python
 
-    In [1]: %timeit bin_packing(weights)
+    >>> %timeit bin_packing(weights)
     385 ms ± 9.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
 .. note::
@@ -157,7 +157,7 @@ This simple change already reduces the runtime.
 
 .. code-block:: python
 
-    In [1]: %timeit bin_packing(weights)
+    >>> %timeit bin_packing(weights)
     294 ms ± 9.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
 Construct Models Directly
@@ -190,7 +190,7 @@ between variables and labels.
 
 .. code-block:: python
 
-    In [1]: %timeit make_bqm_symbolic(1000)
+    >>> %timeit make_bqm_symbolic(1000)
     12.7 ms ± 213 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
     In [2]: %timeit make_bqm_labels(1000)
     194 µs ± 2.32 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
@@ -246,7 +246,7 @@ This change significantly reduces runtime.
 
 .. code-block:: python
 
-    In [1]: %timeit bin_packing(weights)
+    >>> %timeit bin_packing(weights)
     95.5 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
 Add Constraints Without Copying
@@ -306,5 +306,5 @@ This results in another performance improvement.
 
 .. code-block:: python
 
-    In [1]: %timeit bin_packing(weights)
+    >>> %timeit bin_packing(weights)
     68.1 ms ± 299 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/docs/intro/intro_scaling.rst
+++ b/docs/intro/intro_scaling.rst
@@ -97,7 +97,7 @@ Time the construction:
 
     bin_packing(weights)
 
-.. code-block:: ipythonconsole
+.. code-block:: python
 
     In [1]: %timeit bin_packing(weights)
     385 ms ± 9.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
@@ -155,7 +155,7 @@ This simple change already reduces the runtime.
 
     bin_packing(weights)
 
-.. code-block:: ipythonconsole
+.. code-block:: python
 
     In [1]: %timeit bin_packing(weights)
     294 ms ± 9.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
@@ -188,7 +188,7 @@ between variables and labels.
     make_bqm_symbolic(1000)
     make_bqm_labels(1000)
 
-.. code-block:: ipythonconsole
+.. code-block:: python
 
     In [1]: %timeit make_bqm_symbolic(1000)
     12.7 ms ± 213 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
@@ -244,7 +244,7 @@ This change significantly reduces runtime.
 
     bin_packing(weights)
 
-.. code-block:: ipythonconsole
+.. code-block:: python
 
     In [1]: %timeit bin_packing(weights)
     95.5 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
@@ -304,7 +304,7 @@ This results in another performance improvement.
 
     bin_packing(weights)
 
-.. code-block:: ipythonconsole
+.. code-block:: python
 
     In [1]: %timeit bin_packing(weights)
     68.1 ms ± 299 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

--- a/docs/intro/intro_scaling.rst
+++ b/docs/intro/intro_scaling.rst
@@ -99,7 +99,7 @@ Time the construction:
 
 .. code-block:: python
 
-    >>> %timeit bin_packing(weights)
+    In [1]: %timeit bin_packing(weights)
     385 ms ± 9.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
 .. note::
@@ -157,7 +157,7 @@ This simple change already reduces the runtime.
 
 .. code-block:: python
 
-    >>> %timeit bin_packing(weights)
+    In [1]: %timeit bin_packing(weights)
     294 ms ± 9.39 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
 Construct Models Directly
@@ -190,7 +190,7 @@ between variables and labels.
 
 .. code-block:: python
 
-    >>> %timeit make_bqm_symbolic(1000)
+    In [1]: %timeit make_bqm_symbolic(1000)
     12.7 ms ± 213 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
     In [2]: %timeit make_bqm_labels(1000)
     194 µs ± 2.32 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
@@ -246,7 +246,7 @@ This change significantly reduces runtime.
 
 .. code-block:: python
 
-    >>> %timeit bin_packing(weights)
+    In [1]: %timeit bin_packing(weights)
     95.5 ms ± 2.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
 Add Constraints Without Copying
@@ -306,5 +306,5 @@ This results in another performance improvement.
 
 .. code-block:: python
 
-    >>> %timeit bin_packing(weights)
+    In [1]: %timeit bin_packing(weights)
     68.1 ms ± 299 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300), [dwave-system](https://github.com/dwavesystems/dwave-system/pull/524), [dwave-cloud-client](https://github.com/dwavesystems/dwave-cloud-client/pull/633), and [dwave-hybrid](https://github.com/dwavesystems/dwave-hybrid/pull/294) PRs to reduce build warnings

The updates in this dimod PR reduce the number of warnings by half (<70 left).  

Additional minor update: Pyments does not have an `ipythonconsole` lexer so dimod was producing `Could not lex literal_block as "python"` warnings so switched to the standard Python console for those examples. 