### PR TITLE
Doxyfile update

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -243,8 +243,8 @@ ALIASES                =
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"
 # will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
+# OBSOLETE FOR DOXYGEN 1.9.1
+# TCL_SUBST              =         
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -1104,8 +1104,8 @@ ALPHABETICAL_INDEX     = YES
 # which the alphabetical index list will be split.
 # Minimum value: 1, maximum value: 20, default value: 5.
 # This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
+# OBSOLETE FOR DOXYGEN 1.9.1
+# COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag
@@ -2169,8 +2169,8 @@ EXTERNAL_PAGES         = YES
 # The PERL_PATH should be the absolute path and name of the perl script
 # interpreter (i.e. the result of 'which perl').
 # The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
+# OBSOLETE FOR DOXYGEN 1.9.1
+# PERL_PATH              = /usr/bin/perl
 
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
@@ -2191,8 +2191,8 @@ CLASS_DIAGRAMS         = YES
 # documentation. The MSCGEN_PATH tag allows you to specify the directory where
 # the mscgen tool resides. If left empty the tool is assumed to be found in the
 # default search path.
-
-MSCGEN_PATH            =
+# OBSOLETE FOR DOXYGEN 1.9.1
+# MSCGEN_PATH            =
 
 # You can include diagrams made with dia in doxygen documentation. Doxygen will
 # then run dia to produce the diagram and insert it in the documentation. The

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -724,7 +724,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = $(DOXYGEN_QUIET)
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -733,7 +733,7 @@ QUIET                  = NO
 # Tip: Turn warnings on while writing the documentation.
 # The default value is: YES.
 
-WARNINGS               = YES
+WARNINGS               = $(DOXYGEN_WARNINGS)
 
 # If the WARN_IF_UNDOCUMENTED tag is set to YES then doxygen will generate
 # warnings for undocumented members. If EXTRACT_ALL is set to YES then this flag
@@ -778,7 +778,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           =
+WARN_LOGFILE           = $(DOXYGEN_WARN_LOGFILE)
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files


### PR DESCRIPTION
This is to get rid of the doxygen warnings below. Alternatively one can upgrade the Doxyfile but I see that our build uses version 1.9.1 and my systems won't go down that low (and the upgrade mainly updates comments).

I also replaced defaults for verbosity with env variables so we can run with fewer warnings in CircleCI and with warnings locally and in RTD builds. Execution should continue to use the defaults unless one sets these new env variables in the conf file, something like: 

```
if os.environ.get('CI', False):
    subprocess.call('cd ../minorminer/docs/; DOXYGEN_QUIET=YES make cpp', shell=True)
    ...
```

```
warning: Tag 'TCL_SUBST' at line 247 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'COLS_IN_ALPHA_INDEX' at line 1108 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'PERL_PATH' at line 2173 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
warning: Tag 'MSCGEN_PATH' at line 2195 of file '-' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```