### PR TITLE
Fix Variables._relabel() with supersets

### DIFF
--- a/dimod/utilities.py
+++ b/dimod/utilities.py
@@ -366,6 +366,10 @@ def iter_safe_relabels(mapping: collections.abc.Mapping[Variable, Variable],
         A "safe" relabelling.
 
     """
+    # first if the mapping is a superset of existing, we can go ahead and drop
+    # the stuff we don't care about
+    mapping = {old: new for old, new in mapping.items() if old in existing}
+
     # put the new labels into a set for fast lookup, also ensures that the
     # values are valid labels
     # We could use a set, but using a dict makes for nicer error messages later

--- a/releasenotes/notes/fix-variables-relabel-c145815df427c55c.yaml
+++ b/releasenotes/notes/fix-variables-relabel-c145815df427c55c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix ``Variables._relabel()`` method. Previously when given a superset of
+    labels that happen to correspond to valid indices the wrong relabelling
+    would sometimes be applied.
+    See also `#1408 <https://github.com/dwavesystems/dimod/issues/1408>`_.

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -210,6 +210,11 @@ class TestRelabel(unittest.TestCase):
 
         self.assertEqual(variables, Variables('ab'))
 
+    def test_superset(self):
+        variables = Variables([2, 0])
+        variables._relabel({0: "a", 1: "b", 2: "c"})
+        self.assertEqual(variables, ["c", "a"])
+
     def test_swap(self):
         variables = Variables([1, 0, 3, 4, 5])
         variables._relabel({5: 3, 3: 5})


### PR DESCRIPTION
Looking through the logic, I think it would be possible to avoid the copy with a more significant rework. But we already are doing many copies and traversals in that family of functions so IMO the simpler approach is best.


Closes #1408 