### PR TITLE
Add Quadratic Multi Knapsack Generator

### DIFF
--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -51,6 +51,7 @@ Optimization
    maximum_weight_independent_set
    mimo
    multi_knapsack
+   multi_quadratic_knapsack
    quadratic_assignment
    quadratic_knapsack
    random_bin_packing

--- a/releasenotes/notes/quadratic-multi-knapsack-generator-6bd6daf629f11399.yaml
+++ b/releasenotes/notes/quadratic-multi-knapsack-generator-6bd6daf629f11399.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add ``quadratic_multi_knapsack`` generator function to ``dimod.generators``.

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -653,6 +653,25 @@ class TestMultiKnapsack(unittest.TestCase):
         self.assertEqual(len(cqm.variables), num_items*num_bins)
         self.assertEqual(len(cqm.constraints), num_bins+num_items)
 
+    def test_quadratic_exceptions(self):
+        with self.assertRaises(ValueError):
+            dimod.generators.quadratic_multi_knapsack([1], [], [], [])
+
+        with self.assertRaises(ValueError):
+            dimod.generators.quadratic_multi_knapsack([1], [1], [[1, 1]], [])
+
+        with self.assertRaises(ValueError):
+            dimod.generators.quadratic_multi_knapsack([1], [1], [[1, 1], [1, 1]], [])
+
+    def test_quadratic_model(self):
+        values = [1, 2, 3]
+        weights = [3, 2, 1]
+        profits = [[1, 2, 3], [2, 2, 2], [3, 2, 1]]
+        capacity = [1, 2]
+        cqm = dimod.generators.quadratic_multi_knapsack(values, weights, profits, capacity)
+        self.assertEqual(len(cqm.variables), len(values)*len(capacity))
+        self.assertEqual(len(cqm.constraints), len(weights)+len(capacity))
+
 
 class TestGates(unittest.TestCase):
     def test_gates_no_aux(self):


### PR DESCRIPTION
A quadratic multiple knapsack generator that allows for custom values, weights, profits and capacities.

@arcondello: @eordog and I chatted about whether it makes more sense for the diagonal of `profits` to be the `values` instead of passing `values` in as a separate array. Some of her benchmarking datasets have `values` as a separate array and some have it as the diagonal of `profits`. Curious if you have any thoughts on this. I went with separate as that's how I did it for `quadratic_knapsack`, whatever we end up going with I think these two functions should be consistent.