### PR TITLE
Propagate `.wait_id` from future to `SampleSet`

### DIFF
--- a/releasenotes/notes/add-sampleset.wait_id-as-proxy-to-qpu-future-9de9fbbc3dbc2285.yaml
+++ b/releasenotes/notes/add-sampleset.wait_id-as-proxy-to-qpu-future-9de9fbbc3dbc2285.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add ``SampleSet.wait_id()`` as a proxy to the underlying QPU result future,
+    when sample set is constructed from such a future.
+    See `#1392 <https://github.com/dwavesystems/dimod/issues/1392>`_.


### PR DESCRIPTION
Close #1392.