### PR TITLE
Remove build-time dependency on NumPy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
             python -m venv env
             . env/bin/activate
             pip install dimod --no-index -f dist/ --force-reinstall --no-deps
-            pip install << parameters.dependencies >> --upgrade --only-binary=numpy
+            pip install "<< parameters.dependencies >>" --upgrade --only-binary=numpy
       - run: &unix-run-tests
           name: run tests
           command: |
@@ -333,7 +333,7 @@ workflows:
           matrix:
             parameters:
               # test the lowest supported numpy and the latest
-              dependencies: [oldest-supported-numpy, numpy]
+              dependencies: [oldest-supported-numpy, numpy<2.0.0]
               python-version: *python-versions
       - test-linux-cpp
       - test-osx-cpp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3
   win: circleci/windows@5.0.0
+  macos: circleci/macos@2.4.1
 
 environment: &global-environment
   PIP_PROGRESS_BAR: 'off'
@@ -74,14 +75,21 @@ jobs:
         type: string
 
     macos:
-      xcode: 13.4.0
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
 
     environment:
       <<: *global-environment
       CIBW_PROJECT_REQUIRES_PYTHON: ~=<< parameters.python-version>>
 
-    steps: *build-steps
-
+    steps:
+      - checkout
+      - macos/install-rosetta
+      - restore_cache: *build-linux-restore-cache
+      - run: *build-linux-wheels
+      - save_cache: *build-linux-save-cache
+      - store_artifacts: *store-artifacts
+      - persist_to_workspace: *persist-to-workspace
   build-sdist:
     docker:
       - image: cimg/python:3.9
@@ -281,7 +289,8 @@ jobs:
 
   test-osx-cpp:
     macos:
-      xcode: 13.4.0
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
 
     steps:
       - checkout

--- a/dimod/binary/cybqm/cybqm_float32.pxd
+++ b/dimod/binary/cybqm/cybqm_float32.pxd
@@ -15,8 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
-
 from dimod.cyqmbase.cyqmbase_float32 cimport cyQMBase_float32 as cyQMBase, bias_type, index_type
 
 __all__ = ['cyBQM_float32']

--- a/dimod/binary/cybqm/cybqm_float64.pxd
+++ b/dimod/binary/cybqm/cybqm_float64.pxd
@@ -15,8 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
-
 from dimod.cyqmbase.cyqmbase_float64 cimport cyQMBase_float64 as cyQMBase, bias_type, index_type
 
 __all__ = ['cyBQM_float64']

--- a/dimod/binary/cybqm/cybqm_template.pxd.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pxd.pxi
@@ -14,7 +14,7 @@
 
 cimport cython
 
-from dimod.cyutilities cimport ConstNumeric
+from dimod.typing cimport Numeric
 from dimod.libcpp.binary_quadratic_model cimport BinaryQuadraticModel as cppBinaryQuadraticModel
 
 
@@ -26,8 +26,8 @@ cdef class cyBQM_template(cyQMBase):
     # likes to use
 
     cdef Py_ssize_t _index(self, object, bint permissive=*) except -1
-    cpdef Py_ssize_t add_linear_from_array(self, ConstNumeric[:] linear) except -1
-    cpdef Py_ssize_t add_quadratic_from_dense(self, ConstNumeric[:, ::1] quadratic) except -1
+    cpdef Py_ssize_t add_linear_from_array(self, const Numeric[:] linear) except -1
+    cpdef Py_ssize_t add_quadratic_from_dense(self, const Numeric[:, ::1] quadratic) except -1
     cpdef Py_ssize_t change_vartype(self, object) except -1
     cdef const cppBinaryQuadraticModel[bias_type, index_type]* data(self)
     cpdef Py_ssize_t resize(self, Py_ssize_t) except? 0

--- a/dimod/binary/cybqm/cybqm_template.pyx.pxi
+++ b/dimod/binary/cybqm/cybqm_template.pyx.pxi
@@ -30,11 +30,12 @@ from libcpp.unordered_set cimport unordered_set
 from libcpp.vector cimport vector
 
 from dimod.binary.cybqm cimport cyBQM
-from dimod.cyutilities cimport as_numpy_float, ConstInteger
+from dimod.cyutilities cimport as_numpy_float
 from dimod.cyutilities import coo_sort
 from dimod.libcpp.vartypes cimport Vartype as cppVartype
 from dimod.sampleset import as_samples
 from dimod.typing import BQMVectors, LabelledBQMVectors, QuadraticVectors
+from dimod.typing cimport Integer, Numeric
 from dimod.utilities import asintegerarrays, asnumericarrays
 from dimod.variables import Variables
 from dimod.vartypes import Vartype, as_vartype
@@ -173,7 +174,7 @@ cdef class cyBQM_template(cyQMBase):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cpdef Py_ssize_t add_linear_from_array(self, ConstNumeric[:] linear) except -1:
+    cpdef Py_ssize_t add_linear_from_array(self, const Numeric[:] linear) except -1:
         cdef Py_ssize_t vi
         cdef Py_ssize_t length = linear.shape[0]
 
@@ -191,7 +192,7 @@ cdef class cyBQM_template(cyQMBase):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def add_offset_from_array(self, ConstNumeric[::1] offset):
+    def add_offset_from_array(self, const Numeric[::1] offset):
         if offset.shape[0] != 1:
             raise ValueError("array should be of length 1")
         self.cppbqm.add_offset(offset[0])
@@ -205,9 +206,9 @@ cdef class cyBQM_template(cyQMBase):
         self.cppbqm.add_quadratic(ui, vi, bias)
 
     def add_quadratic_from_arrays(self,
-                                  ConstInteger[::1] irow,
-                                  ConstInteger[::1] icol,
-                                  ConstNumeric[::1] qdata):
+                                  const Integer[::1] irow,
+                                  const Integer[::1] icol,
+                                  const Numeric[::1] qdata):
 
         if not irow.shape[0] == icol.shape[0] == qdata.shape[0]:
             raise ValueError("quadratic vectors should be equal length")
@@ -223,7 +224,7 @@ cdef class cyBQM_template(cyQMBase):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cpdef Py_ssize_t add_quadratic_from_dense(self, ConstNumeric[:, ::1] quadratic) except -1:
+    cpdef Py_ssize_t add_quadratic_from_dense(self, const Numeric[:, ::1] quadratic) except -1:
         if quadratic.shape[0] != quadratic.shape[1]:
             raise ValueError("quadratic must be a square matrix")
 
@@ -268,10 +269,10 @@ cdef class cyBQM_template(cyQMBase):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def _from_numpy_vectors(cls,
-                            ConstNumeric[::1] linear,
-                            ConstInteger[::1] irow,
-                            ConstInteger[::1] icol,
-                            ConstNumeric[::1] qdata,
+                            const Numeric[::1] linear,
+                            const Integer[::1] irow,
+                            const Integer[::1] icol,
+                            const Numeric[::1] qdata,
                             bias_type offset,
                             object vartype):
         """Equivalent of from_numpy_vectors with fused types."""

--- a/dimod/constrained/cyconstrained.pxd
+++ b/dimod/constrained/cyconstrained.pxd
@@ -15,8 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-# cimport numpy as np
-
 from dimod.libcpp.constrained_quadratic_model cimport ConstrainedQuadraticModel as cppConstrainedQuadraticModel
 from dimod.constrained.cyexpression cimport cyObjectiveView, cyConstraintView
 from dimod.cyqmbase.cyqmbase_float64 cimport cyQMBase_float64, bias_type, index_type

--- a/dimod/constrained/cyconstrained.pyx
+++ b/dimod/constrained/cyconstrained.pyx
@@ -22,7 +22,6 @@ from copy import deepcopy
 
 cimport cython
 import numpy as np
-cimport numpy as np
 
 from cython.operator cimport preincrement as inc, dereference as deref
 from libc.math cimport ceil, floor
@@ -43,8 +42,8 @@ from dimod.discrete.cydiscrete_quadratic_model cimport cyDiscreteQuadraticModel
 from dimod.libcpp.abc cimport QuadraticModelBase as cppQuadraticModelBase
 from dimod.libcpp.constrained_quadratic_model cimport Sense as cppSense, Penalty as cppPenalty, Constraint as cppConstraint
 from dimod.libcpp.vartypes cimport Vartype as cppVartype, vartype_info as cppvartype_info
-
 from dimod.sym import Sense, Eq, Ge, Le
+from dimod.typing cimport int8_t
 from dimod.variables import Variables
 from dimod.vartypes import as_vartype, Vartype
 from dimod.views.quadratic import QuadraticViewsMixin
@@ -443,7 +442,7 @@ cdef class cyConstrainedQuadraticModel:
                          align=False)
         varinfo = np.empty(num_variables, dtype)
 
-        cdef np.int8_t[:] vartype_view = varinfo['vartype']
+        cdef int8_t[:] vartype_view = varinfo['vartype']
         cdef bias_type[:] lb_view = varinfo['lb']
         cdef bias_type[:] ub_view = varinfo['ub']
 
@@ -466,7 +465,7 @@ cdef class cyConstrainedQuadraticModel:
                          align=False)
 
         arr = np.frombuffer(buff[:dtype.itemsize*num_variables], dtype=dtype)
-        cdef const np.int8_t[:] vartype_view = arr['vartype']
+        cdef const int8_t[:] vartype_view = arr['vartype']
         cdef const bias_type[:] lb_view = arr['lb']
         cdef const bias_type[:] ub_view = arr['ub']
 

--- a/dimod/constrained/cyexpression.pyx
+++ b/dimod/constrained/cyexpression.pyx
@@ -16,7 +16,6 @@ import numbers
 import typing
 
 cimport cython
-cimport numpy as np
 import numpy as np
 
 from cython.operator cimport preincrement as inc, dereference as deref
@@ -37,7 +36,7 @@ from dimod.serialization.fileview import (
     read_header, write_header,
     IndicesSection, LinearSection, OffsetSection, NeighborhoodSection, QuadraticSection,
     )
-from dimod.typing cimport Numeric
+from dimod.typing cimport Numeric, float64_t
 from dimod.variables import Variables
 
 
@@ -142,7 +141,7 @@ cdef class _cyExpression:
         # we could do this manually, but way better to let NumPy handle it
         cdef const Numeric[:, ::1] subsamples = np.ascontiguousarray(np.asarray(samples)[:, reindex])
 
-        cdef np.float64_t[::1] energies = np.empty(num_samples, dtype=np.float64)
+        cdef float64_t[::1] energies = np.empty(num_samples, dtype=np.float64)
         cdef Py_ssize_t si
         if subsamples.shape[1]:
             for si in range(num_samples):

--- a/dimod/constrained/cyexpression.pyx
+++ b/dimod/constrained/cyexpression.pyx
@@ -27,7 +27,6 @@ import dimod
 
 from dimod.cyqmbase.cyqmbase_float64 import _dtype, _index_dtype
 from dimod.cyutilities cimport as_numpy_float
-from dimod.cyutilities cimport ConstNumeric
 from dimod.cyvariables cimport cyVariables
 from dimod.libcpp.abc cimport QuadraticModelBase as cppQuadraticModelBase
 from dimod.libcpp.constrained_quadratic_model cimport Penalty as cppPenalty
@@ -38,6 +37,7 @@ from dimod.serialization.fileview import (
     read_header, write_header,
     IndicesSection, LinearSection, OffsetSection, NeighborhoodSection, QuadraticSection,
     )
+from dimod.typing cimport Numeric
 from dimod.variables import Variables
 
 
@@ -124,7 +124,7 @@ cdef class _cyExpression:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _energies(self, ConstNumeric[:, ::1] samples, cyVariables labels):
+    def _energies(self, const Numeric[:, ::1] samples, cyVariables labels):
         cdef cppExpression[bias_type, index_type]* expression = self.expression()
 
         cdef Py_ssize_t num_samples = samples.shape[0]
@@ -140,7 +140,7 @@ cdef class _cyExpression:
         # the same length of the sample array, but let's not for now
 
         # we could do this manually, but way better to let NumPy handle it
-        cdef ConstNumeric[:, ::1] subsamples = np.ascontiguousarray(np.asarray(samples)[:, reindex])
+        cdef const Numeric[:, ::1] subsamples = np.ascontiguousarray(np.asarray(samples)[:, reindex])
 
         cdef np.float64_t[::1] energies = np.empty(num_samples, dtype=np.float64)
         cdef Py_ssize_t si

--- a/dimod/cyqmbase/cyqmbase_float32.pxd
+++ b/dimod/cyqmbase/cyqmbase_float32.pxd
@@ -15,10 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
+from dimod.typing cimport float32_t, int32_t
 
-ctypedef np.float32_t bias_type
-ctypedef np.int32_t index_type
+ctypedef float32_t bias_type
+ctypedef int32_t index_type
 
 include "cyqmbase_template.pxd.pxi"
 

--- a/dimod/cyqmbase/cyqmbase_float64.pxd
+++ b/dimod/cyqmbase/cyqmbase_float64.pxd
@@ -15,10 +15,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
+from dimod.typing cimport float64_t, int32_t
 
-ctypedef np.float64_t bias_type
-ctypedef np.int32_t index_type
+ctypedef float64_t bias_type
+ctypedef int32_t index_type
 
 include "cyqmbase_template.pxd.pxi"
 

--- a/dimod/cyqmbase/cyqmbase_template.pyx.pxi
+++ b/dimod/cyqmbase/cyqmbase_template.pyx.pxi
@@ -23,7 +23,7 @@ from dimod.libcpp.vartypes cimport Vartype as cppVartype
 
 from dimod.cyutilities cimport as_numpy_float
 from dimod.sampleset import as_samples
-from dimod.typing cimport Numeric
+from dimod.typing cimport Numeric, float64_t, int8_t
 from dimod.variables import Variables
 from dimod.vartypes import Vartype
 
@@ -86,7 +86,7 @@ cdef class cyQMBase_template:
         for si in range(self.num_variables()):
             qm_to_sample[si] = labels.index(self.variables.at(si))
 
-        cdef np.float64_t[::1] energies = np.empty(num_samples, dtype=np.float64)
+        cdef float64_t[::1] energies = np.empty(num_samples, dtype=np.float64)
 
         # alright, now let's calculate some energies!
         cdef Py_ssize_t ui, vi
@@ -215,7 +215,7 @@ cdef class cyQMBase_template:
                          align=False)
         varinfo = np.empty(num_variables, dtype)
 
-        cdef np.int8_t[:] vartype_view = varinfo['vartype']
+        cdef int8_t[:] vartype_view = varinfo['vartype']
         cdef bias_type[:] lb_view = varinfo['lb']
         cdef bias_type[:] ub_view = varinfo['ub']
 

--- a/dimod/cyqmbase/cyqmbase_template.pyx.pxi
+++ b/dimod/cyqmbase/cyqmbase_template.pyx.pxi
@@ -22,8 +22,8 @@ from libcpp.algorithm cimport lower_bound as cpplower_bound
 from dimod.libcpp.vartypes cimport Vartype as cppVartype
 
 from dimod.cyutilities cimport as_numpy_float
-from dimod.cyutilities cimport ConstNumeric
 from dimod.sampleset import as_samples
+from dimod.typing cimport Numeric
 from dimod.variables import Variables
 from dimod.vartypes import Vartype
 
@@ -70,7 +70,7 @@ cdef class cyQMBase_template:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    def _energies(self, ConstNumeric[:, ::1] samples, cyVariables labels):
+    def _energies(self, const Numeric[:, ::1] samples, cyVariables labels):
         cdef Py_ssize_t num_samples = samples.shape[0]
         cdef Py_ssize_t num_variables = samples.shape[1]
 

--- a/dimod/cyutilities.pxd
+++ b/dimod/cyutilities.pxd
@@ -16,59 +16,16 @@
 #    limitations under the License.
 
 cimport cython
-cimport numpy as np
 
 from dimod.libcpp.vartypes cimport Vartype as cppVartype
+from dimod.typing cimport Integer
 
 __all__ = [
     'as_numpy_float',
     'coo_sort',
-    'Integer',
-    'SignedInteger',
-    'UnsignedInteger',
     ]
 
-cdef fused SignedInteger:
-    np.int8_t
-    np.int16_t
-    np.int32_t
-    np.int64_t
-
-cdef fused UnsignedInteger:
-    np.uint8_t
-    np.uint16_t
-    np.uint32_t
-    np.uint64_t
-
-cdef fused Integer:
-    SignedInteger
-    UnsignedInteger
-
-cdef fused ConstInteger:
-    const short
-    const int
-    const long long
-    const unsigned short
-    const unsigned int
-    const unsigned long long
-
-ctypedef fused Numeric:
-    signed char
-    cython.integral  # short, int, long
-    cython.floating  # float, double
-
-# cython doesn't like const Numeric
-ctypedef fused ConstNumeric:
-    const signed char
-    const signed short
-    const signed int
-    const signed long long
-    const float
-    const double
-
-
 cdef object as_numpy_float(cython.floating)
-
 
 cpdef Py_ssize_t coo_sort(Integer[:], Integer[:], cython.floating[:]) except -1
 

--- a/dimod/cyutilities.pyx
+++ b/dimod/cyutilities.pyx
@@ -17,10 +17,10 @@ import typing
 cimport cython
 
 import numpy as np
-cimport numpy as np
 
 from dimod.libcpp.vartypes cimport vartype_info as cppvartype_info
 from dimod.typing import VartypeLike
+from dimod.typing cimport float32_t, float64_t
 from dimod.vartypes import as_vartype, Vartype
 
 __all__ = ['vartype_info']
@@ -153,17 +153,17 @@ def vartype_info(vartype, dtype=np.float64):
     dtype = np.dtype(dtype)
     if dtype == np.dtype(np.float32):
         return Info(
-            as_numpy_float(cppvartype_info[np.float32_t].default_min(vt)),
-            as_numpy_float(cppvartype_info[np.float32_t].default_max(vt)),
-            as_numpy_float(cppvartype_info[np.float32_t].min(vt)),
-            as_numpy_float(cppvartype_info[np.float32_t].max(vt)),
+            as_numpy_float(cppvartype_info[float32_t].default_min(vt)),
+            as_numpy_float(cppvartype_info[float32_t].default_max(vt)),
+            as_numpy_float(cppvartype_info[float32_t].min(vt)),
+            as_numpy_float(cppvartype_info[float32_t].max(vt)),
             )
     elif dtype == np.dtype(np.float64):
         return Info(
-            as_numpy_float(cppvartype_info[np.float64_t].default_min(vt)),
-            as_numpy_float(cppvartype_info[np.float64_t].default_max(vt)),
-            as_numpy_float(cppvartype_info[np.float64_t].min(vt)),
-            as_numpy_float(cppvartype_info[np.float64_t].max(vt)),
+            as_numpy_float(cppvartype_info[float64_t].default_min(vt)),
+            as_numpy_float(cppvartype_info[float64_t].default_max(vt)),
+            as_numpy_float(cppvartype_info[float64_t].min(vt)),
+            as_numpy_float(cppvartype_info[float64_t].max(vt)),
             )
     else:
         raise ValueError("only supports np.float64 and np.float32 dtypes")

--- a/dimod/cyutilities.pyx
+++ b/dimod/cyutilities.pyx
@@ -26,24 +26,13 @@ from dimod.vartypes import as_vartype, Vartype
 __all__ = ['vartype_info']
 
 
-cdef extern from "numpy/arrayobject.h":
-    ctypedef struct PyArray_Descr:
-        pass
-
-    object PyArray_Scalar(void*, PyArray_Descr*, object)
-
-np.import_array()  # needed for PyArray_Scalar
-
-# preconstruct these dtypes for speed, we could possibly improve it more
-# by casting to PyArray_Descr but I had trouble getting that to work
-cdef object _float32_dtype = np.dtype(np.float32)
-cdef object _float64_dtype = np.dtype(np.float64)
-
 cdef object as_numpy_float(cython.floating a):
-    if cython.floating == double:
-        return PyArray_Scalar(&a, <PyArray_Descr*>_float64_dtype, None)
-    elif cython.floating == float:
-        return PyArray_Scalar(&a, <PyArray_Descr*>_float32_dtype, None)
+    if cython.floating is double:
+        return np.float64(a)
+    elif cython.floating is float:
+        # this will promote to float64, then demote again. Annoying, but the
+        # alternative is to use NumPy C-API methods.
+        return np.float32(a)
     else:
         raise NotImplementedError
 

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -18,8 +18,6 @@
 
 from libcpp.vector cimport vector
 
-cimport numpy as np
-
 from dimod.libcpp.binary_quadratic_model cimport BinaryQuadraticModel as cppBinaryQuadraticModel
 from dimod.typing cimport float64_t, int32_t, Numeric, Integer
 

--- a/dimod/discrete/cydiscrete_quadratic_model.pxd
+++ b/dimod/discrete/cydiscrete_quadratic_model.pxd
@@ -21,38 +21,10 @@ from libcpp.vector cimport vector
 cimport numpy as np
 
 from dimod.libcpp.binary_quadratic_model cimport BinaryQuadraticModel as cppBinaryQuadraticModel
+from dimod.typing cimport float64_t, int32_t, Numeric, Integer
 
-ctypedef np.float64_t bias_type
-ctypedef np.int32_t index_type
-
-ctypedef fused Unsigned:
-    np.uint8_t
-    np.uint16_t
-    np.uint32_t
-    np.uint64_t
-
-ctypedef fused Integral32plus:
-    np.uint32_t
-    np.uint64_t
-    np.int32_t
-    np.int64_t
-
-ctypedef fused Numeric:
-    np.uint8_t
-    np.uint16_t
-    np.uint32_t
-    np.uint64_t
-    np.int8_t
-    np.int16_t
-    np.int32_t
-    np.int64_t
-    np.float32_t
-    np.float64_t
-
-ctypedef fused Numeric32plus:
-    Integral32plus
-    np.float32_t
-    np.float64_t
+ctypedef float64_t bias_type
+ctypedef int32_t index_type
 
 cdef class cyDiscreteQuadraticModel:
     cdef cppBinaryQuadraticModel[bias_type, index_type] cppbqm
@@ -76,5 +48,9 @@ cdef class cyDiscreteQuadraticModel:
     cpdef bias_type get_quadratic_case(
         self, index_type, index_type, index_type, index_type)  except? -45.3
 
-    cdef void _into_numpy_vectors(self, Unsigned[:] starts, bias_type[:] ldata,
-        Unsigned[:] irow, Unsigned[:] icol, bias_type[:] qdata)
+    cdef void _into_numpy_vectors(
+        self,
+        Integer[:] starts,
+        bias_type[:] ldata,
+        Integer[:] irow, Integer[:] icol, bias_type[:] qdata,
+        )

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -25,6 +25,7 @@ import numpy as np
 
 from dimod.utilities import asintegerarrays, asnumericarrays
 from dimod.cyutilities cimport as_numpy_float
+from dimod.typing cimport Integer
 
 BIAS_DTYPE = np.float64
 INDEX_DTYPE = np.int32
@@ -280,11 +281,11 @@ cdef class cyDiscreteQuadraticModel:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     def _from_numpy_vectors(cls,
-                            Integral32plus[::1] case_starts,
-                            Numeric32plus[::1] linear_biases,
-                            Integral32plus[::1] irow,
-                            Integral32plus[::1] icol,
-                            Numeric32plus[::1] quadratic_biases,
+                            Integer[::1] case_starts,
+                            Numeric[::1] linear_biases,
+                            Integer[::1] irow,
+                            Integer[::1] icol,
+                            Numeric[::1] quadratic_biases,
                             bias_type offset):
         """Equivalent of from_numpy_vectors with fused types."""
 
@@ -661,8 +662,11 @@ cdef class cyDiscreteQuadraticModel:
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef void _into_numpy_vectors(self, Unsigned[:] starts, bias_type[:] ldata,
-                                  Unsigned[:] irow, Unsigned[:] icol, bias_type[:] qdata):
+    cdef void _into_numpy_vectors(self,
+                                  Integer[:] starts,
+                                  bias_type[:] ldata,
+                                  Integer[:] irow, Integer[:] icol, bias_type[:] qdata,
+                                  ):
         # we don't do array length checking so be careful! This can segfault
         # if the given arrays are incorrectly sized
 

--- a/dimod/discrete/cydiscrete_quadratic_model.pyx
+++ b/dimod/discrete/cydiscrete_quadratic_model.pyx
@@ -25,7 +25,7 @@ import numpy as np
 
 from dimod.utilities import asintegerarrays, asnumericarrays
 from dimod.cyutilities cimport as_numpy_float
-from dimod.typing cimport Integer
+from dimod.typing cimport Integer, int64_t, uint16_t, uint32_t, uint64_t
 
 BIAS_DTYPE = np.float64
 INDEX_DTYPE = np.int32
@@ -53,8 +53,8 @@ cdef extern from *:
     }
     """
     struct LinearTerm:
-        np.int64_t variable
-        np.int64_t case "case_v"
+        int64_t variable
+        int64_t case "case_v"
         double bias
     void sort_terms(vector[LinearTerm]&)
 
@@ -713,11 +713,11 @@ cdef class cyDiscreteQuadraticModel:
         qdata = np.empty(num_interactions, dtype=self.dtype)
 
         if index_dtype == np.uint16:
-            self._into_numpy_vectors[np.uint16_t](starts, ldata, irow, icol, qdata)
+            self._into_numpy_vectors[uint16_t](starts, ldata, irow, icol, qdata)
         elif index_dtype == np.uint32:
-            self._into_numpy_vectors[np.uint32_t](starts, ldata, irow, icol, qdata)
+            self._into_numpy_vectors[uint32_t](starts, ldata, irow, icol, qdata)
         else:
-            self._into_numpy_vectors[np.uint64_t](starts, ldata, irow, icol, qdata)
+            self._into_numpy_vectors[uint64_t](starts, ldata, irow, icol, qdata)
 
         if return_offset:
             return starts, ldata, (irow, icol, qdata), self.offset

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -676,6 +676,12 @@ class DiscreteQuadraticModel:
             biases (array-like): The linear biases in an array.
 
         """
+        biases = np.asarray(biases)
+
+        # handle unsigned
+        if np.issubdtype(biases.dtype, np.unsignedinteger):
+            biases = np.asarray(biases, dtype=np.int64)
+
         self._cydqm.set_linear(self.variables.index(v), np.asarray(biases))
 
     def set_linear_case(self, v, case, bias):

--- a/dimod/quadratic/cyqm/cyqm_float32.pxd
+++ b/dimod/quadratic/cyqm/cyqm_float32.pxd
@@ -15,8 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
-
 from dimod.cyqmbase.cyqmbase_float32 cimport cyQMBase_float32 as cyQMBase, bias_type, index_type
 
 include "cyqm_template.pxd.pxi"

--- a/dimod/quadratic/cyqm/cyqm_float64.pxd
+++ b/dimod/quadratic/cyqm/cyqm_float64.pxd
@@ -15,8 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-cimport numpy as np
-
 from dimod.cyqmbase.cyqmbase_float64 cimport cyQMBase_float64 as cyQMBase, bias_type, index_type
 
 include "cyqm_template.pxd.pxi"

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -27,10 +27,11 @@ from libcpp.vector cimport vector
 import dimod
 
 from dimod.binary.cybqm cimport cyBQM
-from dimod.cyutilities cimport as_numpy_float, ConstInteger, ConstNumeric, cppvartype
+from dimod.cyutilities cimport as_numpy_float, cppvartype
 from dimod.libcpp.vartypes cimport vartype_info as cppvartype_info
 from dimod.quadratic cimport cyQM
 from dimod.sampleset import as_samples
+from dimod.typing cimport Integer, Numeric
 from dimod.variables import Variables
 from dimod.vartypes import as_vartype, Vartype
 
@@ -126,7 +127,7 @@ cdef class cyQM_template(cyQMBase):
 
         self.cppqm.add_linear(vi, bias)
 
-    def add_linear_from_array(self, ConstNumeric[:] linear):
+    def add_linear_from_array(self, const Numeric[:] linear):
         cdef Py_ssize_t length = linear.shape[0]
         cdef Py_ssize_t vi
 
@@ -172,8 +173,8 @@ cdef class cyQM_template(cyQMBase):
         self._add_quadratic(ui, vi, bias)
 
     def add_quadratic_from_arrays(self,
-                                  ConstInteger[::1] irow, ConstInteger[::1] icol,
-                                  ConstNumeric[::1] qdata):
+                                  const Integer[::1] irow, const Integer[::1] icol,
+                                  const Numeric[::1] qdata):
         if not irow.shape[0] == icol.shape[0] == qdata.shape[0]:
             raise ValueError("quadratic vectors should be equal length")
         cdef Py_ssize_t length = irow.shape[0]

--- a/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
+++ b/dimod/quadratic/cyqm/cyqm_template.pyx.pxi
@@ -31,7 +31,7 @@ from dimod.cyutilities cimport as_numpy_float, cppvartype
 from dimod.libcpp.vartypes cimport vartype_info as cppvartype_info
 from dimod.quadratic cimport cyQM
 from dimod.sampleset import as_samples
-from dimod.typing cimport Integer, Numeric
+from dimod.typing cimport Integer, Numeric, int8_t
 from dimod.variables import Variables
 from dimod.vartypes import as_vartype, Vartype
 
@@ -95,7 +95,7 @@ cdef class cyQM_template(cyQMBase):
                          align=False)
 
         arr = np.frombuffer(buff[:dtype.itemsize*num_variables], dtype=dtype)
-        cdef const np.int8_t[:] vartype_view = arr['vartype']
+        cdef const int8_t[:] vartype_view = arr['vartype']
         cdef const bias_type[:] lb_view = arr['lb']
         cdef const bias_type[:] ub_view = arr['ub']
 

--- a/dimod/typing.pxd
+++ b/dimod/typing.pxd
@@ -44,7 +44,6 @@ cdef fused Integer:
     SignedInteger
     UnsignedInteger
 
-# The same as cython.numeric with the addition of int8
 ctypedef fused Numeric:
     int8_t
     int16_t

--- a/dimod/typing.pxd
+++ b/dimod/typing.pxd
@@ -1,0 +1,54 @@
+# Copyright 2024 D-Wave Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+cimport cython
+
+from libc.stdint cimport (
+    int8_t, int16_t, int32_t, int64_t,
+    uint8_t, uint16_t, uint32_t, uint64_t,
+    )
+
+# Follow NumPy
+# https://github.com/numpy/numpy/blob/882611cf11e1925bd8f3a8d7aa00d74675a7601c/numpy/__init__.pxd#L73-L74
+# By following their behavior but not cimporting NumPy directly we can avoid  requiring
+# NumPy at build-time.
+ctypedef float float32_t
+ctypedef double float64_t
+
+# cython.integral only has short, int, long, so we need our own to also support int8
+cdef fused SignedInteger:
+    int8_t
+    int16_t
+    int32_t
+    int64_t
+
+# cython.integral doesn't support unsigned at all.
+cdef fused UnsignedInteger:
+    uint8_t
+    uint16_t
+    uint32_t
+    uint64_t
+
+cdef fused Integer:
+    SignedInteger
+    UnsignedInteger
+
+# The same as cython.numeric with the addition of int8
+ctypedef fused Numeric:
+    int8_t
+    int16_t
+    int32_t
+    int64_t
+    float32_t
+    float64_t

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=46.4.0",
     "wheel",
     "Cython~=3.0",
-    'oldest-supported-numpy',
 ]
 build-backend = "setuptools.build_meta"
 

--- a/releasenotes/notes/remove-numpy-build-dependency-9a5cd6a9661dcde7.yaml
+++ b/releasenotes/notes/remove-numpy-build-dependency-9a5cd6a9661dcde7.yaml
@@ -3,6 +3,7 @@ features:
   - |
     Add ``dimod/typing.pdx``. This allows users to ``cimport`` common C
     types into other namespaces.
+  - No longer require NumPy at build-time.
 upgrade:
   - |
     Remove Cython fused types

--- a/releasenotes/notes/remove-numpy-build-dependency-9a5cd6a9661dcde7.yaml
+++ b/releasenotes/notes/remove-numpy-build-dependency-9a5cd6a9661dcde7.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Add ``dimod/typing.pdx``. This allows users to ``cimport`` common C
+    types into other namespaces.
+upgrade:
+  - |
+    Remove Cython fused types
+    ``dimod.cyutilities.SignedInteger``,
+    ``dimod.cyutilities.UnsignedInteger``,
+    ``dimod.cyutilities.Integer``, and
+    ``dimod.cyutilities.ConstInteger``,
+    ``dimod.cyutilities.Numeric``, and
+    ``dimod.cyutilities.ConstNumeric``.
+    Use the types in ``dimod.typing`` instead.
+  - |
+    Remove Cython fused types
+    ``dimod.discrete.cydiscrete_quadratic_model.Unsigned``,
+    ``dimod.discrete.cydiscrete_quadratic_model.Integral32plus``,
+    ``dimod.discrete.cydiscrete_quadratic_model.Numeric``, and
+    ``dimod.discrete.cydiscrete_quadratic_model.Numeric32plus``.
+    Use the types in ``dimod.typing`` instead.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 oldest-supported-numpy
-cython==3.0.4
+cython==3.0.10
 
 reno==3.3.0  # for changelog
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@ import os
 
 from setuptools import setup
 
-import numpy
-
 from Cython.Build import cythonize
 from setuptools.command.build_ext import build_ext as _build_ext
 
@@ -75,9 +73,6 @@ setup(
         annotate=True,
         nthreads=int(os.getenv('CYTHON_NTHREADS', 0)),
         ),
-    include_dirs=[
-        numpy.get_include(),
-        ],
     install_requires=[
         # this is the oldest supported NumPy on Python 3.8
         'numpy>=1.17.3,<2.0.0',


### PR DESCRIPTION
This will make NumPy 2.0 support much easier. Will do that in a followup PR.

Contains the commits from https://github.com/dwavesystems/dimod/pull/1374. I will rebase once that one is merged.