### PR TITLE
Use dict rather than OrderedDict in TrackingComposite

### DIFF
--- a/dimod/reference/composites/tracking.py
+++ b/dimod/reference/composites/tracking.py
@@ -13,7 +13,6 @@
 #    limitations under the License.
 
 """A composite that tracks inputs and outputs."""
-from collections import OrderedDict
 from copy import deepcopy
 from functools import wraps
 
@@ -33,7 +32,7 @@ def tracking(f):
     @wraps(f)
     def _tracking(sampler, *args, **kwargs):
 
-        inpt = OrderedDict(zip(getfullargspec(f).args[1:], args))  # skip self
+        inpt = dict(zip(getfullargspec(f).args[1:], args))  # skip self
         inpt.update(kwargs)
 
         # we need to do this before in case they get mutated
@@ -72,7 +71,7 @@ class TrackingComposite(ComposedSampler):
         >>> sampleset = sampler.sample_ising({'a': -1}, {('a', 'b'): 1},
         ...                                  num_reads=5)
         >>> sampler.input
-        OrderedDict([('h', {'a': -1}), ('J', {('a', 'b'): 1}), ('num_reads', 5)])
+        {'h': {'a': -1}, 'J': {('a', 'b'): 1}, 'num_reads': 5}
         >>> sampleset == sampler.output
         True
 
@@ -82,10 +81,10 @@ class TrackingComposite(ComposedSampler):
 
         >>> sampleset = sampler.sample_qubo({('a', 'b'): 1})
         >>> sampler.input
-        OrderedDict([('Q', {('a', 'b'): 1})])
+        {'Q': {('a', 'b'): 1}}
         >>> sampler.inputs # doctest: +SKIP
-        [OrderedDict([('h', {'a': -1}), ('J', {('a', 'b'): 1}), ('num_reads', 5)]),
-         OrderedDict([('Q', {('a', 'b'): 1})])]
+        [{'h': {'a': -1}, 'J': {('a', 'b'): 1}, 'num_reads': 5},
+         {'Q': {('a', 'b'): 1}}]
 
         In the case that you want to nest the tracking composite, there are two
         patterns for retrieving the data

--- a/releasenotes/notes/TrackingComposite-OrderedDict-to-dict-073323bc352bc35d.yaml
+++ b/releasenotes/notes/TrackingComposite-OrderedDict-to-dict-073323bc352bc35d.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Use ``dict`` rather than ``collections.OrderedDict`` to capture the inputs
+    in ``TrackingComposite``.
+    See also `#1395 <https://github.com/dwavesystems/dimod/issues/1395>`_.

--- a/tests/test_trackingcomposite.py
+++ b/tests/test_trackingcomposite.py
@@ -110,6 +110,7 @@ class TestSample(unittest.TestCase):
         ss = sampler.sample_ising(h, J, num_reads=5)
 
         self.assertEqual(sampler.input, dict(h=h, J=J, num_reads=5))
+        self.assertEqual(list(sampler.input), ["h", "J", "num_reads"])
         self.assertEqual(sampler.output, ss)
 
     def test_sample_qubo(self):


### PR DESCRIPTION
`TrackingComposite` was added while we still supported Python 2.7 (https://github.com/dwavesystems/dimod/pull/484). Now that `dict` is ordered, we can just use `dict` rather than `OrderedDict`.

Closes https://github.com/dwavesystems/dimod/issues/1395