### PR TITLE
Fix CQMToBQMInverter

### DIFF
--- a/dimod/constrained/constrained.py
+++ b/dimod/constrained/constrained.py
@@ -2050,10 +2050,12 @@ class CQMToBQMInverter:
             else:
                 raise RuntimeError("unexpected vartype")
 
+        sample_u = None
         for v, bqm in self._integers.items():
             new[v] = 0
             for u in bqm.variables:
-                new[v] += sample[u] * u[1]
+                sample_u = np.uint(sample[u]) if 'msb' in u else sample[u]
+                new[v] += sample_u * u[1]
 
         return new
 

--- a/tests/test_constrained.py
+++ b/tests/test_constrained.py
@@ -937,6 +937,13 @@ class TestCQMtoBQM(unittest.TestCase):
             int_sample = newinverter(bin_sample)
             self.assertGreaterEqual(int_sample['i'] + int_sample['j'] + int_sample['x'], 5)
 
+    def test_cqm_inverter(self):
+        cqm = dimod.ConstrainedQuadraticModel()
+        cqm.set_objective(dimod.Integer('var', upper_bound=255))
+        bqm, inverter = dimod.cqm_to_bqm(cqm)
+        cqm_sol = inverter(dimod.ExactSolver().sample(bqm).first.sample)
+        self.assertEqual(cqm_sol['var'], 0)
+
 
 class TestFromDQM(unittest.TestCase):
     def test_case_label(self):


### PR DESCRIPTION
CQMToBQMInverter produced a bug with some instances due to the interaction between python's `int` and numpy's `uint`

As the bug only occurs with `msb` in that case a cast is made which avoids the error

Example code before the fix:

```python
cqm = dimod.ConstrainedQuadraticModel()
cqm.set_objective(dimod.Integer('var', upper_bound=255))
bqm, inverter = dimod.cqm_to_bqm(cqm)
cqm_sol = inverter(dimod.ExactSolver().sample(bqm).first.sample)
```

Error generated: `Python integer 128 out of bounds for int8`