### PR TITLE
Simplify xcode version management in CI by using `current`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,7 @@ jobs:
         type: string
 
     macos:
-      xcode: 16.4.0  # latest as of August 2025
-    resource_class: macos.m1.medium.gen1
+      xcode: 16.4.0
 
     environment:
       <<: *global-environment
@@ -269,8 +268,7 @@ jobs:
 
   test-osx-cpp:
     macos:
-      xcode: 15.3.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 16.4.0
 
     steps:
       - checkout


### PR DESCRIPTION
Also, fix the use of a legacy resource class, `macos.m1.medium.gen1`.