### PR TITLE
Drop `manylinux2014` wheels support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ test-command = "python -m unittest discover {project}/tests/"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64 aarch64"
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 # We follow NumPy and don't build universal wheels, see https://github.com/numpy/numpy/pull/20787

--- a/releasenotes/notes/drop-manylinux2014-9ce259a0bf30de1b.yaml
+++ b/releasenotes/notes/drop-manylinux2014-9ce259a0bf30de1b.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Stop releasing ``manylinux2014``/``manylinux_2_17`` wheels in favor of
+    ``manylinux_2_28``.


### PR DESCRIPTION
`manylinux2014`/`manylinux_2_17` wheels are built on CentOS 7. CentOS 7 reached EOL on June 30th, 2024.

Scientific python community has been gradually migrating to `manylinux_2_28` for years. Latest versions of numpy/pandas only release `maylinux_2_28`, thus slowing down our builds to 30min+.

With this change in place, the build time is better (15min), but still not great.

#### AI Generation Disclosure

No AI tools used