### PR TITLE
Use M1 resource class for macos builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
             python -m venv env
             . env/bin/activate
             pip install dimod --no-index -f dist/ --force-reinstall --no-deps
-            pip install << parameters.dependencies >> --upgrade --only-binary=numpy
+            pip install "<< parameters.dependencies >>" --upgrade --only-binary=numpy
       - run: &unix-run-tests
           name: run tests
           command: |
@@ -333,7 +333,7 @@ workflows:
           matrix:
             parameters:
               # test the lowest supported numpy and the latest
-              dependencies: [oldest-supported-numpy, numpy]
+              dependencies: [oldest-supported-numpy, numpy<2.0.0]
               python-version: *python-versions
       - test-linux-cpp
       - test-osx-cpp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 orbs:
   codecov: codecov/codecov@3
-  win: circleci/windows@5.0.0
-  macos: circleci/macos@2.4.1
+  win: circleci/windows@5.0
+  macos: circleci/macos@2.4
 
 environment: &global-environment
   PIP_PROGRESS_BAR: 'off'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@3
   win: circleci/windows@5.0.0
+  macos: circleci/macos@2.4.1
 
 environment: &global-environment
   PIP_PROGRESS_BAR: 'off'
@@ -74,14 +75,21 @@ jobs:
         type: string
 
     macos:
-      xcode: 13.4.0
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
 
     environment:
       <<: *global-environment
       CIBW_PROJECT_REQUIRES_PYTHON: ~=<< parameters.python-version>>
 
-    steps: *build-steps
-
+    steps:
+      - checkout
+      - macos/install-rosetta
+      - restore_cache: *build-linux-restore-cache
+      - run: *build-linux-wheels
+      - save_cache: *build-linux-save-cache
+      - store_artifacts: *store-artifacts
+      - persist_to_workspace: *persist-to-workspace
   build-sdist:
     docker:
       - image: cimg/python:3.9
@@ -281,7 +289,8 @@ jobs:
 
   test-osx-cpp:
     macos:
-      xcode: 13.4.0
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
 
     steps:
       - checkout


### PR DESCRIPTION
I'll uncap the NumPy version in another PR (i.e., https://github.com/dwavesystems/dimod/pull/1373).

See also https://github.com/dwavesystems/dwave-ocean-sdk/issues/294.