### PR TITLE
prevent syntax warnings for invalid escape characters

### DIFF
--- a/dimod/binary/binary_quadratic_model.py
+++ b/dimod/binary/binary_quadratic_model.py
@@ -487,7 +487,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
 
     @property
     def binary(self) -> 'BinaryQuadraticModel':
-        """Binary-valued version of the binary quadratic model.
+        r"""Binary-valued version of the binary quadratic model.
 
         If the binary quadratic model is binary-valued, this references itself,
         otherwise it references a view.
@@ -656,7 +656,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
     def add_linear_equality_constraint(
             self, terms: Iterable[Tuple[Variable, Bias]],
             lagrange_multiplier: Bias, constant: Bias):
-        """Add a linear constraint as a quadratic objective.
+        r"""Add a linear constraint as a quadratic objective.
 
         Adds a linear constraint of the form
         :math:`\\sum_{i} a_{i} x_{i} + C = 0`
@@ -713,7 +713,7 @@ class BinaryQuadraticModel(QuadraticViewsMixin):
                 cross_zero: bool = False,
                 penalization_method: Literal["slack", "unbalanced"] = "slack",
         ) -> Iterable[Tuple[Variable, int]]:
-        """Add a linear inequality constraint as a quadratic objective.
+        r"""Add a linear inequality constraint as a quadratic objective.
 
         The linear inequality constraint is of the form:
         :math:`lb <= \sum_{i,k} a_{i,k} x_{i,k} + constant <= ub`.
@@ -2617,7 +2617,7 @@ AdjVectorBQM = Float64BQM
 @unique_variable_labels
 def Binary(label: Optional[Variable] = None, bias: Bias = 1,
            dtype: Optional[DTypeLike] = None) -> BinaryQuadraticModel:
-    """Return a binary quadratic model with a single binary variable.
+    r"""Return a binary quadratic model with a single binary variable.
 
     Args:
         label: Hashable label to identify the variable. Defaults to a
@@ -2643,7 +2643,7 @@ def Binary(label: Optional[Variable] = None, bias: Bias = 1,
 
 def Binaries(labels: Union[int, Iterable[Variable]],
              dtype: Optional[DTypeLike] = None) -> Iterator[BinaryQuadraticModel]:
-    """Yield binary quadratic models, each with a single binary variable.
+    r"""Yield binary quadratic models, each with a single binary variable.
 
     Args:
         labels: Either an iterable of variable labels or a number. If a number
@@ -2679,7 +2679,7 @@ def Binaries(labels: Union[int, Iterable[Variable]],
 
 def BinaryArray(labels: Union[int, Iterable[Variable]],
                 dtype: Optional[DTypeLike] = None) -> np.ndarray:
-    """Return a NumPy array of binary quadratic models, each with a
+    r"""Return a NumPy array of binary quadratic models, each with a
     single binary variable.
 
     Args:
@@ -2718,7 +2718,7 @@ def BinaryArray(labels: Union[int, Iterable[Variable]],
 @unique_variable_labels
 def Spin(label: Optional[Variable] = None, bias: Bias = 1,
          dtype: Optional[DTypeLike] = None) -> BinaryQuadraticModel:
-    """Return a binary quadratic model with a single spin variable.
+    r"""Return a binary quadratic model with a single spin variable.
 
     Args:
         label: Hashable label to identify the variable. Defaults to a
@@ -2781,7 +2781,7 @@ def Spins(labels: Union[int, Iterable[Variable]],
 
 def SpinArray(labels: Union[int, Iterable[Variable]],
               dtype: Optional[DTypeLike] = None) -> np.ndarray:
-    """Return a NumPy array of binary quadratic models, each with a
+    r"""Return a NumPy array of binary quadratic models, each with a
     single spin variable.
 
     Args:

--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -1149,7 +1149,7 @@ class ConstrainedQuadraticModel(cyConstrainedQuadraticModel):
                              *,
                              labels: typing.Optional[typing.Iterable[typing.Hashable]] = None,
                              ) -> Iterator[ConstraintData]:
-        """Yield information about the constraints for the given sample.
+        r"""Yield information about the constraints for the given sample.
 
         Note that this method iterates over constraints in the same order as
         they appear in :attr:`.constraints`.

--- a/dimod/discrete/discrete_quadratic_model.py
+++ b/dimod/discrete/discrete_quadratic_model.py
@@ -191,7 +191,7 @@ class DiscreteQuadraticModel:
     def add_linear_equality_constraint(self, terms: LinearTriplets,
                                        lagrange_multiplier: float,
                                        constant: float):
-        """Add a linear constraint as a quadratic objective.
+        r"""Add a linear constraint as a quadratic objective.
 
         Adds a linear constraint of the form
         :math:`\sum_{i,k} a_{i,k} x_{i,k} + C = 0`
@@ -219,7 +219,7 @@ class DiscreteQuadraticModel:
                                          cross_zero: bool = False)\
             -> LinearTriplets:
 
-        """Add a linear inequality constraint as a quadratic objective.
+        r"""Add a linear inequality constraint as a quadratic objective.
 
         Adds a linear inequality constraint of the form:
 

--- a/dimod/generators/anti_crossing.py
+++ b/dimod/generators/anti_crossing.py
@@ -63,7 +63,7 @@ def anti_crossing_clique(num_variables: int) -> BinaryQuadraticModel:
 
 
 def anti_crossing_loops(num_variables: int) -> BinaryQuadraticModel:
-    """Generate an anti-crossing problem with two loops.
+    r"""Generate an anti-crossing problem with two loops.
 
     The low-energy space of this model consists of a unique ground state of all
     :math:`+1`\ s and a degenerate first excited state, centered at all

--- a/dimod/generators/wireless.py
+++ b/dimod/generators/wireless.py
@@ -36,7 +36,7 @@ mod_config = {
     "256QAM": mod_params(8, 8, 8, 5, 4)}
 
 def _quadratic_form(y, F):
-    """Convert :math:`O(v) = ||y - F v||^2` to sparse quadratic form.
+    r"""Convert :math:`O(v) = ||y - F v||^2` to sparse quadratic form.
 
     Constructs coefficients for the form
     :math:`O(v) = v^{\dagger} J v - 2 \Re(h^{\dagger} v) + \\text{offset}`.
@@ -175,7 +175,7 @@ def _symbols_to_bits(symbols, modulation="BPSK"):
     return bits
 
 def _yF_to_hJ(y, F, modulation="BPSK"):
-    """Convert :math:`O(v) = ||y - F v||^2` to modulated quadratic form.
+    r"""Convert :math:`O(v) = ||y - F v||^2` to modulated quadratic form.
 
     Constructs coefficients for the form
     :math:`O(v) = v^{\dagger} J v - 2 \Re(h^{\dagger} v) + \\text{offset}`.
@@ -446,7 +446,7 @@ def _create_signal(F,
                    modulation='BPSK', 
                    channel_power=None, 
                    random_state=None):
-    """Simulate a transmission signal. 
+    r"""Simulate a transmission signal. 
 
     Generates random transmitted symbols and optionally noise, math:`y = F v + n`,
     where the channel, :math:`F`, is assumed to consist of independent and 
@@ -549,7 +549,7 @@ def mimo(modulation: Literal["BPSK", "QPSK", "16QAM", "64QAM", "256QAM"] = "BPSK
          seed: Union[None, int, np.random.RandomState] = None,
          F_distribution: Union[None, tuple] = None,
          attenuation_matrix = None) -> dimod.BinaryQuadraticModel:
-    """Generate a multi-input multiple-output (MIMO) channel-decoding problem.
+    r"""Generate a multi-input multiple-output (MIMO) channel-decoding problem.
 
     In radio networks, `MIMO <https://en.wikipedia.org/wiki/MIMO>`_ is a method 
     of increasing link capacity by using multiple transmission and receiving 
@@ -897,7 +897,7 @@ def coordinated_multipoint(lattice: 'networkx.Graph',
 # and are maintained here for user convenience 
  
 def linear_filter(F, method='zero_forcing', SNRoverNt=float('Inf'), PoverNt=1):
-    """Construct a linear filter for estimating transmitted signals.
+    r"""Construct a linear filter for estimating transmitted signals.
 
     Following the conventions of MacKay\ [#Mackay]_, a filter is constructed 
     for independent and identically distributed Gaussian noise at power spectral 

--- a/dimod/quadratic/quadratic_model.py
+++ b/dimod/quadratic/quadratic_model.py
@@ -698,7 +698,7 @@ class QuadraticModel(QuadraticViewsMixin):
         return energy
 
     def flip_variable(self, v: Variable):
-        """Flip the specified binary-valued variable.
+        r"""Flip the specified binary-valued variable.
 
         Args:
             v: Binary-valued (:math:`\{0, 1\}` or :math:`\{-1, 1\}`) variable in

--- a/dimod/sym.py
+++ b/dimod/sym.py
@@ -22,7 +22,7 @@ __all__ = ['Sense', 'Eq', 'Ge', 'Le']
 
 
 class Sense(enum.Enum):
-    """Sense of a constraint.
+    r"""Sense of a constraint.
 
     Supported values are:
 

--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -34,7 +34,7 @@ __all__ = ['ising_energy',
 
 
 def ising_energy(sample, h, J, offset=0.0):
-    """Calculate the energy for the specified sample of an Ising model.
+    r"""Calculate the energy for the specified sample of an Ising model.
 
     Energy of a sample for a binary quadratic model is defined as a sum, offset
     by the constant energy offset associated with the model, of
@@ -97,7 +97,7 @@ def ising_energy(sample, h, J, offset=0.0):
 
 
 def qubo_energy(sample, Q, offset=0.0):
-    """Calculate the energy for the specified sample of a QUBO model.
+    r"""Calculate the energy for the specified sample of a QUBO model.
 
     Energy of a sample for a binary quadratic model is defined as a sum, offset
     by the constant energy offset associated with the model, of


### PR DESCRIPTION
importing dimod currently results in a number of syntax warnings due to invalid escape sequences in docstrings in recent python versions (see #1370). This just prevents the warnings by marking the offending docstrings as `r"raw string literals"`