### PR TITLE
Fix docstring warnings

### DIFF
--- a/dimod/ess.py
+++ b/dimod/ess.py
@@ -30,8 +30,9 @@ __all__ = ['compute_ess', 'compute_ess_sampleset']
 def compute_ess(x: np.ndarray, batch_size: int | None = None) -> float:
     """Estimates the effective sample size of ``x``.
 
-    NOTE: The estimate can be nan or negative for extreme cases (e.g., constants). This can occur
-    by definition of the estimator and is not a bug.
+    .. note:: The estimate can be nan or negative for extreme cases (e.g.,
+        constants). This can occur by definition of the estimator and is not a
+        bug.
 
     Examples:
         These two examples demonstrate typical use cases of the estimator based on an energy statistic.
@@ -39,6 +40,7 @@ def compute_ess(x: np.ndarray, batch_size: int | None = None) -> float:
         Metropolis-Hastings samplers (one with one sweep, another with ten sweeps).
 
         Example (1): QPU
+
         .. code-block:: python
 
             import numpy as np
@@ -94,6 +96,7 @@ def compute_ess(x: np.ndarray, batch_size: int | None = None) -> float:
             # Effective sample size per chain (MH): 12.496482970401358
 
         Use a larger number of sweeps to achieve larger ESS
+
         >>> num_sweeps = 10
         Effective sample size per chain (MH): 64.44999653861495
 

--- a/dimod/ess.py
+++ b/dimod/ess.py
@@ -95,10 +95,9 @@ def compute_ess(x: np.ndarray, batch_size: int | None = None) -> float:
                   estimate_effective_sample_size(mc_energy)/num_chains)
             # Effective sample size per chain (MH): 12.496482970401358
 
-        Use a larger number of sweeps to achieve larger ESS
-
-        >>> num_sweeps = 10
-        Effective sample size per chain (MH): 64.44999653861495
+        Use a larger number of sweeps to achieve larger ESS. For example,
+        ``num_sweeps = 10`` produces an effective sample size per chain of
+        ~64.45.
 
     Args:
         x: An (m, n) matrix where rows index independent Markov chains and columns index

--- a/dimod/generators/matching.py
+++ b/dimod/generators/matching.py
@@ -88,7 +88,7 @@ def maximal_matching(graph: GraphLike,
     once. A maximal matching is one in which no edges from ``graph`` can be
     added without violating the matching rule.
     This function returns a binary quadratic model (BQM) with ground
-    states corresponding to the possible maximal matchings of ``graph`.
+    states corresponding to the possible maximal matchings of ``graph``.
 
     Finding maximal matchings can be done in polynomial time, so finding
     maximal matching with BQMs is generally inefficient.


### PR DESCRIPTION
#### What does this implement/fix?
Fixes docbuild warnings:

```
/root/project/env/lib/python3.12/site-packages/dimod/ess.py:docstring of dimod.ess.compute_ess:27: ERROR: Unexpected indentation. [docutils]
/root/project/env/lib/python3.12/site-packages/dimod/ess.py:docstring of dimod.ess.compute_ess:29: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/root/project/env/lib/python3.12/site-packages/dimod/ess.py:docstring of dimod.ess.compute_ess:31: ERROR: Unexpected indentation. [docutils]
/root/project/env/lib/python3.12/site-packages/dimod/ess.py:docstring of dimod.ess.compute_ess:32: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/root/project/env/lib/python3.12/site-packages/dimod/generators/matching.py:docstring of dimod.generators.matching.maximal_matching:3: WARNING: Inline literal start-string without end-string. [docutils]
```

#### Additional information
This PR updates part of the ``compute_ess()`` docstring but is not an endorsement of the remainder of that docstring.

#### AI Generation Disclosure
No AI tools used
