### PR TITLE
Fix `multi_quadratic_knapsack` from #1397

### DIFF
--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -51,9 +51,9 @@ Optimization
    maximum_weight_independent_set
    mimo
    multi_knapsack
-   multi_quadratic_knapsack
    quadratic_assignment
    quadratic_knapsack
+   quadratic_multi_knapsack
    random_bin_packing
    random_knapsack
    random_multi_knapsack


### PR DESCRIPTION
the relevant code: https://github.com/dwavesystems/dimod/blob/ac4dcbb7424db6b6a14448ec84f0f04bbbd8b80f/dimod/generators/multi_knapsack.py#L23